### PR TITLE
fix: `KdTree::default()` panics for immutable trees with VecOfArenas

### DIFF
--- a/src/kd_tree/mod.rs
+++ b/src/kd_tree/mod.rs
@@ -408,9 +408,14 @@ where
             (stems, -1, stem_leaf_resolution)
         };
 
+        let leaves = if LS::Mutability::is_mutable() {
+            LS::new_with_empty_leaf()
+        } else {
+            LS::new_with_capacity(0)
+        };
         let tree = Self {
             stems,
-            leaves: LS::new_with_empty_leaf(),
+            leaves,
             stem_leaf_resolution,
             size: 0,
             max_stem_level,
@@ -693,6 +698,7 @@ mod tests {
     use crate::stem_strategy::DonnellySimdFull;
     use crate::Eytzinger;
     use crate::SquaredEuclidean;
+    use crate::{ImmutableKdTree, MutableKdTree};
     #[cfg(feature = "rkyv_08")]
     use std::num::NonZeroUsize;
 
@@ -726,6 +732,20 @@ mod tests {
             points.into_iter().enumerate().collect();
 
         assert_eq!(kd_tree.size, 0);
+    }
+
+    #[test]
+    fn test_new_from_slice_empty() {
+        let tree: ImmutableKdTree<f64, 2> = ImmutableKdTree::new_from_slice(&[]).unwrap();
+        assert_eq!(tree.size(), 0);
+        assert!(tree.is_empty());
+    }
+
+    #[test]
+    fn test_default_mutable_tree_empty() {
+        let tree: MutableKdTree<f64, 2> = MutableKdTree::default();
+        assert_eq!(tree.size(), 0);
+        assert!(tree.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Thank you for your work on the great rewrite, Scott! Porting from v5 to v6 is rather easy with your wide documentation, also when using many references to KdTrees. I have noticed a small edge case that might interest you.

`KdTree::default()` unconditionally calls `LS::new_with_empty_leaf()` to initialise leaf storage. For immutable leaf strategies like `VecOfArenas`, this method is deliberately `unimplemented!()`, as it reads "`VecOfArenas` is immutable-focused and should be constructed from slices" only.

The immutable branch of `default()` already sets `stem_leaf_resolution` to `Arithmetic { leaf_count: 0 }`, correctly declaring that no leaves exist. Constructing an empty leaf container contradicts this and hits the unimplemented panic.

### Suggested fix
In the immutable branch, use `LS::new_with_capacity(0)` instead. This creates an empty leaf container consistent with the existing `leaf_count: 0` declaration. Mutable trees continue using `new_with_empty_leaf()` since they require a single mutable leaf from the start.

### MWE Reproduction
```rust
let tree: ImmutableKdTree<f64, 2> = ImmutableKdTree::new_from_slice(&[]).unwrap();
// panics: "VecOfArenas is immutable-focused and should be constructed from slices"
```

### How did I find this
While porting `infomeasure-rs` from kiddo v5 to `v6.0.0-alpha.1`, our empty-dataset edge case triggered this panic. The same bug would affect any `KdTree` using `VecOfArenas` constructed from an empty slice.

I also added two regression tests: one for `new_from_slice(&[])` on the default `ImmutableKdTree`, and one verifying `MutableKdTree::default()` continues to work.

I know this is quite an edge case, but in turn this means I did not find any heavier problem with the alpha, whcih is good 👍 I hope the branch targeted is the right one for this PR.