### PR TITLE
Periodic nearest_n / within queries are now single-pass

### DIFF
--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -2,7 +2,6 @@
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::num::NonZero;
 use std::num::NonZeroUsize;
@@ -11,14 +10,14 @@ use crate::dist::KdTreeDistanceMetric;
 use crate::kd_tree::query_stack::StackTrait;
 #[cfg(feature = "rkyv_08")]
 use crate::kd_tree::ArchivedKdTree;
-use crate::kd_tree::{KdTree, KdTreeAccessor, KdTreeIter, WithinUnsortedIter};
+use crate::kd_tree::{KdTree, KdTreeAccessor, KdTreeIter, KdTreeQueryOps, WithinUnsortedIter};
 use crate::leaf_view::TlsLeafScratch;
 use crate::stem_strategy::donnelly_2_blockmarker_simd::{
     BacktrackBlock3, BacktrackBlock4, SimdSelectBestChildBlock3,
 };
 use crate::{Axis, BestQueryResultItem, Content, LeafStrategy, QueryResultItem, StemStrategy};
 
-use super::periodic::{periodic_nearest_one_result, periodic_nearest_results_by_item};
+use super::periodic::{periodic_nearest_one_result, periodic_nearest_results};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BoundaryMode {
@@ -1474,22 +1473,16 @@ impl<'a, Tree, A, T, SS, LS, D, const K: usize, const B: usize>
     PeriodicNearestNQuery<'a, Tree, A, T, SS, LS, D, K, B>
 where
     A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
+    T: Content + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<(), T, D::Output>> {
-        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+        periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
             self.tree,
             self.query,
             self.box_size,
@@ -1548,24 +1541,18 @@ impl<'a, Tree, A, T, SS, LS, D, const K: usize, const B: usize>
     PeriodicNearestNWithinQuery<'a, Tree, A, T, SS, LS, D, K, B>
 where
     A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
+    T: Content + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<(), T, D::Output>> {
         match self.boundary {
             BoundaryMode::Inclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1575,7 +1562,7 @@ where
                 )
             }
             BoundaryMode::Exclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, true, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1623,24 +1610,18 @@ impl<'a, Tree, A, T, SS, LS, D, const K: usize, const B: usize>
     PeriodicNearestNWithinUnsortedQuery<'a, Tree, A, T, SS, LS, D, K, B>
 where
     A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
+    T: Content + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<(), T, D::Output>> {
         match self.boundary {
             BoundaryMode::Inclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1650,7 +1631,7 @@ where
                 )
             }
             BoundaryMode::Exclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, true, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1710,24 +1691,18 @@ impl<'a, Tree, A, T, SS, LS, D, const K: usize, const B: usize>
     PeriodicWithinQuery<'a, Tree, A, T, SS, LS, D, K, B>
 where
     A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
+    T: Content + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<(), T, D::Output>> {
         match self.boundary {
             BoundaryMode::Inclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1737,7 +1712,7 @@ where
                 )
             }
             BoundaryMode::Exclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, true, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1785,24 +1760,18 @@ impl<'a, Tree, A, T, SS, LS, D, const K: usize, const B: usize>
     PeriodicWithinUnsortedQuery<'a, Tree, A, T, SS, LS, D, K, B>
 where
     A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
+    T: Content + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<(), T, D::Output>> {
         match self.boundary {
             BoundaryMode::Inclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -1812,7 +1781,7 @@ where
                 )
             }
             BoundaryMode::Exclusive => {
-                periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
+                periodic_nearest_results::<Tree, A, T, SS, LS, D, true, K, B>(
                     self.tree,
                     self.query,
                     self.box_size,
@@ -2760,25 +2729,19 @@ impl<'a, Tree, A, T, SS, LS, D, P, I, Dp, const K: usize, const B: usize>
     Projected<PeriodicNearestNQuery<'a, Tree, A, T, SS, LS, D, K, B>, Projection<P, I, Dp>>
 where
     A: PeriodicAxis + 'static,
-    T: Content + Copy + Eq + Hash + PartialOrd,
+    T: Content + Copy + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
     P: PointProjectionField<A, K>,
     I: ProjectionField<T>,
     Dp: ProjectionField<D::Output>,
 {
     #[inline]
     pub fn execute(self) -> Vec<QueryResultItem<P::Output, I::Output, Dp::Output>> {
-        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+        periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
             self.inner.tree,
             self.inner.query,
             self.inner.box_size,
@@ -3238,18 +3201,12 @@ macro_rules! impl_projected_periodic_radius_execute {
             Projected<$wrapper<'a, Tree, A, T, SS, LS, D, K, B>, Projection<P, I, Dp>>
         where
             A: PeriodicAxis + 'static,
-            T: Content + Copy + Eq + Hash + PartialOrd,
+            T: Content + Copy + PartialOrd,
             SS: StemStrategy,
             LS: LeafStrategy<A, T, SS, K, B>,
-            Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
+            Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
             D: KdTreeDistanceMetric<A, K>,
-            D::Output: crate::stem_strategy::SimdPrune
-                + SimdSelectBestChildBlock3
-                + BacktrackBlock3
-                + BacktrackBlock4
-                + TlsLeafScratch
-                + 'static,
-            SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+            D::Output: Axis<Coord = D::Output>,
             P: PointProjectionField<A, K>,
             I: ProjectionField<T>,
             Dp: ProjectionField<D::Output>,
@@ -3258,7 +3215,7 @@ macro_rules! impl_projected_periodic_radius_execute {
             pub fn execute(self) -> Vec<QueryResultItem<P::Output, I::Output, Dp::Output>> {
                 let results = match self.inner.boundary {
                     BoundaryMode::Inclusive => {
-                        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, false, K, B>(
+                        periodic_nearest_results::<Tree, A, T, SS, LS, D, false, K, B>(
                             self.inner.tree,
                             self.inner.query,
                             self.inner.box_size,
@@ -3268,7 +3225,7 @@ macro_rules! impl_projected_periodic_radius_execute {
                         )
                     }
                     BoundaryMode::Exclusive => {
-                        periodic_nearest_results_by_item::<Tree, A, T, SS, LS, D, true, K, B>(
+                        periodic_nearest_results::<Tree, A, T, SS, LS, D, true, K, B>(
                             self.inner.tree,
                             self.inner.query,
                             self.inner.box_size,
@@ -3378,7 +3335,7 @@ mod tests {
     type WrapTree = KdTree<f64, u32, EytzingerPf<2, 8>, FlatVec<f64, u32, 2, 32>, 2, 32>;
 
     #[test]
-    fn periodic_nearest_one_wraps_and_returns_points() {
+    fn periodic_nearest_one_wraps_and_supports_non_point_projection() {
         let points = [(1u32, [0.95, 0.5]), (2u32, [0.40, 0.5])];
         let tree = WrapTree::new_from_entries(&points).unwrap();
         let query = [0.05, 0.5];
@@ -3404,7 +3361,7 @@ mod tests {
     }
 
     #[test]
-    fn periodic_radius_queries_dedup_and_respect_boundary_mode() {
+    fn periodic_radius_queries_use_per_entry_semantics_and_respect_boundary_mode() {
         let points = [
             (1u32, [0.95, 0.5]),
             (2u32, [0.85, 0.5]),
@@ -3451,6 +3408,31 @@ mod tests {
             .collect();
         items.sort_unstable();
         assert_eq!(items, vec![1, 2]);
+    }
+
+    #[test]
+    fn periodic_plural_queries_do_not_dedup_duplicate_items() {
+        let points = [
+            (7u32, [0.95, 0.5]),
+            (7u32, [0.96, 0.5]),
+            (9u32, [0.85, 0.5]),
+        ];
+        let tree = WrapTree::new_from_entries(&points).unwrap();
+        let query = [0.05, 0.5];
+        let box_size = [1.0, 1.0];
+
+        let mut results: Vec<_> = tree
+            .query(&query)
+            .periodic_boundary_condition(&box_size)
+            .within::<SquaredEuclidean<f64>>(0.02)
+            .unsorted()
+            .execute()
+            .into_iter()
+            .map(|result| result.item)
+            .collect();
+        results.sort_unstable();
+
+        assert_eq!(results, vec![7, 7]);
     }
 
     #[cfg(feature = "rkyv_08")]

--- a/src/kd_tree/query/periodic.rs
+++ b/src/kd_tree/query/periodic.rs
@@ -1,17 +1,29 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::hash::Hash;
+use std::marker::PhantomData;
 use std::num::NonZeroUsize;
+use std::ptr::NonNull;
 
 use crate::dist::KdTreeDistanceMetric;
-use crate::kd_tree::query_stack::StackTrait;
-use crate::leaf_view::TlsLeafScratch;
-use crate::stem_strategy::donnelly_2_blockmarker_simd::{
-    BacktrackBlock3, BacktrackBlock4, SimdSelectBestChildBlock3,
+use crate::kd_tree::query_context::QueryContext;
+use crate::kd_tree::{KdTreeAccessor, KdTreeQueryOps, StemLeafResolution};
+use crate::leaf_view::LeafView;
+#[cfg(not(feature = "small_n_result_collectors"))]
+use crate::results::result_collection::SortedVecResultCollection;
+use crate::results::result_collection::{BinaryHeapResultCollection, ResultCollection};
+#[cfg(feature = "small_n_result_collectors")]
+use crate::results::result_collection::{
+    SmallSortedVecResultCollection, SMALL_RESULT_COLLECTION_MAX_QTY,
 };
+use crate::stem_strategy::donnelly_2_blockmarker_simd::{
+    interval_distance_1d, BacktrackBlock3, BacktrackBlock4, SimdSelectBestChildBlock3,
+};
+use crate::traits::leaf_strategy::LeafProjection;
 use crate::{Axis, Content, LeafStrategy, QueryResultItem, StemStrategy};
 
 use super::builder::{boundary_accepts, BoundaryMode, PeriodicAxis, QueryBuilderTreeOps};
+
+#[cfg(not(feature = "small_n_result_collectors"))]
+const MAX_VEC_RESULT_SIZE: usize = 20;
 
 fn with_wrapped_queries<A: PeriodicAxis, F, const K: usize>(
     query: &[A; K],
@@ -199,9 +211,10 @@ where
         + SimdSelectBestChildBlock3
         + BacktrackBlock3
         + BacktrackBlock4
-        + TlsLeafScratch
+        + crate::leaf_view::TlsLeafScratch
         + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + Default + 'static,
+    SS::Stack<D::Output>:
+        crate::kd_tree::query_stack::StackTrait<D::Output, SS> + Default + 'static,
 {
     assert!(
         A::periodic_box_is_valid(box_size),
@@ -260,7 +273,472 @@ where
     best_result
 }
 
-pub(crate) fn periodic_nearest_results_by_item<
+#[derive(Clone)]
+struct PeriodicTraversalFrame<O, S, const K: usize> {
+    stem_state: S,
+    lower: [O; K],
+    upper: [O; K],
+    off: [O; K],
+    rd: O,
+}
+
+struct PeriodicNearestResultsReqCtx<'a, A, T, O, R, const EXCLUSIVE: bool, const K: usize>
+where
+    O: Axis<Coord = O>,
+{
+    query: &'a [A; K],
+    max_dist: O,
+    results: R,
+    _phantom: PhantomData<T>,
+}
+
+impl<A, T, O, R, const EXCLUSIVE: bool, const K: usize> QueryContext<A, O, K>
+    for PeriodicNearestResultsReqCtx<'_, A, T, O, R, EXCLUSIVE, K>
+where
+    O: Axis<Coord = O>,
+    R: ResultCollection<O, QueryResultItem<(), T, O>>,
+{
+    #[inline(always)]
+    fn query(&self) -> &[A; K] {
+        self.query
+    }
+
+    #[inline(always)]
+    fn max_dist(&self) -> O {
+        let results_cap = self.results.threshold_distance().unwrap_or(O::max_value());
+        if results_cap < self.max_dist {
+            results_cap
+        } else {
+            self.max_dist
+        }
+    }
+
+    #[inline(always)]
+    fn prune_on_equal_max_dist(&self) -> bool {
+        EXCLUSIVE
+    }
+}
+
+#[inline(always)]
+fn periodic_should_prune<O>(rd: O, max_dist: O, prune_on_equal: bool) -> bool
+where
+    O: Axis<Coord = O>,
+{
+    let rd_vs_max = O::cmp(rd, max_dist);
+    rd_vs_max == Ordering::Greater || (prune_on_equal && rd_vs_max == Ordering::Equal)
+}
+
+#[inline(always)]
+fn periodic_min_image_axis_delta<O>(query: O, coord: O, axis_len: O) -> O
+where
+    O: Axis<Coord = O>,
+{
+    let delta = O::saturating_dist(query, coord);
+    let wrapped = axis_len - delta;
+    if O::cmp(wrapped, delta) == Ordering::Less {
+        wrapped
+    } else {
+        delta
+    }
+}
+
+#[inline(always)]
+fn periodic_interval_distance_1d<O>(query: O, lower: O, upper: O, axis_len: O) -> O
+where
+    O: Axis<Coord = O>,
+{
+    let mut best = interval_distance_1d(query, lower, upper);
+
+    let minus = interval_distance_1d(query, lower - axis_len, upper - axis_len);
+    if O::cmp(minus, best) == Ordering::Less {
+        best = minus;
+    }
+
+    let mut lower_plus = lower;
+    lower_plus += axis_len;
+    let mut upper_plus = upper;
+    upper_plus += axis_len;
+    let plus = interval_distance_1d(query, lower_plus, upper_plus);
+    if O::cmp(plus, best) == Ordering::Less {
+        best = plus;
+    }
+
+    best
+}
+
+#[inline(always)]
+fn process_periodic_leaf_view<A, T, D, R, const EXCLUSIVE: bool, const K: usize, const B: usize>(
+    leaf: &LeafView<'_, A, T, K, B>,
+    query_wide: &[D::Output; K],
+    box_size_wide: &[D::Output; K],
+    max_dist: D::Output,
+    results: &mut R,
+) where
+    A: Axis<Coord = A> + 'static,
+    T: Content,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: Axis<Coord = D::Output>,
+    R: ResultCollection<D::Output, QueryResultItem<(), T, D::Output>>,
+{
+    let points = leaf.points();
+    let items = leaf.items();
+
+    for idx in 0..leaf.len() {
+        let mut candidate_dist = D::Output::zero();
+        for dim in 0..K {
+            let coord = D::widen_coord(unsafe { *points.get_unchecked(dim).get_unchecked(idx) });
+            let delta = periodic_min_image_axis_delta(
+                unsafe { *query_wide.get_unchecked(dim) },
+                coord,
+                unsafe { *box_size_wide.get_unchecked(dim) },
+            );
+            D::combine_component(&mut candidate_dist, D::dist1(delta, D::Output::zero()));
+        }
+
+        if boundary_accepts(
+            if EXCLUSIVE {
+                BoundaryMode::Exclusive
+            } else {
+                BoundaryMode::Inclusive
+            },
+            candidate_dist,
+            max_dist,
+        ) {
+            results.add(QueryResultItem {
+                point: (),
+                item: unsafe { *items.get_unchecked(idx) },
+                distance: candidate_dist,
+            });
+        }
+    }
+}
+
+#[inline(always)]
+fn process_periodic_leaf_arena<A, T, D, R, const EXCLUSIVE: bool, const K: usize>(
+    arena: crate::leaf_view::LeafArena<'_, A, T, K>,
+    query_wide: &[D::Output; K],
+    box_size_wide: &[D::Output; K],
+    max_dist: D::Output,
+    results: &mut R,
+) where
+    A: Axis<Coord = A> + 'static,
+    T: Content,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: Axis<Coord = D::Output>,
+    R: ResultCollection<D::Output, QueryResultItem<(), T, D::Output>>,
+{
+    arena.for_each_tiled_chunk(|tile| {
+        for idx in 0..tile.len() {
+            let mut candidate_dist = D::Output::zero();
+            for dim in 0..K {
+                let coord = D::widen_coord(unsafe { tile.point_unaligned(dim, idx) });
+                let delta = periodic_min_image_axis_delta(
+                    unsafe { *query_wide.get_unchecked(dim) },
+                    coord,
+                    unsafe { *box_size_wide.get_unchecked(dim) },
+                );
+                D::combine_component(&mut candidate_dist, D::dist1(delta, D::Output::zero()));
+            }
+
+            if boundary_accepts(
+                if EXCLUSIVE {
+                    BoundaryMode::Exclusive
+                } else {
+                    BoundaryMode::Inclusive
+                },
+                candidate_dist,
+                max_dist,
+            ) {
+                results.add(QueryResultItem {
+                    point: (),
+                    item: unsafe { tile.item_unaligned(idx) },
+                    distance: candidate_dist,
+                });
+            }
+        }
+    });
+}
+
+#[inline(always)]
+fn process_periodic_leaf<
+    Tree,
+    A,
+    T,
+    SS,
+    LS,
+    D,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    tree: &Tree,
+    leaf_idx: usize,
+    query_wide: &[D::Output; K],
+    box_size_wide: &[D::Output; K],
+    max_dist: D::Output,
+    results: &mut R,
+) where
+    A: Axis<Coord = A> + 'static,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: KdTreeAccessor<A, T, SS, LS, K, B>,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: Axis<Coord = D::Output>,
+    R: ResultCollection<D::Output, QueryResultItem<(), T, D::Output>>,
+{
+    match LS::LEAF_PROJECTION {
+        LeafProjection::LeafView => {
+            let leaf = tree.leaves().leaf_view(leaf_idx);
+            process_periodic_leaf_view::<A, T, D, R, EXCLUSIVE, K, B>(
+                &leaf,
+                query_wide,
+                box_size_wide,
+                max_dist,
+                results,
+            );
+        }
+        LeafProjection::LeafArena => {
+            let arena = tree.leaves().leaf_arena(leaf_idx);
+            process_periodic_leaf_arena::<A, T, D, R, EXCLUSIVE, K>(
+                arena,
+                query_wide,
+                box_size_wide,
+                max_dist,
+                results,
+            );
+        }
+    }
+}
+
+fn periodic_backtracking_query<Tree, A, T, SS, LS, QC, O, D, F, const K: usize, const B: usize>(
+    tree: &Tree,
+    query_ctx: &mut QC,
+    box_size: &[A; K],
+    mut process_leaf: F,
+) where
+    Tree: KdTreeAccessor<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
+    A: PeriodicAxis + 'static,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    QC: QueryContext<A, O, K>,
+    O: Axis<Coord = O>,
+    D: KdTreeDistanceMetric<A, K, Output = O>,
+    F: FnMut(usize, &[O; K], &[O; K], &mut QC),
+{
+    if tree.size() == 0 {
+        return;
+    }
+
+    let stems_ptr = NonNull::new(tree.stems().as_ptr() as *mut u8).unwrap();
+    let mut stem_strat: SS = SS::new(stems_ptr);
+
+    let query = *query_ctx.query();
+    let mut query_wide = [O::zero(); K];
+    let mut box_size_wide = [O::zero(); K];
+    for dim in 0..K {
+        query_wide[dim] = D::widen_coord(query[dim]);
+        box_size_wide[dim] = D::widen_coord(box_size[dim]);
+    }
+
+    let mut lower = [O::zero(); K];
+    let mut upper = box_size_wide;
+    let mut off = [O::zero(); K];
+    let mut rd = O::zero();
+
+    let mut stack: Vec<PeriodicTraversalFrame<O, SS::DeferredState, K>> =
+        Vec::with_capacity((tree.max_stem_level().max(0) as usize) + 1);
+
+    loop {
+        loop {
+            if let Some(leaf_idx) = tree.resolve_terminal_stem(stem_strat.stem_idx()) {
+                process_leaf(leaf_idx, &query_wide, &box_size_wide, query_ctx);
+                break;
+            }
+
+            if stem_strat.level() > tree.max_stem_level() {
+                let leaf_idx = tree
+                    .stem_leaf_resolution()
+                    .resolve_terminal_stem_idx(stem_strat.stem_idx(), stem_strat.leaf_idx());
+                process_leaf(leaf_idx, &query_wide, &box_size_wide, query_ctx);
+                break;
+            }
+
+            let dim = stem_strat.dim();
+            let stem_idx = stem_strat.stem_idx();
+            let pivot = if stem_idx < tree.stems().len() {
+                unsafe { *tree.stems().get_unchecked(stem_idx) }
+            } else {
+                A::max_value()
+            };
+
+            if pivot >= A::max_value() {
+                stem_strat.traverse(false);
+                continue;
+            }
+
+            let old_lower = lower[dim];
+            let old_upper = upper[dim];
+            let pivot_wide = D::widen_coord(pivot);
+            let query_val = query[dim];
+            let query_wide_val = query_wide[dim];
+            let is_right_child = query_val >= pivot;
+            let far_ctx = stem_strat.branch_relative(is_right_child);
+
+            let (near_lower, near_upper, far_lower, far_upper) = if is_right_child {
+                (
+                    O::max(old_lower, pivot_wide),
+                    old_upper,
+                    old_lower,
+                    if O::cmp(old_upper, pivot_wide) == Ordering::Less {
+                        old_upper
+                    } else {
+                        pivot_wide
+                    },
+                )
+            } else {
+                (
+                    old_lower,
+                    if O::cmp(old_upper, pivot_wide) == Ordering::Less {
+                        old_upper
+                    } else {
+                        pivot_wide
+                    },
+                    O::max(old_lower, pivot_wide),
+                    old_upper,
+                )
+            };
+
+            let near_off = periodic_interval_distance_1d(
+                query_wide_val,
+                near_lower,
+                near_upper,
+                box_size_wide[dim],
+            );
+            let far_off = periodic_interval_distance_1d(
+                query_wide_val,
+                far_lower,
+                far_upper,
+                box_size_wide[dim],
+            );
+            let near_rd = D::rect_dist_after_update(rd, &off, dim, near_off);
+            let far_rd = D::rect_dist_after_update(rd, &off, dim, far_off);
+
+            let threshold = query_ctx.max_dist();
+            let prune_on_equal = query_ctx.prune_on_equal_max_dist();
+            let near_pruned = periodic_should_prune(near_rd, threshold, prune_on_equal);
+            let far_pruned = periodic_should_prune(far_rd, threshold, prune_on_equal);
+
+            if !far_pruned {
+                let mut far_lower_state = lower;
+                far_lower_state[dim] = far_lower;
+                let mut far_upper_state = upper;
+                far_upper_state[dim] = far_upper;
+                let mut far_off_state = off;
+                far_off_state[dim] = far_off;
+                stack.push(PeriodicTraversalFrame {
+                    stem_state: far_ctx.deferred_state(),
+                    lower: far_lower_state,
+                    upper: far_upper_state,
+                    off: far_off_state,
+                    rd: far_rd,
+                });
+            }
+
+            if near_pruned {
+                if let Some(frame) = stack.pop() {
+                    stem_strat.rehydrate_deferred_state(frame.stem_state);
+                    lower = frame.lower;
+                    upper = frame.upper;
+                    off = frame.off;
+                    rd = frame.rd;
+                    continue;
+                }
+                return;
+            }
+
+            lower[dim] = near_lower;
+            upper[dim] = near_upper;
+            off[dim] = near_off;
+            rd = near_rd;
+        }
+
+        if let Some(frame) = stack.pop() {
+            stem_strat.rehydrate_deferred_state(frame.stem_state);
+            lower = frame.lower;
+            upper = frame.upper;
+            off = frame.off;
+            rd = frame.rd;
+            continue;
+        }
+
+        break;
+    }
+}
+
+fn periodic_nearest_results_inner<
+    Tree,
+    A,
+    T,
+    SS,
+    LS,
+    D,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    tree: &Tree,
+    query: &[A; K],
+    box_size: &[A; K],
+    max_dist: D::Output,
+    max_qty: usize,
+    sorted: bool,
+) -> Vec<QueryResultItem<(), T, D::Output>>
+where
+    Tree: KdTreeAccessor<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
+    A: PeriodicAxis + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    D: KdTreeDistanceMetric<A, K>,
+    D::Output: Axis<Coord = D::Output>,
+    R: ResultCollection<D::Output, QueryResultItem<(), T, D::Output>>,
+{
+    let mut req_ctx = PeriodicNearestResultsReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
+        query,
+        max_dist,
+        results: R::with_max_qty(max_qty),
+        _phantom: PhantomData,
+    };
+
+    periodic_backtracking_query::<Tree, A, T, SS, LS, _, _, D, _, K, B>(
+        tree,
+        &mut req_ctx,
+        box_size,
+        |leaf_idx, query_wide, box_size_wide, req_ctx| {
+            let leaf_max_dist = req_ctx.max_dist();
+            process_periodic_leaf::<Tree, A, T, SS, LS, D, R, EXCLUSIVE, K, B>(
+                tree,
+                leaf_idx,
+                query_wide,
+                box_size_wide,
+                leaf_max_dist,
+                &mut req_ctx.results,
+            );
+        },
+    );
+
+    if sorted {
+        req_ctx.results.into_sorted_vec()
+    } else {
+        req_ctx.results.into_vec()
+    }
+}
+
+pub(crate) fn periodic_nearest_results<
     Tree,
     A,
     T,
@@ -279,181 +757,85 @@ pub(crate) fn periodic_nearest_results_by_item<
     sorted: bool,
 ) -> Vec<QueryResultItem<(), T, D::Output>>
 where
+    Tree: KdTreeAccessor<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
     A: PeriodicAxis + 'static,
-    T: Content + Eq + Hash + PartialOrd,
+    T: Content + PartialOrd,
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
-    Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
     D: KdTreeDistanceMetric<A, K>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
-    SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
+    D::Output: Axis<Coord = D::Output>,
 {
     assert!(
         A::periodic_box_is_valid(box_size),
         "periodic box sizes must be strictly positive"
     );
+    assert!(
+        radius.is_some() || max_qty.is_some(),
+        "periodic plural queries require radius and/or max_qty"
+    );
 
-    if D::ORDERING != Ordering::Less {
-        let mut best_by_item = HashMap::<T, D::Output>::new();
+    let max_dist = radius.unwrap_or_else(D::Output::max_value);
+    let max_qty = max_qty.map_or(usize::MAX, NonZeroUsize::get);
 
-        with_wrapped_queries::<A, _, K>(query, box_size, |wrapped_query| {
-            let candidates = match (radius, max_qty) {
-                (None, Some(max_qty)) => tree.qb_nearest_n::<D>(wrapped_query, max_qty, true),
-                (Some(radius), Some(max_qty)) => {
-                    tree.qb_nearest_n_within::<D, EXCLUSIVE>(wrapped_query, radius, max_qty, sorted)
-                }
-                (Some(radius), None) if sorted => {
-                    tree.qb_within::<D, EXCLUSIVE>(wrapped_query, radius)
-                }
-                (Some(radius), None) => {
-                    tree.qb_within_unsorted::<D, EXCLUSIVE>(wrapped_query, radius)
-                }
-                (None, None) => {
-                    unreachable!("periodic plural queries require radius and/or max_qty")
-                }
-            };
-
-            for candidate in candidates {
-                best_by_item
-                    .entry(candidate.item)
-                    .and_modify(|best_distance| {
-                        if D::Output::cmp(candidate.distance, *best_distance) == Ordering::Less {
-                            *best_distance = candidate.distance;
-                        }
-                    })
-                    .or_insert(candidate.distance);
-            }
-        });
-
-        let mut results: Vec<_> = best_by_item
-            .into_iter()
-            .map(|(item, distance)| QueryResultItem {
-                point: (),
-                item,
-                distance,
-            })
-            .collect();
-
-        if sorted {
-            results.sort_unstable();
-        }
-        if let Some(max_qty) = max_qty {
-            results.truncate(max_qty.get());
-        }
-
-        return results;
+    if max_qty == usize::MAX {
+        return periodic_nearest_results_inner::<
+            Tree,
+            A,
+            T,
+            SS,
+            LS,
+            D,
+            Vec<QueryResultItem<(), T, D::Output>>,
+            EXCLUSIVE,
+            K,
+            B,
+        >(tree, query, box_size, max_dist, max_qty, sorted);
     }
-
-    let mut best_by_item = HashMap::<T, D::Output>::new();
-    let mut threshold = radius.map(|value| {
-        (
-            if EXCLUSIVE {
-                BoundaryMode::Exclusive
-            } else {
-                BoundaryMode::Inclusive
-            },
-            value,
-        )
-    });
-
-    let mut candidates = periodic_image_candidates::<D, A, K>(query, box_size, threshold, true);
-    sort_periodic_image_candidates(&mut candidates);
-
-    for candidate in candidates {
-        if threshold.is_some_and(|(boundary, limit)| {
-            !boundary_accepts(boundary, candidate.lower_bound, limit)
-        }) {
-            continue;
-        }
-
-        let candidates = match (radius, max_qty) {
-            (None, Some(max_qty)) => {
-                tree.qb_nearest_n::<D>(&candidate.wrapped_query, max_qty, true)
-            }
-            (Some(radius), Some(max_qty)) => tree.qb_nearest_n_within::<D, EXCLUSIVE>(
-                &candidate.wrapped_query,
-                radius,
-                max_qty,
-                sorted,
-            ),
-            (Some(radius), None) if sorted => {
-                tree.qb_within::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
-            }
-            (Some(radius), None) => {
-                tree.qb_within_unsorted::<D, EXCLUSIVE>(&candidate.wrapped_query, radius)
-            }
-            (None, None) => unreachable!("periodic plural queries require radius and/or max_qty"),
-        };
-
-        for periodic_candidate in candidates {
-            best_by_item
-                .entry(periodic_candidate.item)
-                .and_modify(|best_distance| {
-                    if D::Output::cmp(periodic_candidate.distance, *best_distance) == Ordering::Less
-                    {
-                        *best_distance = periodic_candidate.distance;
-                    }
-                })
-                .or_insert(periodic_candidate.distance);
-        }
-
-        if radius.is_none() {
-            if max_qty.is_some_and(|max_qty| best_by_item.len() >= max_qty.get()) {
-                if let Some(current_worst) = best_by_item
-                    .values()
-                    .copied()
-                    .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
-                {
-                    threshold = Some((BoundaryMode::Exclusive, current_worst));
-                }
-            }
-        } else if let Some(radius) = radius {
-            if max_qty.is_none_or(|max_qty| best_by_item.len() < max_qty.get()) {
-                continue;
-            }
-
-            if let Some(current_worst) = best_by_item
-                .values()
-                .copied()
-                .max_by(|lhs, rhs| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal))
-            {
-                let tightened = if D::Output::cmp(current_worst, radius) == Ordering::Less {
-                    current_worst
-                } else {
-                    radius
-                };
-                threshold = Some((
-                    if EXCLUSIVE {
-                        BoundaryMode::Exclusive
-                    } else {
-                        BoundaryMode::Inclusive
-                    },
-                    tightened,
-                ));
-            }
-        }
-    }
-
-    let mut results: Vec<_> = best_by_item
-        .into_iter()
-        .map(|(item, distance)| QueryResultItem {
-            point: (),
-            item,
-            distance,
-        })
-        .collect();
 
     if sorted {
-        results.sort_unstable();
-    }
-    if let Some(max_qty) = max_qty {
-        results.truncate(max_qty.get());
+        #[cfg(feature = "small_n_result_collectors")]
+        if max_qty <= SMALL_RESULT_COLLECTION_MAX_QTY {
+            return periodic_nearest_results_inner::<
+                Tree,
+                A,
+                T,
+                SS,
+                LS,
+                D,
+                SmallSortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+                K,
+                B,
+            >(tree, query, box_size, max_dist, max_qty, sorted);
+        }
+
+        #[cfg(not(feature = "small_n_result_collectors"))]
+        if max_qty <= MAX_VEC_RESULT_SIZE {
+            return periodic_nearest_results_inner::<
+                Tree,
+                A,
+                T,
+                SS,
+                LS,
+                D,
+                SortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+                K,
+                B,
+            >(tree, query, box_size, max_dist, max_qty, sorted);
+        }
     }
 
-    results
+    periodic_nearest_results_inner::<
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
+        EXCLUSIVE,
+        K,
+        B,
+    >(tree, query, box_size, max_dist, max_qty, sorted)
 }


### PR DESCRIPTION
Rather than iterating through images, a dedicated PBC engine does periodic-aware traversal/pruning