### PR TITLE
PBC Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,6 +293,11 @@ name = "v6_codspeed_queries"
 harness = false
 required-features = ["test_utils"]
 
+[[bench]]
+name = "v6_periodic_queries"
+harness = false
+required-features = ["test_utils"]
+
 #[[example]]
 #name = "avx2-check"
 #path = "examples/avx2-check.rs"

--- a/benches/v6_periodic_queries.rs
+++ b/benches/v6_periodic_queries.rs
@@ -1,0 +1,170 @@
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::VecOfArenas;
+use kiddo::stem_strategy::EytzingerPf;
+use rand::Rng;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use std::num::NonZeroUsize;
+
+const K: usize = 3;
+const B: usize = 32;
+const BOX_SIZE: [f64; K] = [1.0; K];
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const DEFAULT_LOG2_POINTS: u32 = 18;
+const DEFAULT_MAX_QTY: usize = 16;
+const DEFAULT_MAX_DIST: f64 = 0.01;
+const POINT_SEED: u64 = 0x5eed_0000_0000_2001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_2002;
+
+type BaselineLeaves = VecOfArenas<f64, u32, K, B>;
+type BaselineTree = KdTree<f64, u32, EytzingerPf<K, 8>, BaselineLeaves, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn read_u32_env(var: &str, default: u32) -> u32 {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(default)
+}
+
+fn read_f64_env(var: &str, default: f64) -> f64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(default)
+}
+
+fn build_points(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_periodic_queries(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count)
+        .map(|idx| {
+            let mut query = rng.random::<[f64; K]>();
+            for coord in &mut query {
+                let edge_sample = rng.random::<f64>() * 0.05;
+                *coord = if idx & 1 == 0 {
+                    edge_sample
+                } else {
+                    1.0 - edge_sample
+                };
+            }
+            query
+        })
+        .collect()
+}
+
+fn run_periodic_nearest_one(tree: &BaselineTree, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .periodic_boundary_condition(&BOX_SIZE)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_periodic_nearest_n_within(
+    tree: &BaselineTree,
+    queries: &[[f64; K]],
+    max_dist: f64,
+    max_qty: NonZeroUsize,
+) -> (usize, u64, f64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_item = 0u64;
+    let mut checksum_dist = 0.0f64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .periodic_boundary_condition(&BOX_SIZE)
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .within(max_dist)
+            .execute();
+        checksum_len += results.len();
+
+        for result in results {
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+            checksum_dist += result.distance;
+        }
+    }
+
+    (checksum_len, checksum_item, checksum_dist)
+}
+
+fn run_periodic_within(
+    tree: &BaselineTree,
+    queries: &[[f64; K]],
+    max_dist: f64,
+) -> (usize, u64, f64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_item = 0u64;
+    let mut checksum_dist = 0.0f64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .periodic_boundary_condition(&BOX_SIZE)
+            .within::<SquaredEuclidean<f64>>(max_dist)
+            .execute();
+        checksum_len += results.len();
+
+        for result in results {
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+            checksum_dist += result.distance;
+        }
+    }
+
+    (checksum_len, checksum_item, checksum_dist)
+}
+
+fn periodic_queries(c: &mut Criterion) {
+    let log2_points = read_u32_env("KIDDO_BENCH_LOG2_POINTS", DEFAULT_LOG2_POINTS);
+    let point_count = 1usize << log2_points;
+    let query_count = read_usize_env("KIDDO_BENCH_QUERIES", DEFAULT_QUERY_COUNT);
+    let max_qty = NonZeroUsize::new(read_usize_env("KIDDO_BENCH_MAX_QTY", DEFAULT_MAX_QTY))
+        .expect("KIDDO_BENCH_MAX_QTY must be non-zero");
+    let max_dist = read_f64_env("KIDDO_BENCH_MAX_DIST", DEFAULT_MAX_DIST);
+
+    let points = build_points(point_count);
+    let queries = build_periodic_queries(query_count);
+    let tree =
+        BaselineTree::new_from_slice(&points).expect("failed to build periodic benchmark tree");
+
+    let mut group = c.benchmark_group("v6 periodic queries");
+    group.bench_function("periodic_nearest_one", |b| {
+        b.iter(|| black_box(run_periodic_nearest_one(&tree, &queries)))
+    });
+    group.bench_function("periodic_nearest_n_within", |b| {
+        b.iter(|| {
+            black_box(run_periodic_nearest_n_within(
+                &tree, &queries, max_dist, max_qty,
+            ))
+        })
+    });
+    group.bench_function("periodic_within", |b| {
+        b.iter(|| black_box(run_periodic_within(&tree, &queries, max_dist)))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, periodic_queries);
+criterion_main!(benches);

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -896,8 +896,38 @@ pub struct Projected<Q, Pj> {
     _phantom: PhantomData<Pj>,
 }
 
+trait SupportsPointProjection {}
+
+macro_rules! impl_supports_point_projection {
+    ($($wrapper:ident),* $(,)?) => {
+        $(
+            impl<'a, Tree, A, T, SS, LS, D, const K: usize, const B: usize> SupportsPointProjection
+                for $wrapper<'a, Tree, A, T, SS, LS, D, K, B>
+            where
+                A: Copy,
+                D: KdTreeDistanceMetric<A, K>,
+            {}
+        )*
+    };
+}
+
+impl_supports_point_projection!(
+    NearestOneQuery,
+    ApproxNearestOneQuery,
+    NearestNQuery,
+    NearestNUnsortedQuery,
+    NearestNWithinQuery,
+    NearestNWithinUnsortedQuery,
+    BestNWithinQuery,
+    WithinQuery,
+    WithinUnsortedQuery,
+);
+
 #[allow(missing_docs)]
-impl<Q, P, I, D> Projected<Q, Projection<P, I, D>> {
+impl<Q, P, I, D> Projected<Q, Projection<P, I, D>>
+where
+    Q: SupportsPointProjection,
+{
     #[inline]
     pub fn with_points(self) -> Projected<Q, Projection<Include, I, D>> {
         Projected {
@@ -905,7 +935,10 @@ impl<Q, P, I, D> Projected<Q, Projection<P, I, D>> {
             _phantom: PhantomData,
         }
     }
+}
 
+#[allow(missing_docs)]
+impl<Q, P, I, D> Projected<Q, Projection<P, I, D>> {
     #[inline]
     pub fn without_points(self) -> Projected<Q, Projection<Exclude, I, D>> {
         Projected {
@@ -1053,7 +1086,29 @@ fn with_wrapped_queries<A: PeriodicAxis, F, const K: usize>(
     recurse(query, box_size, 0, &mut wrapped_query, &mut f);
 }
 
-fn periodic_distance_via_wrapped_queries<D, A, const K: usize>(
+#[inline(always)]
+fn periodic_image_axis_offset<A: PeriodicAxis>(wrapped_coord: A, axis_len: A) -> A {
+    if A::cmp(wrapped_coord, A::zero()) == Ordering::Less {
+        A::saturating_dist(wrapped_coord, A::zero())
+    } else if A::cmp(wrapped_coord, axis_len) == Ordering::Greater {
+        A::saturating_dist(wrapped_coord, axis_len)
+    } else {
+        A::zero()
+    }
+}
+
+#[inline(always)]
+fn periodic_min_image_axis_delta<A: PeriodicAxis>(query: A, point: A, axis_len: A) -> A {
+    let direct = A::saturating_dist(query, point);
+    let wrapped = A::saturating_dist(axis_len, direct);
+    if A::cmp(wrapped, direct) == Ordering::Less {
+        wrapped
+    } else {
+        direct
+    }
+}
+
+fn periodic_distance_via_minimum_image<D, A, const K: usize>(
     query: &[A; K],
     point: &[A; K],
     box_size: &[A; K],
@@ -1063,18 +1118,143 @@ where
     D: KdTreeDistanceMetric<A, K>,
     D::Output: Axis<Coord = D::Output>,
 {
-    let point_wide = point.map(D::widen_coord);
-    let mut best_dist = D::Output::max_value();
+    let mut distance = D::Output::zero();
 
-    with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
-        let wrapped_query_wide = wrapped_query.map(D::widen_coord);
-        let dist = D::dist(&point_wide, &wrapped_query_wide);
-        if D::Output::cmp(dist, best_dist) == Ordering::Less {
-            best_dist = dist;
+    for dim in 0..K {
+        let delta = periodic_min_image_axis_delta(query[dim], point[dim], box_size[dim]);
+        D::combine_component(
+            &mut distance,
+            D::dist1(D::widen_coord(delta), D::Output::zero()),
+        );
+    }
+
+    distance
+}
+
+#[derive(Clone, Copy)]
+struct PeriodicImageCandidate<A, O, const K: usize> {
+    wrapped_query: [A; K],
+    lower_bound: O,
+}
+
+fn periodic_image_candidates<D, A, const K: usize>(
+    query: &[A; K],
+    box_size: &[A; K],
+    threshold: Option<(BoundaryMode, D::Output)>,
+    include_home: bool,
+) -> Vec<PeriodicImageCandidate<A, D::Output, K>>
+where
+    A: PeriodicAxis + 'static,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: Axis<Coord = D::Output>,
+{
+    fn recurse<D, A, const K: usize>(
+        query: &[A; K],
+        box_size: &[A; K],
+        axis: usize,
+        wrapped_query: &mut [A; K],
+        has_non_zero_shift: bool,
+        lower_bound: D::Output,
+        threshold: Option<(BoundaryMode, D::Output)>,
+        include_home: bool,
+        out: &mut Vec<PeriodicImageCandidate<A, D::Output, K>>,
+    ) where
+        A: PeriodicAxis + 'static,
+        D: KdTreeDistanceMetric<A, K>,
+        D::Output: Axis<Coord = D::Output>,
+    {
+        if axis == K {
+            if include_home || has_non_zero_shift {
+                out.push(PeriodicImageCandidate {
+                    wrapped_query: *wrapped_query,
+                    lower_bound,
+                });
+            }
+            return;
         }
-    });
 
-    best_dist
+        let original = query[axis];
+        let axis_len = box_size[axis];
+
+        for shift in [-1_i8, 0, 1] {
+            let wrapped_coord = match shift {
+                -1 => original - axis_len,
+                0 => original,
+                1 => {
+                    let mut plus = original;
+                    plus += axis_len;
+                    plus
+                }
+                _ => unreachable!(),
+            };
+
+            wrapped_query[axis] = wrapped_coord;
+
+            let offset = periodic_image_axis_offset(wrapped_coord, axis_len);
+            let mut next_lower_bound = lower_bound;
+            D::combine_component(
+                &mut next_lower_bound,
+                D::dist1(D::widen_coord(offset), D::Output::zero()),
+            );
+
+            if threshold.is_some_and(|(boundary, limit)| {
+                !boundary_accepts(boundary, next_lower_bound, limit)
+            }) {
+                continue;
+            }
+
+            recurse::<D, A, K>(
+                query,
+                box_size,
+                axis + 1,
+                wrapped_query,
+                has_non_zero_shift || shift != 0,
+                next_lower_bound,
+                threshold,
+                include_home,
+                out,
+            );
+        }
+
+        wrapped_query[axis] = original;
+    }
+
+    let mut candidates = Vec::new();
+    let mut wrapped_query = *query;
+    recurse::<D, A, K>(
+        query,
+        box_size,
+        0,
+        &mut wrapped_query,
+        false,
+        D::Output::zero(),
+        threshold,
+        include_home,
+        &mut candidates,
+    );
+    candidates
+}
+
+#[inline(always)]
+fn sort_periodic_image_candidates<A, O, const K: usize>(
+    candidates: &mut [PeriodicImageCandidate<A, O, K>],
+) where
+    O: Axis<Coord = O>,
+{
+    candidates.sort_unstable_by(|lhs, rhs| {
+        lhs.lower_bound
+            .partial_cmp(&rhs.lower_bound)
+            .unwrap_or(Ordering::Equal)
+    });
+}
+
+#[inline(always)]
+fn periodic_threshold_accepts<O: Axis<Coord = O>>(
+    boundary: BoundaryMode,
+    lower_bound: O,
+    threshold: O,
+) -> bool {
+    boundary_accepts(boundary, lower_bound, threshold)
 }
 
 #[inline(always)]
@@ -1256,19 +1436,54 @@ where
 {
     assert_valid_periodic_box(box_size);
 
+    if D::ORDERING != Ordering::Less {
+        let mut best_result = QueryResultItem {
+            point: (),
+            item: T::default(),
+            distance: D::Output::max_value(),
+        };
+
+        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
+            let (distance, item) = tree.qb_nearest_one::<D>(wrapped_query);
+            if D::Output::cmp(distance, best_result.distance) == Ordering::Less {
+                best_result.distance = distance;
+                best_result.item = item;
+            }
+        });
+
+        return best_result;
+    }
+
+    let (home_distance, home_item) = tree.qb_nearest_one::<D>(query);
     let mut best_result = QueryResultItem {
         point: (),
-        item: T::default(),
-        distance: D::Output::max_value(),
+        item: home_item,
+        distance: home_distance,
     };
 
-    with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
-        let (distance, item) = tree.qb_nearest_one::<D>(wrapped_query);
+    let mut candidates = periodic_image_candidates::<D, A, K>(
+        query,
+        box_size,
+        Some((BoundaryMode::Exclusive, best_result.distance)),
+        false,
+    );
+    sort_periodic_image_candidates(&mut candidates);
+
+    for candidate in candidates {
+        if !periodic_threshold_accepts(
+            BoundaryMode::Exclusive,
+            candidate.lower_bound,
+            best_result.distance,
+        ) {
+            continue;
+        }
+
+        let (distance, item) = tree.qb_nearest_one::<D>(&candidate.wrapped_query);
         if D::Output::cmp(distance, best_result.distance) == Ordering::Less {
             best_result.distance = distance;
             best_result.item = item;
         }
-    });
+    }
 
     best_result
 }
@@ -1308,30 +1523,143 @@ where
 {
     assert_valid_periodic_box(box_size);
 
-    let mut best_by_item = HashMap::<T, D::Output>::new();
+    if D::ORDERING != Ordering::Less {
+        let mut best_by_item = HashMap::<T, D::Output>::new();
 
-    with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
-        let candidates = match (radius, max_qty) {
-            (None, Some(max_qty)) => tree.qb_nearest_n::<D>(wrapped_query, max_qty, true),
-            (Some(radius), Some(max_qty)) => {
-                tree.qb_nearest_n_within::<D, EXCLUSIVE>(wrapped_query, radius, max_qty, sorted)
+        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
+            let candidates = match (radius, max_qty) {
+                (None, Some(max_qty)) => tree.qb_nearest_n::<D>(wrapped_query, max_qty, true),
+                (Some(radius), Some(max_qty)) => {
+                    tree.qb_nearest_n_within::<D, EXCLUSIVE>(wrapped_query, radius, max_qty, sorted)
+                }
+                (Some(radius), None) if sorted => {
+                    tree.qb_within::<D, EXCLUSIVE>(wrapped_query, radius)
+                }
+                (Some(radius), None) => {
+                    tree.qb_within_unsorted::<D, EXCLUSIVE>(wrapped_query, radius)
+                }
+                (None, None) => {
+                    unreachable!("periodic plural queries require radius and/or max_qty")
+                }
+            };
+
+            for candidate in candidates {
+                best_by_item
+                    .entry(candidate.item)
+                    .and_modify(|best_distance| {
+                        if D::Output::cmp(candidate.distance, *best_distance) == Ordering::Less {
+                            *best_distance = candidate.distance;
+                        }
+                    })
+                    .or_insert(candidate.distance);
             }
-            (Some(radius), None) if sorted => tree.qb_within::<D, EXCLUSIVE>(wrapped_query, radius),
-            (Some(radius), None) => tree.qb_within_unsorted::<D, EXCLUSIVE>(wrapped_query, radius),
+        });
+
+        let mut results: Vec<_> = best_by_item
+            .into_iter()
+            .map(|(item, distance)| QueryResultItem {
+                point: (),
+                item,
+                distance,
+            })
+            .collect();
+
+        if sorted {
+            results.sort_unstable();
+        }
+        if let Some(max_qty) = max_qty {
+            results.truncate(max_qty.get());
+        }
+
+        return results;
+    }
+
+    let mut best_by_item = HashMap::<T, D::Output>::new();
+    let mut threshold = radius.map(|value| {
+        (
+            if EXCLUSIVE {
+                BoundaryMode::Exclusive
+            } else {
+                BoundaryMode::Inclusive
+            },
+            value,
+        )
+    });
+
+    let mut candidates = periodic_image_candidates::<D, A, K>(query, box_size, threshold, true);
+    sort_periodic_image_candidates(&mut candidates);
+
+    for candidate in candidates {
+        if threshold.is_some_and(|(boundary, limit)| {
+            !periodic_threshold_accepts(boundary, candidate.lower_bound, limit)
+        }) {
+            continue;
+        }
+
+        let candidates = match (radius, max_qty) {
+            (None, Some(max_qty)) => {
+                tree.qb_nearest_n::<D>(&candidate.wrapped_query, max_qty, true)
+            }
+            (Some(radius), Some(max_qty)) => tree.qb_nearest_n_within::<D, EXCLUSIVE>(
+                &candidate.wrapped_query,
+                radius,
+                max_qty,
+                sorted,
+            ),
+            (Some(radius), None) if sorted => {
+                tree.qb_within::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
+            }
+            (Some(radius), None) => {
+                tree.qb_within_unsorted::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
+            }
             (None, None) => unreachable!("periodic plural queries require radius and/or max_qty"),
         };
 
-        for candidate in candidates {
+        for periodic_candidate in candidates {
             best_by_item
-                .entry(candidate.item)
+                .entry(periodic_candidate.item)
                 .and_modify(|best_distance| {
-                    if D::Output::cmp(candidate.distance, *best_distance) == Ordering::Less {
-                        *best_distance = candidate.distance;
+                    if D::Output::cmp(periodic_candidate.distance, *best_distance) == Ordering::Less
+                    {
+                        *best_distance = periodic_candidate.distance;
                     }
                 })
-                .or_insert(candidate.distance);
+                .or_insert(periodic_candidate.distance);
         }
-    });
+
+        if radius.is_none() {
+            if max_qty.is_some_and(|max_qty| best_by_item.len() >= max_qty.get()) {
+                if let Some(current_worst) = best_by_item
+                    .values()
+                    .copied()
+                    .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
+                {
+                    threshold = Some((BoundaryMode::Exclusive, current_worst));
+                }
+            }
+        } else if max_qty.is_some_and(|max_qty| best_by_item.len() >= max_qty.get()) {
+            if let Some(current_worst) = best_by_item
+                .values()
+                .copied()
+                .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
+            {
+                let radius = radius.unwrap();
+                let tightened = if D::Output::cmp(current_worst, radius) == Ordering::Less {
+                    current_worst
+                } else {
+                    radius
+                };
+                threshold = Some((
+                    if EXCLUSIVE {
+                        BoundaryMode::Exclusive
+                    } else {
+                        BoundaryMode::Inclusive
+                    },
+                    tightened,
+                ));
+            }
+        }
+    }
 
     let mut results: Vec<_> = best_by_item
         .into_iter()
@@ -1371,7 +1699,7 @@ where
 
     let mut best: Option<FullNearest<A, T, D::Output, K>> = None;
     for (item, point) in KdTreeIter::<Tree, A, T, SS, LS, K, B>::new(tree) {
-        let distance = periodic_distance_via_wrapped_queries::<D, A, K>(query, &point, box_size);
+        let distance = periodic_distance_via_minimum_image::<D, A, K>(query, &point, box_size);
         let candidate = FullNearest {
             point,
             item,
@@ -1424,7 +1752,7 @@ where
 
     let mut best_by_item = HashMap::<T, FullNearest<A, T, D::Output, K>>::new();
     for (item, point) in KdTreeIter::<Tree, A, T, SS, LS, K, B>::new(tree) {
-        let distance = periodic_distance_via_wrapped_queries::<D, A, K>(query, &point, box_size);
+        let distance = periodic_distance_via_minimum_image::<D, A, K>(query, &point, box_size);
         if radius.is_some_and(|max_dist| !boundary_accepts(boundary, distance, max_dist)) {
             continue;
         }
@@ -1646,14 +1974,6 @@ where
     D: KdTreeDistanceMetric<A, K>,
 {
     #[inline]
-    pub fn with_points(self) -> Projected<Self, Projection<Include, Include, Include>> {
-        Projected {
-            inner: self,
-            _phantom: PhantomData,
-        }
-    }
-
-    #[inline]
     pub fn without_items(self) -> Projected<Self, Projection<Exclude, Exclude, Include>> {
         Projected {
             inner: self,
@@ -1705,14 +2025,6 @@ where
     A: PeriodicAxis,
     D: KdTreeDistanceMetric<A, K>,
 {
-    #[inline]
-    pub fn with_points(self) -> Projected<Self, Projection<Include, Include, Include>> {
-        Projected {
-            inner: self,
-            _phantom: PhantomData,
-        }
-    }
-
     #[inline]
     pub fn without_items(self) -> Projected<Self, Projection<Exclude, Exclude, Include>> {
         Projected {
@@ -1784,14 +2096,6 @@ where
     A: PeriodicAxis,
     D: KdTreeDistanceMetric<A, K>,
 {
-    #[inline]
-    pub fn with_points(self) -> Projected<Self, Projection<Include, Include, Include>> {
-        Projected {
-            inner: self,
-            _phantom: PhantomData,
-        }
-    }
-
     #[inline]
     pub fn without_items(self) -> Projected<Self, Projection<Exclude, Exclude, Include>> {
         Projected {
@@ -1881,14 +2185,6 @@ where
     D: KdTreeDistanceMetric<A, K>,
 {
     #[inline]
-    pub fn with_points(self) -> Projected<Self, Projection<Include, Include, Include>> {
-        Projected {
-            inner: self,
-            _phantom: PhantomData,
-        }
-    }
-
-    #[inline]
     pub fn without_items(self) -> Projected<Self, Projection<Exclude, Exclude, Include>> {
         Projected {
             inner: self,
@@ -1963,14 +2259,6 @@ where
     A: PeriodicAxis,
     D: KdTreeDistanceMetric<A, K>,
 {
-    #[inline]
-    pub fn with_points(self) -> Projected<Self, Projection<Include, Include, Include>> {
-        Projected {
-            inner: self,
-            _phantom: PhantomData,
-        }
-    }
-
     #[inline]
     pub fn without_items(self) -> Projected<Self, Projection<Exclude, Exclude, Include>> {
         Projected {
@@ -2058,14 +2346,6 @@ where
     A: PeriodicAxis,
     D: KdTreeDistanceMetric<A, K>,
 {
-    #[inline]
-    pub fn with_points(self) -> Projected<Self, Projection<Include, Include, Include>> {
-        Projected {
-            inner: self,
-            _phantom: PhantomData,
-        }
-    }
-
     #[inline]
     pub fn without_items(self) -> Projected<Self, Projection<Exclude, Exclude, Include>> {
         Projected {
@@ -3757,10 +4037,10 @@ mod tests {
             .query(&query)
             .periodic_boundary_condition(&box_size)
             .nearest_one::<SquaredEuclidean<f64>>()
-            .with_points()
+            .without_items()
             .execute();
-        assert_eq!(projected.item, 1);
-        assert_eq!(projected.point, [0.95, 0.5]);
+        assert_eq!(projected.item, ());
+        assert_eq!(projected.point, ());
         assert!((projected.distance - 0.01).abs() < f64::EPSILON);
     }
 

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -2,7 +2,6 @@
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::num::NonZero;
@@ -18,6 +17,8 @@ use crate::stem_strategy::donnelly_2_blockmarker_simd::{
     BacktrackBlock3, BacktrackBlock4, SimdSelectBestChildBlock3,
 };
 use crate::{Axis, BestQueryResultItem, Content, LeafStrategy, QueryResultItem, StemStrategy};
+
+use super::periodic::{periodic_nearest_one_result, periodic_nearest_results_by_item};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BoundaryMode {
@@ -85,7 +86,7 @@ impl<A: Axis<Coord = A>, const K: usize> PointProjectionField<A, K> for Exclude 
     fn absent_point() -> Self::Output {}
 }
 
-trait ProjectionSpec<A, T, O, const K: usize> {
+pub(crate) trait ProjectionSpec<A, T, O, const K: usize> {
     const WANTS_POINTS: bool;
     type NearestOut;
     type BestOut;
@@ -176,10 +177,10 @@ where
 }
 
 #[derive(Copy, Clone)]
-struct FullNearest<A, T, O, const K: usize> {
-    point: [A; K],
-    item: T,
-    distance: O,
+pub(crate) struct FullNearest<A, T, O, const K: usize> {
+    pub(crate) point: [A; K],
+    pub(crate) item: T,
+    pub(crate) distance: O,
 }
 
 #[derive(Copy, Clone)]
@@ -1029,7 +1030,11 @@ where
 }
 
 #[inline(always)]
-fn boundary_accepts<O: Axis<Coord = O>>(boundary: BoundaryMode, distance: O, radius: O) -> bool {
+pub(crate) fn boundary_accepts<O: Axis<Coord = O>>(
+    boundary: BoundaryMode,
+    distance: O,
+    radius: O,
+) -> bool {
     match boundary {
         BoundaryMode::Inclusive => O::cmp(distance, radius) != Ordering::Greater,
         BoundaryMode::Exclusive => O::cmp(distance, radius) == Ordering::Less,
@@ -1037,228 +1042,7 @@ fn boundary_accepts<O: Axis<Coord = O>>(boundary: BoundaryMode, distance: O, rad
 }
 
 #[inline(always)]
-fn assert_valid_periodic_box<A: PeriodicAxis, const K: usize>(box_size: &[A; K]) {
-    assert!(
-        A::periodic_box_is_valid(box_size),
-        "periodic box sizes must be strictly positive"
-    );
-}
-
-fn with_wrapped_queries<A: PeriodicAxis, F, const K: usize>(
-    query: &[A; K],
-    box_size: &[A; K],
-    mut f: F,
-) where
-    F: FnMut(&[A; K]),
-{
-    fn recurse<A: PeriodicAxis, F, const K: usize>(
-        query: &[A; K],
-        box_size: &[A; K],
-        axis: usize,
-        wrapped_query: &mut [A; K],
-        f: &mut F,
-    ) where
-        F: FnMut(&[A; K]),
-    {
-        if axis == K {
-            f(wrapped_query);
-            return;
-        }
-
-        let original = query[axis];
-        let axis_len = box_size[axis];
-
-        wrapped_query[axis] = original - axis_len;
-        recurse(query, box_size, axis + 1, wrapped_query, f);
-
-        wrapped_query[axis] = original;
-        recurse(query, box_size, axis + 1, wrapped_query, f);
-
-        let mut plus = original;
-        plus += axis_len;
-        wrapped_query[axis] = plus;
-        recurse(query, box_size, axis + 1, wrapped_query, f);
-
-        wrapped_query[axis] = original;
-    }
-
-    let mut wrapped_query = *query;
-    recurse(query, box_size, 0, &mut wrapped_query, &mut f);
-}
-
-#[inline(always)]
-fn periodic_image_axis_offset<A: PeriodicAxis>(wrapped_coord: A, axis_len: A) -> A {
-    if A::cmp(wrapped_coord, A::zero()) == Ordering::Less {
-        A::saturating_dist(wrapped_coord, A::zero())
-    } else if A::cmp(wrapped_coord, axis_len) == Ordering::Greater {
-        A::saturating_dist(wrapped_coord, axis_len)
-    } else {
-        A::zero()
-    }
-}
-
-#[inline(always)]
-fn periodic_min_image_axis_delta<A: PeriodicAxis>(query: A, point: A, axis_len: A) -> A {
-    let direct = A::saturating_dist(query, point);
-    let wrapped = A::saturating_dist(axis_len, direct);
-    if A::cmp(wrapped, direct) == Ordering::Less {
-        wrapped
-    } else {
-        direct
-    }
-}
-
-fn periodic_distance_via_minimum_image<D, A, const K: usize>(
-    query: &[A; K],
-    point: &[A; K],
-    box_size: &[A; K],
-) -> D::Output
-where
-    A: PeriodicAxis + 'static,
-    D: KdTreeDistanceMetric<A, K>,
-    D::Output: Axis<Coord = D::Output>,
-{
-    let mut distance = D::Output::zero();
-
-    for dim in 0..K {
-        let delta = periodic_min_image_axis_delta(query[dim], point[dim], box_size[dim]);
-        D::combine_component(
-            &mut distance,
-            D::dist1(D::widen_coord(delta), D::Output::zero()),
-        );
-    }
-
-    distance
-}
-
-#[derive(Clone, Copy)]
-struct PeriodicImageCandidate<A, O, const K: usize> {
-    wrapped_query: [A; K],
-    lower_bound: O,
-}
-
-fn periodic_image_candidates<D, A, const K: usize>(
-    query: &[A; K],
-    box_size: &[A; K],
-    threshold: Option<(BoundaryMode, D::Output)>,
-    include_home: bool,
-) -> Vec<PeriodicImageCandidate<A, D::Output, K>>
-where
-    A: PeriodicAxis + 'static,
-    D: KdTreeDistanceMetric<A, K>,
-    D::Output: Axis<Coord = D::Output>,
-{
-    fn recurse<D, A, const K: usize>(
-        query: &[A; K],
-        box_size: &[A; K],
-        axis: usize,
-        wrapped_query: &mut [A; K],
-        has_non_zero_shift: bool,
-        lower_bound: D::Output,
-        threshold: Option<(BoundaryMode, D::Output)>,
-        include_home: bool,
-        out: &mut Vec<PeriodicImageCandidate<A, D::Output, K>>,
-    ) where
-        A: PeriodicAxis + 'static,
-        D: KdTreeDistanceMetric<A, K>,
-        D::Output: Axis<Coord = D::Output>,
-    {
-        if axis == K {
-            if include_home || has_non_zero_shift {
-                out.push(PeriodicImageCandidate {
-                    wrapped_query: *wrapped_query,
-                    lower_bound,
-                });
-            }
-            return;
-        }
-
-        let original = query[axis];
-        let axis_len = box_size[axis];
-
-        for shift in [-1_i8, 0, 1] {
-            let wrapped_coord = match shift {
-                -1 => original - axis_len,
-                0 => original,
-                1 => {
-                    let mut plus = original;
-                    plus += axis_len;
-                    plus
-                }
-                _ => unreachable!(),
-            };
-
-            wrapped_query[axis] = wrapped_coord;
-
-            let offset = periodic_image_axis_offset(wrapped_coord, axis_len);
-            let mut next_lower_bound = lower_bound;
-            D::combine_component(
-                &mut next_lower_bound,
-                D::dist1(D::widen_coord(offset), D::Output::zero()),
-            );
-
-            if threshold.is_some_and(|(boundary, limit)| {
-                !boundary_accepts(boundary, next_lower_bound, limit)
-            }) {
-                continue;
-            }
-
-            recurse::<D, A, K>(
-                query,
-                box_size,
-                axis + 1,
-                wrapped_query,
-                has_non_zero_shift || shift != 0,
-                next_lower_bound,
-                threshold,
-                include_home,
-                out,
-            );
-        }
-
-        wrapped_query[axis] = original;
-    }
-
-    let mut candidates = Vec::new();
-    let mut wrapped_query = *query;
-    recurse::<D, A, K>(
-        query,
-        box_size,
-        0,
-        &mut wrapped_query,
-        false,
-        D::Output::zero(),
-        threshold,
-        include_home,
-        &mut candidates,
-    );
-    candidates
-}
-
-#[inline(always)]
-fn sort_periodic_image_candidates<A, O, const K: usize>(
-    candidates: &mut [PeriodicImageCandidate<A, O, K>],
-) where
-    O: Axis<Coord = O>,
-{
-    candidates.sort_unstable_by(|lhs, rhs| {
-        lhs.lower_bound
-            .partial_cmp(&rhs.lower_bound)
-            .unwrap_or(Ordering::Equal)
-    });
-}
-
-#[inline(always)]
-fn periodic_threshold_accepts<O: Axis<Coord = O>>(
-    boundary: BoundaryMode,
-    lower_bound: O,
-    threshold: O,
-) -> bool {
-    boundary_accepts(boundary, lower_bound, threshold)
-}
-
-#[inline(always)]
-fn map_full_nearest<A, T, O, Pj, const K: usize>(
+pub(crate) fn map_full_nearest<A, T, O, Pj, const K: usize>(
     candidate: FullNearest<A, T, O, K>,
 ) -> Pj::NearestOut
 where
@@ -1411,379 +1195,6 @@ where
 
     heap.into_iter()
         .map(map_full_best::<A, T, D::Output, Pj, K>)
-        .collect()
-}
-
-fn periodic_nearest_one_result<Tree, A, T, SS, LS, D, const K: usize, const B: usize>(
-    tree: &Tree,
-    query: &[A; K],
-    box_size: &[A; K],
-) -> QueryResultItem<(), T, D::Output>
-where
-    A: PeriodicAxis + 'static,
-    T: Content,
-    SS: StemStrategy + 'static,
-    LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
-    D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + Default + 'static,
-{
-    assert_valid_periodic_box(box_size);
-
-    if D::ORDERING != Ordering::Less {
-        let mut best_result = QueryResultItem {
-            point: (),
-            item: T::default(),
-            distance: D::Output::max_value(),
-        };
-
-        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
-            let (distance, item) = tree.qb_nearest_one::<D>(wrapped_query);
-            if D::Output::cmp(distance, best_result.distance) == Ordering::Less {
-                best_result.distance = distance;
-                best_result.item = item;
-            }
-        });
-
-        return best_result;
-    }
-
-    let (home_distance, home_item) = tree.qb_nearest_one::<D>(query);
-    let mut best_result = QueryResultItem {
-        point: (),
-        item: home_item,
-        distance: home_distance,
-    };
-
-    let mut candidates = periodic_image_candidates::<D, A, K>(
-        query,
-        box_size,
-        Some((BoundaryMode::Exclusive, best_result.distance)),
-        false,
-    );
-    sort_periodic_image_candidates(&mut candidates);
-
-    for candidate in candidates {
-        if !periodic_threshold_accepts(
-            BoundaryMode::Exclusive,
-            candidate.lower_bound,
-            best_result.distance,
-        ) {
-            continue;
-        }
-
-        let (distance, item) = tree.qb_nearest_one::<D>(&candidate.wrapped_query);
-        if D::Output::cmp(distance, best_result.distance) == Ordering::Less {
-            best_result.distance = distance;
-            best_result.item = item;
-        }
-    }
-
-    best_result
-}
-
-fn periodic_nearest_results_by_item<
-    Tree,
-    A,
-    T,
-    SS,
-    LS,
-    D,
-    const EXCLUSIVE: bool,
-    const K: usize,
-    const B: usize,
->(
-    tree: &Tree,
-    query: &[A; K],
-    box_size: &[A; K],
-    radius: Option<D::Output>,
-    max_qty: Option<NonZeroUsize>,
-    sorted: bool,
-) -> Vec<QueryResultItem<(), T, D::Output>>
-where
-    A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
-    SS: StemStrategy,
-    LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
-    D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
-{
-    assert_valid_periodic_box(box_size);
-
-    if D::ORDERING != Ordering::Less {
-        let mut best_by_item = HashMap::<T, D::Output>::new();
-
-        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
-            let candidates = match (radius, max_qty) {
-                (None, Some(max_qty)) => tree.qb_nearest_n::<D>(wrapped_query, max_qty, true),
-                (Some(radius), Some(max_qty)) => {
-                    tree.qb_nearest_n_within::<D, EXCLUSIVE>(wrapped_query, radius, max_qty, sorted)
-                }
-                (Some(radius), None) if sorted => {
-                    tree.qb_within::<D, EXCLUSIVE>(wrapped_query, radius)
-                }
-                (Some(radius), None) => {
-                    tree.qb_within_unsorted::<D, EXCLUSIVE>(wrapped_query, radius)
-                }
-                (None, None) => {
-                    unreachable!("periodic plural queries require radius and/or max_qty")
-                }
-            };
-
-            for candidate in candidates {
-                best_by_item
-                    .entry(candidate.item)
-                    .and_modify(|best_distance| {
-                        if D::Output::cmp(candidate.distance, *best_distance) == Ordering::Less {
-                            *best_distance = candidate.distance;
-                        }
-                    })
-                    .or_insert(candidate.distance);
-            }
-        });
-
-        let mut results: Vec<_> = best_by_item
-            .into_iter()
-            .map(|(item, distance)| QueryResultItem {
-                point: (),
-                item,
-                distance,
-            })
-            .collect();
-
-        if sorted {
-            results.sort_unstable();
-        }
-        if let Some(max_qty) = max_qty {
-            results.truncate(max_qty.get());
-        }
-
-        return results;
-    }
-
-    let mut best_by_item = HashMap::<T, D::Output>::new();
-    let mut threshold = radius.map(|value| {
-        (
-            if EXCLUSIVE {
-                BoundaryMode::Exclusive
-            } else {
-                BoundaryMode::Inclusive
-            },
-            value,
-        )
-    });
-
-    let mut candidates = periodic_image_candidates::<D, A, K>(query, box_size, threshold, true);
-    sort_periodic_image_candidates(&mut candidates);
-
-    for candidate in candidates {
-        if threshold.is_some_and(|(boundary, limit)| {
-            !periodic_threshold_accepts(boundary, candidate.lower_bound, limit)
-        }) {
-            continue;
-        }
-
-        let candidates = match (radius, max_qty) {
-            (None, Some(max_qty)) => {
-                tree.qb_nearest_n::<D>(&candidate.wrapped_query, max_qty, true)
-            }
-            (Some(radius), Some(max_qty)) => tree.qb_nearest_n_within::<D, EXCLUSIVE>(
-                &candidate.wrapped_query,
-                radius,
-                max_qty,
-                sorted,
-            ),
-            (Some(radius), None) if sorted => {
-                tree.qb_within::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
-            }
-            (Some(radius), None) => {
-                tree.qb_within_unsorted::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
-            }
-            (None, None) => unreachable!("periodic plural queries require radius and/or max_qty"),
-        };
-
-        for periodic_candidate in candidates {
-            best_by_item
-                .entry(periodic_candidate.item)
-                .and_modify(|best_distance| {
-                    if D::Output::cmp(periodic_candidate.distance, *best_distance) == Ordering::Less
-                    {
-                        *best_distance = periodic_candidate.distance;
-                    }
-                })
-                .or_insert(periodic_candidate.distance);
-        }
-
-        if radius.is_none() {
-            if max_qty.is_some_and(|max_qty| best_by_item.len() >= max_qty.get()) {
-                if let Some(current_worst) = best_by_item
-                    .values()
-                    .copied()
-                    .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
-                {
-                    threshold = Some((BoundaryMode::Exclusive, current_worst));
-                }
-            }
-        } else if max_qty.is_some_and(|max_qty| best_by_item.len() >= max_qty.get()) {
-            if let Some(current_worst) = best_by_item
-                .values()
-                .copied()
-                .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
-            {
-                let radius = radius.unwrap();
-                let tightened = if D::Output::cmp(current_worst, radius) == Ordering::Less {
-                    current_worst
-                } else {
-                    radius
-                };
-                threshold = Some((
-                    if EXCLUSIVE {
-                        BoundaryMode::Exclusive
-                    } else {
-                        BoundaryMode::Inclusive
-                    },
-                    tightened,
-                ));
-            }
-        }
-    }
-
-    let mut results: Vec<_> = best_by_item
-        .into_iter()
-        .map(|(item, distance)| QueryResultItem {
-            point: (),
-            item,
-            distance,
-        })
-        .collect();
-
-    if sorted {
-        results.sort_unstable();
-    }
-    if let Some(max_qty) = max_qty {
-        results.truncate(max_qty.get());
-    }
-
-    results
-}
-
-fn scan_periodic_projected_nearest_one<Tree, A, T, SS, LS, D, Pj, const K: usize, const B: usize>(
-    tree: &Tree,
-    query: &[A; K],
-    box_size: &[A; K],
-) -> Pj::NearestOut
-where
-    A: PeriodicAxis + 'static,
-    T: Content + Copy + Default + PartialOrd,
-    SS: StemStrategy,
-    LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: KdTreeAccessor<A, T, SS, LS, K, B>,
-    D: KdTreeDistanceMetric<A, K>,
-    D::Output: Axis<Coord = D::Output>,
-    Pj: ProjectionSpec<A, T, D::Output, K>,
-{
-    assert_valid_periodic_box(box_size);
-
-    let mut best: Option<FullNearest<A, T, D::Output, K>> = None;
-    for (item, point) in KdTreeIter::<Tree, A, T, SS, LS, K, B>::new(tree) {
-        let distance = periodic_distance_via_minimum_image::<D, A, K>(query, &point, box_size);
-        let candidate = FullNearest {
-            point,
-            item,
-            distance,
-        };
-        if best.as_ref().is_none_or(|current| candidate < *current) {
-            best = Some(candidate);
-        }
-    }
-
-    let best = best.unwrap_or(FullNearest {
-        point: [A::zero(); K],
-        item: T::default(),
-        distance: D::Output::max_value(),
-    });
-
-    map_full_nearest::<A, T, D::Output, Pj, K>(best)
-}
-
-fn scan_periodic_projected_nearest_results<
-    Tree,
-    A,
-    T,
-    SS,
-    LS,
-    D,
-    Pj,
-    const K: usize,
-    const B: usize,
->(
-    tree: &Tree,
-    query: &[A; K],
-    box_size: &[A; K],
-    radius: Option<D::Output>,
-    max_qty: Option<usize>,
-    sorted: bool,
-    boundary: BoundaryMode,
-) -> Vec<Pj::NearestOut>
-where
-    A: PeriodicAxis + 'static,
-    T: Content + Copy + Eq + Hash + PartialOrd,
-    SS: StemStrategy,
-    LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: KdTreeAccessor<A, T, SS, LS, K, B>,
-    D: KdTreeDistanceMetric<A, K>,
-    D::Output: Axis<Coord = D::Output>,
-    Pj: ProjectionSpec<A, T, D::Output, K>,
-{
-    assert_valid_periodic_box(box_size);
-
-    let mut best_by_item = HashMap::<T, FullNearest<A, T, D::Output, K>>::new();
-    for (item, point) in KdTreeIter::<Tree, A, T, SS, LS, K, B>::new(tree) {
-        let distance = periodic_distance_via_minimum_image::<D, A, K>(query, &point, box_size);
-        if radius.is_some_and(|max_dist| !boundary_accepts(boundary, distance, max_dist)) {
-            continue;
-        }
-
-        let candidate = FullNearest {
-            point,
-            item,
-            distance,
-        };
-
-        best_by_item
-            .entry(item)
-            .and_modify(|current| {
-                if candidate < *current {
-                    *current = candidate;
-                }
-            })
-            .or_insert(candidate);
-    }
-
-    let mut results: Vec<_> = best_by_item.into_values().collect();
-    if sorted {
-        results.sort_unstable();
-    }
-    if let Some(max_qty) = max_qty {
-        results.truncate(max_qty);
-    }
-
-    results
-        .into_iter()
-        .map(map_full_nearest::<A, T, D::Output, Pj, K>)
         .collect()
 }
 
@@ -3249,7 +2660,7 @@ where
     T: Content + Copy + Default + PartialOrd,
     SS: StemStrategy + 'static,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeAccessor<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
     D::Output: crate::stem_strategy::SimdPrune
         + SimdSelectBestChildBlock3
@@ -3264,20 +2675,12 @@ where
 {
     #[inline]
     pub fn execute(self) -> QueryResultItem<P::Output, I::Output, Dp::Output> {
-        if <Projection<P, I, Dp> as ProjectionSpec<A, T, D::Output, K>>::WANTS_POINTS {
-            scan_periodic_projected_nearest_one::<Tree, A, T, SS, LS, D, Projection<P, I, Dp>, K, B>(
-                self.inner.tree,
-                self.inner.query,
-                self.inner.box_size,
-            )
-        } else {
-            let result = periodic_nearest_one_result::<Tree, A, T, SS, LS, D, K, B>(
-                self.inner.tree,
-                self.inner.query,
-                self.inner.box_size,
-            );
-            project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>(result)
-        }
+        let result = periodic_nearest_one_result::<Tree, A, T, SS, LS, D, K, B>(
+            self.inner.tree,
+            self.inner.query,
+            self.inner.box_size,
+        );
+        project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>(result)
     }
 }
 
@@ -3360,7 +2763,7 @@ where
     T: Content + Copy + Eq + Hash + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeAccessor<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
     D::Output: crate::stem_strategy::SimdPrune
         + SimdSelectBestChildBlock3
@@ -3375,39 +2778,17 @@ where
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<P::Output, I::Output, Dp::Output>> {
-        if <Projection<P, I, Dp> as ProjectionSpec<A, T, D::Output, K>>::WANTS_POINTS {
-            scan_periodic_projected_nearest_results::<
-                Tree,
-                A,
-                T,
-                SS,
-                LS,
-                D,
-                Projection<P, I, Dp>,
-                K,
-                B,
-            >(
-                self.inner.tree,
-                self.inner.query,
-                self.inner.box_size,
-                None,
-                Some(self.inner.max_qty.get()),
-                true,
-                BoundaryMode::Inclusive,
-            )
-        } else {
-            periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
-                self.inner.tree,
-                self.inner.query,
-                self.inner.box_size,
-                None,
-                Some(self.inner.max_qty),
-                true,
-            )
-            .into_iter()
-            .map(project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>)
-            .collect()
-        }
+        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+            self.inner.tree,
+            self.inner.query,
+            self.inner.box_size,
+            None,
+            Some(self.inner.max_qty),
+            true,
+        )
+        .into_iter()
+        .map(project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>)
+        .collect()
     }
 }
 
@@ -3860,7 +3241,7 @@ macro_rules! impl_projected_periodic_radius_execute {
             T: Content + Copy + Eq + Hash + PartialOrd,
             SS: StemStrategy,
             LS: LeafStrategy<A, T, SS, K, B>,
-            Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeAccessor<A, T, SS, LS, K, B>,
+            Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
             D: KdTreeDistanceMetric<A, K>,
             D::Output: crate::stem_strategy::SimdPrune
                 + SimdSelectBestChildBlock3
@@ -3875,54 +3256,32 @@ macro_rules! impl_projected_periodic_radius_execute {
         {
             #[inline]
             pub fn execute(self) -> Vec<QueryResultItem<P::Output, I::Output, Dp::Output>> {
-                if <Projection<P, I, Dp> as ProjectionSpec<A, T, D::Output, K>>::WANTS_POINTS {
-                    scan_periodic_projected_nearest_results::<
-                        Tree,
-                        A,
-                        T,
-                        SS,
-                        LS,
-                        D,
-                        Projection<P, I, Dp>,
-                        K,
-                        B,
-                    >(
-                        self.inner.tree,
-                        self.inner.query,
-                        self.inner.box_size,
-                        Some(self.inner.radius),
-                        $max_qty(&self.inner),
-                        $sorted,
-                        self.inner.boundary,
-                    )
-                } else {
-                    let results = match self.inner.boundary {
-                        BoundaryMode::Inclusive => {
-                            periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
-                                self.inner.tree,
-                                self.inner.query,
-                                self.inner.box_size,
-                                Some(self.inner.radius),
-                                $max_qty(&self.inner).map(NonZeroUsize::new).flatten(),
-                                $sorted,
-                            )
-                        }
-                        BoundaryMode::Exclusive => {
-                            periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
-                                self.inner.tree,
-                                self.inner.query,
-                                self.inner.box_size,
-                                Some(self.inner.radius),
-                                $max_qty(&self.inner).map(NonZeroUsize::new).flatten(),
-                                $sorted,
-                            )
-                        }
-                    };
-                    results
-                        .into_iter()
-                        .map(project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>)
-                        .collect()
-                }
+                let results = match self.inner.boundary {
+                    BoundaryMode::Inclusive => {
+                        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+                            self.inner.tree,
+                            self.inner.query,
+                            self.inner.box_size,
+                            Some(self.inner.radius),
+                            $max_qty(&self.inner).map(NonZeroUsize::new).flatten(),
+                            $sorted,
+                        )
+                    }
+                    BoundaryMode::Exclusive => {
+                        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
+                            self.inner.tree,
+                            self.inner.query,
+                            self.inner.box_size,
+                            Some(self.inner.radius),
+                            $max_qty(&self.inner).map(NonZeroUsize::new).flatten(),
+                            $sorted,
+                        )
+                    }
+                };
+                results
+                    .into_iter()
+                    .map(project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>)
+                    .collect()
             }
         }
     };

--- a/src/kd_tree/query/mod.rs
+++ b/src/kd_tree/query/mod.rs
@@ -1,6 +1,7 @@
 mod approx_nearest_one;
 mod best_n_within;
 mod builder;
+mod periodic;
 pub use builder::{
     ApproxNearestOneQuery, BestNWithinQuery, Exclude, Include, NearestNQuery,
     NearestNUnsortedQuery, NearestNWithinQuery, NearestNWithinUnsortedQuery, NearestOneQuery,

--- a/src/kd_tree/query/periodic.rs
+++ b/src/kd_tree/query/periodic.rs
@@ -1,0 +1,459 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use crate::dist::KdTreeDistanceMetric;
+use crate::kd_tree::query_stack::StackTrait;
+use crate::leaf_view::TlsLeafScratch;
+use crate::stem_strategy::donnelly_2_blockmarker_simd::{
+    BacktrackBlock3, BacktrackBlock4, SimdSelectBestChildBlock3,
+};
+use crate::{Axis, Content, LeafStrategy, QueryResultItem, StemStrategy};
+
+use super::builder::{boundary_accepts, BoundaryMode, PeriodicAxis, QueryBuilderTreeOps};
+
+fn with_wrapped_queries<A: PeriodicAxis, F, const K: usize>(
+    query: &[A; K],
+    box_size: &[A; K],
+    mut f: F,
+) where
+    F: FnMut(&[A; K]),
+{
+    fn recurse<A: PeriodicAxis, F, const K: usize>(
+        query: &[A; K],
+        box_size: &[A; K],
+        axis: usize,
+        wrapped_query: &mut [A; K],
+        f: &mut F,
+    ) where
+        F: FnMut(&[A; K]),
+    {
+        if axis == K {
+            f(wrapped_query);
+            return;
+        }
+
+        let original = query[axis];
+        let axis_len = box_size[axis];
+
+        wrapped_query[axis] = original - axis_len;
+        recurse(query, box_size, axis + 1, wrapped_query, f);
+
+        wrapped_query[axis] = original;
+        recurse(query, box_size, axis + 1, wrapped_query, f);
+
+        let mut plus = original;
+        plus += axis_len;
+        wrapped_query[axis] = plus;
+        recurse(query, box_size, axis + 1, wrapped_query, f);
+
+        wrapped_query[axis] = original;
+    }
+
+    let mut wrapped_query = *query;
+    recurse(query, box_size, 0, &mut wrapped_query, &mut f);
+}
+
+#[inline(always)]
+fn periodic_image_axis_offset<A: PeriodicAxis>(wrapped_coord: A, axis_len: A) -> A {
+    if A::cmp(wrapped_coord, A::zero()) == Ordering::Less {
+        A::saturating_dist(wrapped_coord, A::zero())
+    } else if A::cmp(wrapped_coord, axis_len) == Ordering::Greater {
+        A::saturating_dist(wrapped_coord, axis_len)
+    } else {
+        A::zero()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PeriodicImageCandidate<A, O, const K: usize> {
+    wrapped_query: [A; K],
+    lower_bound: O,
+}
+
+fn periodic_image_candidates<D, A, const K: usize>(
+    query: &[A; K],
+    box_size: &[A; K],
+    threshold: Option<(BoundaryMode, D::Output)>,
+    include_home: bool,
+) -> Vec<PeriodicImageCandidate<A, D::Output, K>>
+where
+    A: PeriodicAxis + 'static,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: Axis<Coord = D::Output>,
+{
+    fn recurse<D, A, const K: usize>(
+        query: &[A; K],
+        box_size: &[A; K],
+        axis: usize,
+        wrapped_query: &mut [A; K],
+        has_non_zero_shift: bool,
+        lower_bound: D::Output,
+        threshold: Option<(BoundaryMode, D::Output)>,
+        include_home: bool,
+        out: &mut Vec<PeriodicImageCandidate<A, D::Output, K>>,
+    ) where
+        A: PeriodicAxis + 'static,
+        D: KdTreeDistanceMetric<A, K>,
+        D::Output: Axis<Coord = D::Output>,
+    {
+        if axis == K {
+            if include_home || has_non_zero_shift {
+                out.push(PeriodicImageCandidate {
+                    wrapped_query: *wrapped_query,
+                    lower_bound,
+                });
+            }
+            return;
+        }
+
+        let original = query[axis];
+        let axis_len = box_size[axis];
+
+        for shift in [-1_i8, 0, 1] {
+            let wrapped_coord = match shift {
+                -1 => original - axis_len,
+                0 => original,
+                1 => {
+                    let mut plus = original;
+                    plus += axis_len;
+                    plus
+                }
+                _ => unreachable!(),
+            };
+
+            wrapped_query[axis] = wrapped_coord;
+
+            let offset = periodic_image_axis_offset(wrapped_coord, axis_len);
+            let mut next_lower_bound = lower_bound;
+            D::combine_component(
+                &mut next_lower_bound,
+                D::dist1(D::widen_coord(offset), D::Output::zero()),
+            );
+
+            if threshold.is_some_and(|(boundary, limit)| {
+                !boundary_accepts(boundary, next_lower_bound, limit)
+            }) {
+                continue;
+            }
+
+            recurse::<D, A, K>(
+                query,
+                box_size,
+                axis + 1,
+                wrapped_query,
+                has_non_zero_shift || shift != 0,
+                next_lower_bound,
+                threshold,
+                include_home,
+                out,
+            );
+        }
+
+        wrapped_query[axis] = original;
+    }
+
+    let mut candidates = Vec::new();
+    let mut wrapped_query = *query;
+    recurse::<D, A, K>(
+        query,
+        box_size,
+        0,
+        &mut wrapped_query,
+        false,
+        D::Output::zero(),
+        threshold,
+        include_home,
+        &mut candidates,
+    );
+    candidates
+}
+
+#[inline(always)]
+fn sort_periodic_image_candidates<A, O, const K: usize>(
+    candidates: &mut [PeriodicImageCandidate<A, O, K>],
+) where
+    O: Axis<Coord = O>,
+{
+    candidates.sort_unstable_by(|lhs, rhs| {
+        lhs.lower_bound
+            .partial_cmp(&rhs.lower_bound)
+            .unwrap_or(Ordering::Equal)
+    });
+}
+
+pub(crate) fn periodic_nearest_one_result<Tree, A, T, SS, LS, D, const K: usize, const B: usize>(
+    tree: &Tree,
+    query: &[A; K],
+    box_size: &[A; K],
+) -> QueryResultItem<(), T, D::Output>
+where
+    A: PeriodicAxis + 'static,
+    T: Content,
+    SS: StemStrategy + 'static,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS> + Default + 'static,
+{
+    assert!(
+        A::periodic_box_is_valid(box_size),
+        "periodic box sizes must be strictly positive"
+    );
+
+    if D::ORDERING != Ordering::Less {
+        let mut best_result = QueryResultItem {
+            point: (),
+            item: T::default(),
+            distance: D::Output::max_value(),
+        };
+
+        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
+            let (distance, item) = tree.qb_nearest_one::<D>(wrapped_query);
+            if D::Output::cmp(distance, best_result.distance) == Ordering::Less {
+                best_result.distance = distance;
+                best_result.item = item;
+            }
+        });
+
+        return best_result;
+    }
+
+    let (home_distance, home_item) = tree.qb_nearest_one::<D>(query);
+    let mut best_result = QueryResultItem {
+        point: (),
+        item: home_item,
+        distance: home_distance,
+    };
+
+    let mut candidates = periodic_image_candidates::<D, A, K>(
+        query,
+        box_size,
+        Some((BoundaryMode::Exclusive, best_result.distance)),
+        false,
+    );
+    sort_periodic_image_candidates(&mut candidates);
+
+    for candidate in candidates {
+        if !boundary_accepts(
+            BoundaryMode::Exclusive,
+            candidate.lower_bound,
+            best_result.distance,
+        ) {
+            continue;
+        }
+
+        let (distance, item) = tree.qb_nearest_one::<D>(&candidate.wrapped_query);
+        if D::Output::cmp(distance, best_result.distance) == Ordering::Less {
+            best_result.distance = distance;
+            best_result.item = item;
+        }
+    }
+
+    best_result
+}
+
+pub(crate) fn periodic_nearest_results_by_item<
+    Tree,
+    A,
+    T,
+    SS,
+    LS,
+    D,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    tree: &Tree,
+    query: &[A; K],
+    box_size: &[A; K],
+    radius: Option<D::Output>,
+    max_qty: Option<NonZeroUsize>,
+    sorted: bool,
+) -> Vec<QueryResultItem<(), T, D::Output>>
+where
+    A: PeriodicAxis + 'static,
+    T: Content + Eq + Hash + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+{
+    assert!(
+        A::periodic_box_is_valid(box_size),
+        "periodic box sizes must be strictly positive"
+    );
+
+    if D::ORDERING != Ordering::Less {
+        let mut best_by_item = HashMap::<T, D::Output>::new();
+
+        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
+            let candidates = match (radius, max_qty) {
+                (None, Some(max_qty)) => tree.qb_nearest_n::<D>(wrapped_query, max_qty, true),
+                (Some(radius), Some(max_qty)) => {
+                    tree.qb_nearest_n_within::<D, EXCLUSIVE>(wrapped_query, radius, max_qty, sorted)
+                }
+                (Some(radius), None) if sorted => {
+                    tree.qb_within::<D, EXCLUSIVE>(wrapped_query, radius)
+                }
+                (Some(radius), None) => {
+                    tree.qb_within_unsorted::<D, EXCLUSIVE>(wrapped_query, radius)
+                }
+                (None, None) => {
+                    unreachable!("periodic plural queries require radius and/or max_qty")
+                }
+            };
+
+            for candidate in candidates {
+                best_by_item
+                    .entry(candidate.item)
+                    .and_modify(|best_distance| {
+                        if D::Output::cmp(candidate.distance, *best_distance) == Ordering::Less {
+                            *best_distance = candidate.distance;
+                        }
+                    })
+                    .or_insert(candidate.distance);
+            }
+        });
+
+        let mut results: Vec<_> = best_by_item
+            .into_iter()
+            .map(|(item, distance)| QueryResultItem {
+                point: (),
+                item,
+                distance,
+            })
+            .collect();
+
+        if sorted {
+            results.sort_unstable();
+        }
+        if let Some(max_qty) = max_qty {
+            results.truncate(max_qty.get());
+        }
+
+        return results;
+    }
+
+    let mut best_by_item = HashMap::<T, D::Output>::new();
+    let mut threshold = radius.map(|value| {
+        (
+            if EXCLUSIVE {
+                BoundaryMode::Exclusive
+            } else {
+                BoundaryMode::Inclusive
+            },
+            value,
+        )
+    });
+
+    let mut candidates = periodic_image_candidates::<D, A, K>(query, box_size, threshold, true);
+    sort_periodic_image_candidates(&mut candidates);
+
+    for candidate in candidates {
+        if threshold.is_some_and(|(boundary, limit)| {
+            !boundary_accepts(boundary, candidate.lower_bound, limit)
+        }) {
+            continue;
+        }
+
+        let candidates = match (radius, max_qty) {
+            (None, Some(max_qty)) => {
+                tree.qb_nearest_n::<D>(&candidate.wrapped_query, max_qty, true)
+            }
+            (Some(radius), Some(max_qty)) => tree.qb_nearest_n_within::<D, EXCLUSIVE>(
+                &candidate.wrapped_query,
+                radius,
+                max_qty,
+                sorted,
+            ),
+            (Some(radius), None) if sorted => {
+                tree.qb_within::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
+            }
+            (Some(radius), None) => {
+                tree.qb_within_unsorted::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
+            }
+            (None, None) => unreachable!("periodic plural queries require radius and/or max_qty"),
+        };
+
+        for periodic_candidate in candidates {
+            best_by_item
+                .entry(periodic_candidate.item)
+                .and_modify(|best_distance| {
+                    if D::Output::cmp(periodic_candidate.distance, *best_distance) == Ordering::Less
+                    {
+                        *best_distance = periodic_candidate.distance;
+                    }
+                })
+                .or_insert(periodic_candidate.distance);
+        }
+
+        if radius.is_none() {
+            if max_qty.is_some_and(|max_qty| best_by_item.len() >= max_qty.get()) {
+                if let Some(current_worst) = best_by_item
+                    .values()
+                    .copied()
+                    .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
+                {
+                    threshold = Some((BoundaryMode::Exclusive, current_worst));
+                }
+            }
+        } else if let Some(radius) = radius {
+            if max_qty.is_none_or(|max_qty| best_by_item.len() < max_qty.get()) {
+                continue;
+            }
+
+            if let Some(current_worst) = best_by_item
+                .values()
+                .copied()
+                .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
+            {
+                let tightened = if D::Output::cmp(current_worst, radius) == Ordering::Less {
+                    current_worst
+                } else {
+                    radius
+                };
+                threshold = Some((
+                    if EXCLUSIVE {
+                        BoundaryMode::Exclusive
+                    } else {
+                        BoundaryMode::Inclusive
+                    },
+                    tightened,
+                ));
+            }
+        }
+    }
+
+    let mut results: Vec<_> = best_by_item
+        .into_iter()
+        .map(|(item, distance)| QueryResultItem {
+            point: (),
+            item,
+            distance,
+        })
+        .collect();
+
+    if sorted {
+        results.sort_unstable();
+    }
+    if let Some(max_qty) = max_qty {
+        results.truncate(max_qty.get());
+    }
+
+    results
+}


### PR DESCRIPTION
Add a PBC benchmark and refactor the previous implementation to prune images more efficiently and avoid the hashmap.

performance on the benchmark is ~1100x faster on nearest_one(!). Within and nearest_n_within benchmarks are also improved but only 1.1x and 1.77x respectively. I think I can get those much faster but that will need a follow-up as the change is much more invasive