### PR TITLE
Configurable scratch location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "v6_scratch_strategies"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "profile_v6_nearest_one_eytzinger"
 path = "benches/profile_v6_nearest_one_eytzinger.rs"
 harness = false

--- a/benches/v6_scratch_strategies.rs
+++ b/benches/v6_scratch_strategies.rs
@@ -1,0 +1,130 @@
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, Criterion, Throughput,
+};
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::VecOfArrays;
+use kiddo::stem_strategy::Eytzinger;
+use kiddo::QueryScratch;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::num::NonZeroUsize;
+
+const K: usize = 3;
+const B: usize = 32;
+const POINT_COUNT: usize = 1_000_000;
+const QUERY_COUNT: usize = 10_000;
+const MAX_QTY: usize = 16;
+const POINT_SEED: u64 = 0x5eed_5c12_a7e9_1001;
+const QUERY_SEED: u64 = 0x5eed_5c12_a7e9_1002;
+
+type Tree = KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, K, B>, K, B>;
+
+fn build_points() -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..POINT_COUNT).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries() -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..QUERY_COUNT).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn run_tls_default(tree: &Tree, queries: &[[f64; K]], max_qty: NonZeroUsize) -> (usize, u64, f64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_item = 0u64;
+    let mut checksum_dist = 0.0f64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+            checksum_dist += result.distance;
+        }
+    }
+
+    (checksum_len, checksum_item, checksum_dist)
+}
+
+fn run_stack_scratch(
+    tree: &Tree,
+    queries: &[[f64; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, u64, f64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_item = 0u64;
+    let mut checksum_dist = 0.0f64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .with_stack_scratch()
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+            checksum_dist += result.distance;
+        }
+    }
+
+    (checksum_len, checksum_item, checksum_dist)
+}
+
+fn run_reused_scratch(
+    tree: &Tree,
+    queries: &[[f64; K]],
+    max_qty: NonZeroUsize,
+    scratch: &mut QueryScratch<Eytzinger, f64>,
+) -> (usize, u64, f64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_item = 0u64;
+    let mut checksum_dist = 0.0f64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .with_scratch(scratch)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+            checksum_dist += result.distance;
+        }
+    }
+
+    (checksum_len, checksum_item, checksum_dist)
+}
+
+fn scratch_strategies(c: &mut Criterion) {
+    let points = build_points();
+    let queries = build_queries();
+    let tree = Tree::new_from_slice(&points).unwrap();
+    let max_qty = NonZeroUsize::new(MAX_QTY).unwrap();
+
+    let mut group = c.benchmark_group("v6 scratch strategies");
+    group.throughput(Throughput::Elements(QUERY_COUNT as u64));
+
+    group.bench_function("nearest_n tls default", |b| {
+        b.iter(|| black_box(run_tls_default(&tree, &queries, max_qty)));
+    });
+
+    group.bench_function("nearest_n stack scratch", |b| {
+        b.iter(|| black_box(run_stack_scratch(&tree, &queries, max_qty)));
+    });
+
+    let mut scratch = tree.create_scratch::<SquaredEuclidean<f64>>();
+    group.bench_function("nearest_n reused scratch", |b| {
+        b.iter(|| black_box(run_reused_scratch(&tree, &queries, max_qty, &mut scratch)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, scratch_strategies);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ asm-m4:
 
 
 asm-k6-nearest-one-eytz:
-    cargo asm --features cargo_asm,logging_off --lib --target-cpu=native -C="opt-level=2" "kiddo::immutable::float::query::nearest_one::cargo_asm::v6_nearest_one_eytzinger_with_stack" > v6_nearest_one_eytzinger.asm
+    cargo asm --features cargo_asm,logging_off --lib --target-cpu=native -C="opt-level=2" "kiddo::immutable::float::query::nearest_one::cargo_asm::v6_nearest_one_eytzinger_with_scratch" > v6_nearest_one_eytzinger.asm
 
 asm-k6-nearest-one-eytz-v3:
     cargo asm --features cargo_asm,logging_off --lib --target-cpu=native -C="opt-level=2" "v6_nearest_one_eytzinger_cargo_asm_hook" > v6_nearest_one_eytzinger_v3.asm
@@ -401,7 +401,7 @@ asm-k6-nearest-one-voarena-v3-leaf-avx512-clean:
     RUSTC_WRAPPER= cargo asm --simplify --features simd,cargo_asm,logging_off --lib --target-cpu=native -C="opt-level=2" -C="target-cpu=native" "kiddo::leaf_view_chunked::nearest_one::avx512::leaf_nearest_one_arena_nozero_f64_k3::<f64, kiddo::dist::squared_euclidean::SquaredEuclidean<f64>, usize>" | python3 scripts/clean_cargo_asm.py > v6_nearest_one_arena_leaf_k3_avx512_clean.asm
 
 objdump-k6-nearest-one-eytz:
-    cargo objdump --release --lib --features cargo_asm,logging_off -- --disassemble-symbols="kiddo::immutable::float::query::nearest_one::cargo_asm::v6_nearest_one_eytzinger_with_stack" --demangle > v6_nearest_one_eytzinger.objdump
+    cargo objdump --release --lib --features cargo_asm,logging_off -- --disassemble-symbols="kiddo::immutable::float::query::nearest_one::cargo_asm::v6_nearest_one_eytzinger_with_scratch" --demangle > v6_nearest_one_eytzinger.objdump
 
 objdump-k5-nearest-one:
     cd ../kiddo-v5 && cargo objdump --release --lib -- --disassemble-symbols="kiddo::immutable::float::kdtree::cargo_asm::v5_nearest_one_immutable" --demangle > v5_immutable_nearest_one.objdump

--- a/src/kd_tree/mod.rs
+++ b/src/kd_tree/mod.rs
@@ -35,6 +35,7 @@ pub use orchestrator::KdTreeQueryOps;
 pub use query::QueryBuilder;
 #[doc(hidden)]
 pub use query::{Exclude, Include, Projection};
+pub use query_stack::QueryScratch;
 #[doc(hidden)]
 pub use stem_leaf_resolution::OwnedStemLeafResolution;
 

--- a/src/kd_tree/orchestrator/mod.rs
+++ b/src/kd_tree/orchestrator/mod.rs
@@ -251,13 +251,13 @@ where
 
         with_tls_query_stack::<SS::Stack<O>, _>(|stack| {
             stack.clear();
-            self.backtracking_query_with_stack::<QC, O, D>(query_ctx, stack, process_leaf);
+            self.backtracking_query_with_scratch::<QC, O, D>(query_ctx, stack, process_leaf);
         });
     }
 
     /// Backtracking query with explicit stack
     #[inline(always)]
-    fn backtracking_query_with_stack<QC, O, D>(
+    fn backtracking_query_with_scratch<QC, O, D>(
         &self,
         query_ctx: &mut QC,
         stack: &mut SS::Stack<O>,
@@ -273,11 +273,11 @@ where
         SS::Stack<O>: StackTrait<O, SS>,
     {
         if self.stem_leaf_resolution().uses_arithmetic() && SS::BLOCK_SIZE == 1 {
-            self.arithmetic_query_with_stack::<QC, O, D>(query_ctx, stack, process_leaf);
+            self.arithmetic_query_with_scratch::<QC, O, D>(query_ctx, stack, process_leaf);
             return;
         }
 
-        SS::backtracking_query_with_stack::<Self, A, T, O, D, QC, LS, K, B>(
+        SS::backtracking_query_with_scratch::<Self, A, T, O, D, QC, LS, K, B>(
             self,
             query_ctx,
             stack,
@@ -286,10 +286,10 @@ where
     }
 
     /// Implementation of backtracking query with scalar stack.
-    /// Called by default StemStrategy::backtracking_query_with_stack implementation.
+    /// Called by default StemStrategy::backtracking_query_with_scratch implementation.
     /// SIMD strategies override the trait method with custom implementations.
     #[inline(always)]
-    fn backtracking_query_with_stack_impl<QC, O, D>(
+    fn backtracking_query_with_scratch_impl<QC, O, D>(
         &self,
         query_ctx: &mut QC,
         stack: &mut SS::Stack<O>,
@@ -384,13 +384,13 @@ where
         SS::Stack<O>: StackTrait<O, SS> + Default + 'static,
     {
         with_tls_query_stack::<SS::Stack<O>, _>(|stack| {
-            self.arithmetic_query_with_stack::<QC, O, D>(query_ctx, stack, process_leaf);
+            self.arithmetic_query_with_scratch::<QC, O, D>(query_ctx, stack, process_leaf);
         });
     }
 
     /// Arithmetic-resolution backtracking query with explicit stack.
     #[inline(always)]
-    fn arithmetic_query_with_stack<QC, O, D>(
+    fn arithmetic_query_with_scratch<QC, O, D>(
         &self,
         query_ctx: &mut QC,
         stack: &mut SS::Stack<O>,
@@ -402,7 +402,7 @@ where
         SS::Stack<O>: StackTrait<O, SS>,
         SS::StackContext<O>: ScalarStackContext<O, SS::DeferredState>,
     {
-        SS::arithmetic_query_with_stack::<Self, A, T, O, D, QC, LS, K, B>(
+        SS::arithmetic_query_with_scratch::<Self, A, T, O, D, QC, LS, K, B>(
             self,
             query_ctx,
             stack,
@@ -411,9 +411,9 @@ where
     }
 
     /// Implementation of arithmetic-resolution query with scalar stack.
-    /// Called by default StemStrategy::arithmetic_query_with_stack implementation.
+    /// Called by default StemStrategy::arithmetic_query_with_scratch implementation.
     #[inline(always)]
-    fn arithmetic_query_with_stack_impl<QC, O, D>(
+    fn arithmetic_query_with_scratch_impl<QC, O, D>(
         &self,
         query_ctx: &mut QC,
         stack: &mut SS::Stack<O>,
@@ -643,7 +643,7 @@ where
     }
 
     /// Implementation of backtracking query with SIMD stack.
-    /// Called by DonnellySimdFull's backtracking_query_with_stack override.
+    /// Called by DonnellySimdFull's backtracking_query_with_scratch override.
     #[inline(always)]
     fn backtracking_query_with_block3_simd_stack_impl<QC, O, D>(
         &self,
@@ -1012,7 +1012,7 @@ where
     }
 
     /// Implementation of backtracking query with SIMD stack.
-    /// Called by DonnellySimdFull's backtracking_query_with_stack override.
+    /// Called by DonnellySimdFull's backtracking_query_with_scratch override.
     #[inline(always)]
     fn backtracking_query_with_simd_stack_impl<QC, O, D>(
         &self,

--- a/src/kd_tree/query/best_n_within.rs
+++ b/src/kd_tree/query/best_n_within.rs
@@ -122,6 +122,44 @@ where
         .into_inner()
     }
 
+    pub(crate) fn best_n_within_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZero<usize>,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let max_qty = max_qty.into();
+
+        #[cfg(feature = "small_n_result_collectors")]
+        if max_qty <= SMALL_RESULT_COLLECTION_MAX_QTY {
+            return self
+                .best_n_within_inner_with_scratch::<D, SmallBinaryHeapResultCollection<
+                    BestQueryResultItem<(), T, D::Output>,
+                >, EXCLUSIVE>(query, max_dist, max_qty, stack)
+                .into_inner();
+        }
+
+        self.best_n_within_inner_with_scratch::<
+            D,
+            BinaryHeapResultCollection<BestQueryResultItem<(), T, D::Output>>,
+            EXCLUSIVE,
+        >(
+            query, max_dist, max_qty, stack,
+        )
+        .into_inner()
+    }
+
     fn best_n_within_inner<D, R, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
@@ -153,6 +191,46 @@ where
                 &mut req_ctx.results,
             );
         });
+
+        req_ctx.results
+    }
+
+    fn best_n_within_inner_with_scratch<D, R, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: usize,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> R
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        R: BestNeighbourResultCollection<D::Output, T>,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let mut req_ctx = BestNWithinReqCtx::<A, D::Output, R, EXCLUSIVE, K> {
+            query,
+            max_dist,
+            results: R::with_max_qty(max_qty),
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, req_ctx| {
+                self.process_leaf_best_n_within::<D, _, EXCLUSIVE>(
+                    leaf_idx,
+                    query_wide,
+                    max_dist,
+                    &mut req_ctx.results,
+                );
+            },
+        );
 
         req_ctx.results
     }

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -1,88 +1,3 @@
-//! Fluent query builder APIs used by [`KdTree::query`](crate::kd_tree::KdTree::query)
-//! and the archived-tree `query` entry point when that feature is enabled.
-//!
-//! A query is assembled in stages: choose a query type, apply optional query
-//! modifiers, choose which fields should appear in each result, and then finish
-//! with a terminal method.
-//!
-//! # Query Type
-//!
-//! The first choice is the search family and distance metric:
-//!
-//! - `nearest_one::<D>()` finds the single nearest neighbour.
-//! - `nearest_n::<D>(n)` finds the `n` nearest neighbours.
-//! - `nearest_n::<D>(n).within(radius)` finds up to `n` neighbours, but only
-//!   among entries inside `radius`.
-//! - `within::<D>(radius)` returns every entry inside `radius`.
-//! - `best_n_within::<D>(radius, n)` returns up to `n` entries inside `radius`,
-//!   ranked by item ordering rather than by distance.
-//!
-//! The metric `D` is selected when the query type is chosen, so each fluent
-//! chain starts by deciding both "what kind of query is this?" and "which
-//! distance metric defines closeness?".
-//!
-//! # Query Options
-//!
-//! ## `approx`
-//!
-//! `approx()` is available only after `nearest_one::<D>()`. It switches the
-//! exact nearest-neighbour search to a descent-only approximate search.
-//!
-//! ## `exclusive_boundaries`
-//!
-//! Radius-bounded queries use inclusive `<= radius` semantics by default.
-//! `exclusive_boundaries()` changes those queries to strict `< radius`
-//! semantics. This applies to `within::<D>(radius)`,
-//! `nearest_n::<D>(n).within(radius)`, and `best_n_within::<D>(radius, n)`.
-//!
-//! ## `periodic_boundary_conditions`
-//!
-//! `periodic_boundary_condition(box_size)` must be chosen before the query
-//! type. It changes the space from Cartesian coordinates to periodic wrapping,
-//! using `box_size` as the period along each axis. Every entry in `box_size`
-//! must be strictly positive.
-//!
-//! Periodic queries support `nearest_one`, `nearest_n`, `nearest_n(...).within`,
-//! and `within`. `best_n_within` is Cartesian-only.
-//!
-//! # Result Content
-//!
-//! Result projection is independent from the query type. By default, builder
-//! results include the stored item and the computed distance, but not the point
-//! coordinates.
-//!
-//! - `with_points()` includes point coordinates.
-//! - `without_points()` removes point coordinates.
-//! - `with_items()` includes stored items.
-//! - `without_items()` removes stored items.
-//! - `with_distances()` includes distances.
-//! - `without_distances()` removes distances.
-//!
-//! These toggles rewrite the eventual result item type by replacing omitted
-//! fields with `()`. For example, removing items produces
-//! `QueryResultItem<_, (), _>`.
-//!
-//! `with_points()` is available only for Cartesian queries. Periodic queries do
-//! not expose a point projection toggle.
-//!
-//! # Result Type
-//!
-//! `execute()` eagerly runs the query and returns the query-specific container:
-//!
-//! - `nearest_one` and `nearest_one().approx()` return one `QueryResultItem`.
-//! - `nearest_n`, `nearest_n(...).within(...)`, and `within(...)` return
-//!   `Vec<QueryResultItem<...>>`.
-//! - `best_n_within(...)` returns
-//!   `BinaryHeap<BestQueryResultItem<...>>`.
-//!
-//! `iter()` and `visit()` are streaming terminal forms for Cartesian
-//! `within(...)` queries after `unsorted()` has been selected:
-//!
-//! - `iter()` returns a lazy iterator instead of materializing a `Vec`.
-//! - `visit()` calls a visitor closure for each matching result.
-//!
-//! `unsorted()` is also available for the other multi-result query families
-//! when traversal order is acceptable.
 #![allow(private_bounds)]
 
 use std::cmp::Ordering;
@@ -94,7 +9,9 @@ use crate::dist::{DistanceMetric, DistanceMetricCore};
 use crate::kd_tree::query_stack::StackTrait;
 #[cfg(feature = "rkyv_08")]
 use crate::kd_tree::ArchivedKdTree;
-use crate::kd_tree::{KdTree, KdTreeAccessor, KdTreeIter, KdTreeQueryOps, WithinUnsortedIter};
+use crate::kd_tree::{
+    KdTree, KdTreeAccessor, KdTreeIter, KdTreeQueryOps, QueryScratch, WithinUnsortedIter,
+};
 use crate::leaf_view::TlsLeafScratch;
 use crate::stem_strategy::donnelly::simd_full::{
     BacktrackBlock3, BacktrackBlock4, SimdSelectBestChildBlock3,
@@ -456,6 +373,138 @@ where
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static;
 }
 
+pub(crate) trait QueryBuilderScratchTreeOps<A, T, SS, LS, const K: usize, const B: usize>:
+    QueryBuilderTreeOps<A, T, SS, LS, K, B>
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+{
+    fn qb_nearest_one_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        stack: &mut SS::Stack<D::Output>,
+    ) -> (D::Output, T)
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>;
+
+    fn qb_nearest_n_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>;
+
+    fn qb_nearest_n_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>;
+
+    fn qb_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>;
+
+    fn qb_within_unsorted_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>;
+
+    fn qb_within_unsorted_visit_with_scratch<D, F, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        visitor: F,
+        stack: &mut SS::Stack<D::Output>,
+    ) where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+        F: FnMut(QueryResultItem<(), T, D::Output>);
+
+    fn qb_best_n_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        max_qty: NonZero<usize>,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>;
+}
+
 impl<A, T, SS, LS, const K: usize, const B: usize> QueryBuilderTreeOps<A, T, SS, LS, K, B>
     for KdTree<A, T, SS, LS, K, B>
 where
@@ -612,6 +661,170 @@ where
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
         self.best_n_within_impl::<D, EXCLUSIVE>(query, radius, max_qty)
+    }
+}
+
+impl<A, T, SS, LS, const K: usize, const B: usize> QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>
+    for KdTree<A, T, SS, LS, K, B>
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+{
+    #[inline]
+    fn qb_nearest_one_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        stack: &mut SS::Stack<D::Output>,
+    ) -> (D::Output, T)
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_one_with_scratch::<D>(query, stack)
+    }
+
+    #[inline]
+    fn qb_nearest_n_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_with_scratch::<D>(query, max_qty, sorted, stack)
+    }
+
+    #[inline]
+    fn qb_nearest_n_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+            query, radius, max_qty, sorted, stack,
+        )
+    }
+
+    #[inline]
+    fn qb_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+    }
+
+    #[inline]
+    fn qb_within_unsorted_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.within_unsorted_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+    }
+
+    #[inline]
+    fn qb_within_unsorted_visit_with_scratch<D, F, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        visitor: F,
+        stack: &mut SS::Stack<D::Output>,
+    ) where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+        F: FnMut(QueryResultItem<(), T, D::Output>),
+    {
+        self.within_unsorted_visit_impl_with_scratch::<D, F, EXCLUSIVE>(
+            query, radius, visitor, stack,
+        )
+    }
+
+    #[inline]
+    fn qb_best_n_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        max_qty: NonZero<usize>,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.best_n_within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, max_qty, stack)
     }
 }
 
@@ -777,6 +990,173 @@ where
     }
 }
 
+#[cfg(feature = "rkyv_08")]
+impl<A, T, SS, LS, const K: usize, const B: usize>
+    QueryBuilderScratchTreeOps<A, T, SS, rkyv_08::Archived<LS>, K, B>
+    for ArchivedKdTree<A, T, SS, LS, K, B>
+where
+    A: rkyv_08::Archive + Axis<Coord = A> + 'static,
+    T: Content + PartialOrd + PartialEq,
+    SS: StemStrategy,
+    LS: rkyv_08::Archive,
+    rkyv_08::Archived<LS>: LeafStrategy<A, T, SS, K, B>,
+{
+    #[inline]
+    fn qb_nearest_one_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        stack: &mut SS::Stack<D::Output>,
+    ) -> (D::Output, T)
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_one_with_scratch::<D>(query, stack)
+    }
+
+    #[inline]
+    fn qb_nearest_n_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_with_scratch::<D>(query, max_qty, sorted, stack)
+    }
+
+    #[inline]
+    fn qb_nearest_n_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+            query, radius, max_qty, sorted, stack,
+        )
+    }
+
+    #[inline]
+    fn qb_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+    }
+
+    #[inline]
+    fn qb_within_unsorted_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.within_unsorted_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+    }
+
+    #[inline]
+    fn qb_within_unsorted_visit_with_scratch<D, F, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        visitor: F,
+        stack: &mut SS::Stack<D::Output>,
+    ) where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+        F: FnMut(QueryResultItem<(), T, D::Output>),
+    {
+        self.within_unsorted_visit_impl_with_scratch::<D, F, EXCLUSIVE>(
+            query, radius, visitor, stack,
+        )
+    }
+
+    #[inline]
+    fn qb_best_n_within_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        radius: D::Output,
+        max_qty: NonZero<usize>,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        T: PartialOrd,
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.best_n_within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, max_qty, stack)
+    }
+}
+
 #[doc(hidden)]
 pub struct NoMetric;
 
@@ -807,6 +1187,13 @@ impl ResultFamily for NearestNState {}
 impl ResultFamily for NearestNWithinState {}
 impl ResultFamily for WithinState {}
 impl ResultFamily for BestNWithinState {}
+
+trait ConfigurableScratchQueryFamily {}
+impl ConfigurableScratchQueryFamily for NearestOneState {}
+impl ConfigurableScratchQueryFamily for NearestNState {}
+impl ConfigurableScratchQueryFamily for NearestNWithinState {}
+impl ConfigurableScratchQueryFamily for WithinState {}
+impl ConfigurableScratchQueryFamily for BestNWithinState {}
 
 trait BuilderMetric<A, const K: usize> {
     type Output: Copy;
@@ -855,7 +1242,9 @@ where
 ///
 /// [`approx`](Self::approx) is available only after
 /// [`nearest_one`](Self::nearest_one)`::<D>()`. It switches the exact
-/// nearest-neighbour search to a descent-only approximate search.
+/// nearest-neighbour search to a descent-only approximate nearest-neighbour (ANN)
+/// search. This is much faster, but the result may not be the truly nearest
+/// neighbour.
 ///
 /// ## `exclusive_boundaries`
 ///
@@ -878,6 +1267,35 @@ where
 /// [`nearest_n`](Self::nearest_n)`(...).`[`within`](Self::within)`(...)`, and
 /// [`within`](Self::within). [`best_n_within`](Self::best_n_within) is
 /// Cartesian-only.
+///
+/// # Scratch Strategy
+///
+/// Queries that involve backtracking need to store temporary state. The scratch
+/// strategy determines how this state is managed. Cartesian (ie not PBC),
+/// non-approximate queries that do not include point coordinates can
+/// choose how their traversal stack scratch is provided. All three options
+/// avoid a heap allocation on the query path (unless your tree is _extremely_
+/// deep - typically deeper than you could ever find in a balanced tree and only
+/// something that you might find in a _very_ unbalanced tree).
+///
+/// - By default, queries will use thread-local-storage scratch.
+///   This avoids allocating per query, but requires a TLS lookup, which may not
+///   be quite as fast as alternatives.
+/// - `with_stack_scratch()` stores scratch in the terminal call's stack frame,
+///   avoiding the TLS lookup. This avoids TLS lookup but increases the size of the
+///   query's stack frame.
+/// - `with_scratch(&mut scratch)` uses caller-owned reusable scratch created by
+///   `KdTree::create_scratch()` or the archived-tree method of the same name.
+///   This is particularly suited to batches of compatible queries but can can
+///   make sense anywhere you'll have the opportunity to re-use the same scratch
+///   for more than one query.
+///
+/// These scratch configuration methods are experimental during the 6.0.0 alpha;
+/// not every option is guaranteed to remain in the final 6.0.0 API.
+///
+/// Scratch strategy selection is not available for `with_points()` or `iter()`.
+/// Those paths currently maintain traversal state in a more complex state
+/// machine rather than the stack-scratch query orchestrator.
 ///
 /// # Result Content
 ///
@@ -1064,6 +1482,213 @@ pub trait ExecuteQueryBuilder {
     fn execute(self) -> Self::Output;
 }
 
+#[doc(hidden)]
+pub trait ExecuteQueryBuilderWithScratch<SS, O>
+where
+    SS: StemStrategy,
+{
+    #[doc(hidden)]
+    type Output;
+
+    #[doc(hidden)]
+    fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, O>) -> Self::Output;
+}
+
+/// Query builder adapter that uses per-call stack scratch instead of TLS.
+pub struct StackScratchQueryBuilder<B, SS, O>
+where
+    SS: StemStrategy,
+{
+    builder: B,
+    _phantom: PhantomData<(SS, O)>,
+}
+
+/// Query builder adapter that uses caller-owned reusable query scratch.
+pub struct ScratchQueryBuilder<'s, B, SS, O>
+where
+    SS: StemStrategy,
+{
+    builder: B,
+    scratch: &'s mut QueryScratch<SS, O>,
+}
+
+impl<B, SS, O> StackScratchQueryBuilder<B, SS, O>
+where
+    SS: StemStrategy,
+    B: ExecuteQueryBuilderWithScratch<SS, O>,
+{
+    /// Executes the configured query with scratch stored in this call's stack frame.
+    #[inline]
+    pub fn execute(self) -> <B as ExecuteQueryBuilderWithScratch<SS, O>>::Output {
+        let mut scratch = QueryScratch::<SS, O>::new();
+        self.builder.execute_with_scratch(&mut scratch)
+    }
+}
+
+impl<B, SS, O> ScratchQueryBuilder<'_, B, SS, O>
+where
+    SS: StemStrategy,
+    B: ExecuteQueryBuilderWithScratch<SS, O>,
+{
+    /// Executes the configured query with caller-owned reusable scratch storage.
+    #[inline]
+    pub fn execute(self) -> <B as ExecuteQueryBuilderWithScratch<SS, O>>::Output {
+        self.builder.execute_with_scratch(self.scratch)
+    }
+}
+
+impl<'a, Tree, A, T, SS, LS, D, I, Dp, const EXCLUSIVE: bool, const K: usize, const B: usize>
+    StackScratchQueryBuilder<
+        QueryBuilder<
+            'a,
+            Tree,
+            A,
+            T,
+            SS,
+            LS,
+            SelectedMetric<D>,
+            WithinState,
+            CartesianSpace,
+            Projection<Exclude, I, Dp>,
+            false,
+            EXCLUSIVE,
+            K,
+            B,
+        >,
+        SS,
+        D::Output,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B> + 'a,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B> + 'a,
+    D: DistanceMetric<A> + 'a,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T> + 'a,
+    Dp: ProjectionField<D::Output> + 'a,
+{
+    /// Visits matching entries using per-call stack scratch instead of TLS.
+    #[inline]
+    pub fn visit<F>(self, mut visitor: F)
+    where
+        F: FnMut(QueryResultItem<(), I::Output, Dp::Output>),
+    {
+        let mut scratch = QueryScratch::<SS, D::Output>::new();
+        let builder = self.builder;
+        with_cleared_scratch(&mut scratch, |stack| {
+            builder
+                .tree
+                .qb_within_unsorted_visit_with_scratch::<D, _, EXCLUSIVE>(
+                    builder.query,
+                    builder.radius,
+                    move |result| {
+                        visitor(project_nearest_without_point::<
+                            A,
+                            T,
+                            D::Output,
+                            Exclude,
+                            I,
+                            Dp,
+                            K,
+                        >(result))
+                    },
+                    stack,
+                );
+        });
+    }
+}
+
+impl<
+        's,
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        I,
+        Dp,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    >
+    ScratchQueryBuilder<
+        's,
+        QueryBuilder<
+            'a,
+            Tree,
+            A,
+            T,
+            SS,
+            LS,
+            SelectedMetric<D>,
+            WithinState,
+            CartesianSpace,
+            Projection<Exclude, I, Dp>,
+            false,
+            EXCLUSIVE,
+            K,
+            B,
+        >,
+        SS,
+        D::Output,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B> + 'a,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B> + 'a,
+    D: DistanceMetric<A> + 'a,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T> + 'a,
+    Dp: ProjectionField<D::Output> + 'a,
+{
+    /// Visits matching entries using caller-owned reusable scratch storage.
+    #[inline]
+    pub fn visit<F>(self, mut visitor: F)
+    where
+        F: FnMut(QueryResultItem<(), I::Output, Dp::Output>),
+    {
+        let builder = self.builder;
+        with_cleared_scratch(self.scratch, |stack| {
+            builder
+                .tree
+                .qb_within_unsorted_visit_with_scratch::<D, _, EXCLUSIVE>(
+                    builder.query,
+                    builder.radius,
+                    move |result| {
+                        visitor(project_nearest_without_point::<
+                            A,
+                            T,
+                            D::Output,
+                            Exclude,
+                            I,
+                            Dp,
+                            K,
+                        >(result))
+                    },
+                    stack,
+                );
+        });
+    }
+}
+
 impl<
         'a,
         Tree,
@@ -1088,6 +1713,94 @@ where
     #[inline]
     pub fn execute(self) -> <Self as ExecuteQueryBuilder>::Output {
         <Self as ExecuteQueryBuilder>::execute(self)
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        Family,
+        I,
+        Dp,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    >
+    QueryBuilder<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        SelectedMetric<D>,
+        Family,
+        CartesianSpace,
+        Projection<Exclude, I, Dp>,
+        SORTED,
+        EXCLUSIVE,
+        K,
+        B,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
+    D: DistanceMetric<A>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T>,
+    Dp: ProjectionField<D::Output>,
+    Family: ConfigurableScratchQueryFamily,
+{
+    /// Uses per-call stack scratch instead of the default thread-local scratch.
+    ///
+    /// This avoids the TLS lookup while keeping scratch lifetime scoped to the
+    /// terminal query call. The inline stack does not allocate unless traversal
+    /// depth exceeds its inline capacity.
+    ///
+    /// This alpha API is experimental; see the
+    /// [`QueryBuilder` scratch strategy section](QueryBuilder#scratch-strategy)
+    /// for the available strategies and current limitations.
+    #[inline]
+    pub fn with_stack_scratch(self) -> StackScratchQueryBuilder<Self, SS, D::Output> {
+        StackScratchQueryBuilder {
+            builder: self,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Uses caller-owned reusable scratch instead of the default thread-local scratch.
+    ///
+    /// Scratch must have been created for the same stem strategy and distance
+    /// output type, for example with [`KdTree::create_scratch`] or the
+    /// archived-tree method of the same name.
+    ///
+    /// This alpha API is experimental; see the
+    /// [`QueryBuilder` scratch strategy section](QueryBuilder#scratch-strategy)
+    /// for the available strategies and current limitations.
+    #[inline]
+    pub fn with_scratch<'s>(
+        self,
+        scratch: &'s mut QueryScratch<SS, D::Output>,
+    ) -> ScratchQueryBuilder<'s, Self, SS, D::Output> {
+        ScratchQueryBuilder {
+            builder: self,
+            scratch,
+        }
     }
 }
 
@@ -1296,6 +2009,15 @@ where
     /// Includes stored point coordinates in the eventual query results.
     ///
     /// This is available only for non-periodic queries.
+    ///
+    /// Scratch strategy selectors such as
+    /// [`with_stack_scratch`](Self::with_stack_scratch) and
+    /// [`with_scratch`](Self::with_scratch) are not currently available after
+    /// `with_points()`. Point-projected queries use a separate traversal and
+    /// collection path that maintains more complex state than the stack-scratch
+    /// query orchestrator. See the
+    /// [`QueryBuilder` scratch strategy section](QueryBuilder#scratch-strategy)
+    /// for more detail.
     #[inline]
     pub fn with_points(self) -> <Self as WithPointsQueryBuilder>::Output
     where
@@ -1458,6 +2180,18 @@ pub(crate) fn boundary_accepts<O: Axis<Coord = O>>(
         BoundaryMode::Inclusive => O::cmp(distance, radius) != Ordering::Greater,
         BoundaryMode::Exclusive => O::cmp(distance, radius) == Ordering::Less,
     }
+}
+
+#[inline(always)]
+fn with_cleared_scratch<SS, O, R>(
+    scratch: &mut QueryScratch<SS, O>,
+    f: impl FnOnce(&mut SS::Stack<O>) -> R,
+) -> R
+where
+    SS: StemStrategy,
+{
+    scratch.clear();
+    f(scratch.stack_mut())
 }
 
 #[inline(always)]
@@ -1632,6 +2366,56 @@ where
             _phantom: PhantomData,
         }
     }
+
+    /// Creates reusable scratch storage for scratch-aware query builder paths.
+    ///
+    /// Pass the returned value to [`QueryBuilder::with_scratch`] to avoid the
+    /// default thread-local stack lookup and reuse any spill allocation across
+    /// repeated compatible queries.
+    ///
+    /// Scratch strategy selection is experimental during the 6.0.0 alpha; see
+    /// the [`QueryBuilder` scratch strategy section](QueryBuilder#scratch-strategy).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kiddo::dist::SquaredEuclidean;
+    /// use kiddo::leaf_strategy::FlatVec;
+    /// use kiddo::{Eytzinger, KdTree};
+    /// use std::num::NonZeroUsize;
+    ///
+    /// type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+    ///
+    /// let entries = [
+    ///     (10_u32, [0.0, 0.0]),
+    ///     (11_u32, [1.0, 1.0]),
+    ///     (12_u32, [0.2, 0.1]),
+    /// ];
+    /// let tree = Tree::new_from_entries(&entries).unwrap();
+    /// let mut scratch = tree.create_scratch::<SquaredEuclidean<f64>>();
+    /// let max_qty = NonZeroUsize::new(2).unwrap();
+    /// let queries = [[0.1, 0.1], [0.9, 0.9], [0.25, 0.15]];
+    /// let mut nearest_items = Vec::new();
+    ///
+    /// for query in queries {
+    ///     let results = tree
+    ///         .query(&query)
+    ///         .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+    ///         .with_scratch(&mut scratch)
+    ///         .execute();
+    ///
+    ///     nearest_items.push(results[0].item);
+    /// }
+    ///
+    /// assert_eq!(nearest_items, vec![12, 11, 12]);
+    /// ```
+    #[inline]
+    pub fn create_scratch<D>(&self) -> QueryScratch<SS, D::Output>
+    where
+        D: DistanceMetric<A>,
+    {
+        QueryScratch::new()
+    }
 }
 
 #[cfg(feature = "rkyv_08")]
@@ -1660,6 +2444,22 @@ where
             radius: (),
             _phantom: PhantomData,
         }
+    }
+
+    /// Creates reusable scratch storage for scratch-aware query builder paths.
+    ///
+    /// Pass the returned value to [`QueryBuilder::with_scratch`] to avoid the
+    /// default thread-local stack lookup and reuse any spill allocation across
+    /// repeated compatible queries.
+    ///
+    /// Scratch strategy selection is experimental during the 6.0.0 alpha; see
+    /// the [`QueryBuilder` scratch strategy section](QueryBuilder#scratch-strategy).
+    #[inline]
+    pub fn create_scratch<D>(&self) -> QueryScratch<SS, D::Output>
+    where
+        D: DistanceMetric<A>,
+    {
+        QueryScratch::new()
     }
 }
 
@@ -2887,6 +3687,342 @@ where
 impl<
         'a,
         Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        I,
+        Dp,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > ExecuteQueryBuilderWithScratch<SS, D::Output>
+    for QueryBuilder<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        SelectedMetric<D>,
+        NearestOneState,
+        CartesianSpace,
+        Projection<Exclude, I, Dp>,
+        SORTED,
+        EXCLUSIVE,
+        K,
+        B,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
+    D: DistanceMetric<A>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T>,
+    Dp: ProjectionField<D::Output>,
+{
+    type Output = QueryResultItem<(), I::Output, Dp::Output>;
+
+    #[inline]
+    fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, D::Output>) -> Self::Output {
+        let (distance, item) = with_cleared_scratch(scratch, |stack| {
+            self.tree
+                .qb_nearest_one_with_scratch::<D>(self.query, stack)
+        });
+        project_nearest_without_point_from_parts::<A, T, D::Output, Exclude, I, Dp, K>(
+            item, distance,
+        )
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        I,
+        Dp,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > ExecuteQueryBuilderWithScratch<SS, D::Output>
+    for QueryBuilder<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        SelectedMetric<D>,
+        NearestNState,
+        CartesianSpace,
+        Projection<Exclude, I, Dp>,
+        SORTED,
+        EXCLUSIVE,
+        K,
+        B,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
+    D: DistanceMetric<A>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T>,
+    Dp: ProjectionField<D::Output>,
+{
+    type Output = Vec<QueryResultItem<(), I::Output, Dp::Output>>;
+
+    #[inline]
+    fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, D::Output>) -> Self::Output {
+        with_cleared_scratch(scratch, |stack| {
+            self.tree
+                .qb_nearest_n_with_scratch::<D>(
+                    self.query,
+                    self.max_qty.expect("max_qty missing"),
+                    SORTED,
+                    stack,
+                )
+                .into_iter()
+                .map(project_nearest_without_point::<A, T, D::Output, Exclude, I, Dp, K>)
+                .collect()
+        })
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        I,
+        Dp,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > ExecuteQueryBuilderWithScratch<SS, D::Output>
+    for QueryBuilder<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        SelectedMetric<D>,
+        NearestNWithinState,
+        CartesianSpace,
+        Projection<Exclude, I, Dp>,
+        SORTED,
+        EXCLUSIVE,
+        K,
+        B,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
+    D: DistanceMetric<A>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T>,
+    Dp: ProjectionField<D::Output>,
+{
+    type Output = Vec<QueryResultItem<(), I::Output, Dp::Output>>;
+
+    #[inline]
+    fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, D::Output>) -> Self::Output {
+        with_cleared_scratch(scratch, |stack| {
+            self.tree
+                .qb_nearest_n_within_with_scratch::<D, EXCLUSIVE>(
+                    self.query,
+                    self.radius,
+                    self.max_qty.expect("max_qty missing"),
+                    SORTED,
+                    stack,
+                )
+                .into_iter()
+                .map(project_nearest_without_point::<A, T, D::Output, Exclude, I, Dp, K>)
+                .collect()
+        })
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        I,
+        Dp,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > ExecuteQueryBuilderWithScratch<SS, D::Output>
+    for QueryBuilder<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        SelectedMetric<D>,
+        WithinState,
+        CartesianSpace,
+        Projection<Exclude, I, Dp>,
+        SORTED,
+        EXCLUSIVE,
+        K,
+        B,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
+    D: DistanceMetric<A>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T>,
+    Dp: ProjectionField<D::Output>,
+{
+    type Output = Vec<QueryResultItem<(), I::Output, Dp::Output>>;
+
+    #[inline]
+    fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, D::Output>) -> Self::Output {
+        with_cleared_scratch(scratch, |stack| {
+            let results = if SORTED {
+                self.tree
+                    .qb_within_with_scratch::<D, EXCLUSIVE>(self.query, self.radius, stack)
+            } else {
+                self.tree.qb_within_unsorted_with_scratch::<D, EXCLUSIVE>(
+                    self.query,
+                    self.radius,
+                    stack,
+                )
+            };
+            results
+                .into_iter()
+                .map(project_nearest_without_point::<A, T, D::Output, Exclude, I, Dp, K>)
+                .collect()
+        })
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        I,
+        Dp,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > ExecuteQueryBuilderWithScratch<SS, D::Output>
+    for QueryBuilder<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        SelectedMetric<D>,
+        BestNWithinState,
+        CartesianSpace,
+        Projection<Exclude, I, Dp>,
+        SORTED,
+        EXCLUSIVE,
+        K,
+        B,
+    >
+where
+    A: Axis<Coord = A> + 'static,
+    T: Content + PartialOrd,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+    Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
+    D: DistanceMetric<A>,
+    D::Output: crate::stem_strategy::SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static,
+    SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    I: ProjectionField<T>,
+    Dp: ProjectionField<D::Output>,
+    BestQueryResultItem<(), I::Output, Dp::Output>: Ord,
+{
+    type Output = BinaryHeap<BestQueryResultItem<(), I::Output, Dp::Output>>;
+
+    #[inline]
+    fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, D::Output>) -> Self::Output {
+        with_cleared_scratch(scratch, |stack| {
+            self.tree
+                .qb_best_n_within_with_scratch::<D, EXCLUSIVE>(
+                    self.query,
+                    self.radius,
+                    self.max_qty.expect("max_qty missing"),
+                    stack,
+                )
+                .into_iter()
+                .map(project_best_without_point::<A, T, D::Output, Exclude, I, Dp, K>)
+                .collect()
+        })
+    }
+}
+
+impl<
+        'a,
+        Tree,
         A: Copy,
         T,
         SS,
@@ -4087,6 +5223,12 @@ where
     }
 
     /// Returns an iterator over matching entries without first materializing a result vector.
+    ///
+    /// Scratch strategy selectors are not applicable to this iterator path. The
+    /// iterator owns a traversal state machine rather than borrowing one of the
+    /// query builder scratch strategies. See the
+    /// [`QueryBuilder` scratch strategy section](QueryBuilder#scratch-strategy)
+    /// for more detail.
     #[allow(clippy::type_complexity)]
     #[inline]
     pub fn iter(
@@ -4360,9 +5502,9 @@ mod tests {
     #[cfg(feature = "rkyv_08")]
     use crate::kd_tree::ArchivedKdTree;
     use crate::kd_tree::KdTree;
-    use crate::leaf_strategy::FlatVec;
     #[cfg(feature = "rkyv_08")]
     use crate::leaf_strategy::VecOfArenas;
+    use crate::leaf_strategy::{FlatVec, VecOfArrays};
     use crate::stem_strategy::Eytzinger;
     use std::num::NonZeroUsize;
 
@@ -4467,6 +5609,282 @@ mod tests {
         results.sort_unstable();
 
         assert_eq!(results, vec![7, 7]);
+    }
+
+    #[test]
+    fn scratch_query_execution_matches_tls_for_cartesian_queries() {
+        let entries = [
+            (10u32, [0.0, 0.0]),
+            (11u32, [0.2, 0.1]),
+            (12u32, [0.4, 0.4]),
+            (13u32, [0.8, 0.2]),
+            (14u32, [0.9, 0.9]),
+            (15u32, [0.3, 0.7]),
+        ];
+        let tree = WrapTree::new_from_entries(&entries).unwrap();
+        let query = [0.25, 0.2];
+        let max_qty = NonZeroUsize::new(3).unwrap();
+        let radius = 0.25;
+        let mut scratch = tree.create_scratch::<SquaredEuclidean<f64>>();
+
+        assert_eq!(
+            tree.query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .execute(),
+            tree.query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_stack_scratch()
+                .execute()
+        );
+        assert_eq!(
+            tree.query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .execute(),
+            tree.query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_scratch(&mut scratch)
+                .execute()
+        );
+
+        assert_eq!(
+            tree.query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .execute(),
+            tree.query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .with_stack_scratch()
+                .execute()
+        );
+        assert_eq!(
+            tree.query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .unsorted()
+                .execute(),
+            tree.query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .unsorted()
+                .with_scratch(&mut scratch)
+                .execute()
+        );
+
+        assert_eq!(
+            tree.query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .within(radius)
+                .execute(),
+            tree.query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .within(radius)
+                .with_stack_scratch()
+                .execute()
+        );
+        assert_eq!(
+            tree.query(&query)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .unsorted()
+                .execute(),
+            tree.query(&query)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .unsorted()
+                .with_scratch(&mut scratch)
+                .execute()
+        );
+
+        let tls_best = tree
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+            .execute()
+            .into_sorted_vec();
+        let stack_best = tree
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+            .with_stack_scratch()
+            .execute()
+            .into_sorted_vec();
+        assert_eq!(tls_best, stack_best);
+
+        let mut tls_visit = Vec::new();
+        tree.query(&query)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .unsorted()
+            .visit(|result| tls_visit.push(result));
+        let mut stack_visit = Vec::new();
+        tree.query(&query)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .unsorted()
+            .with_stack_scratch()
+            .visit(|result| stack_visit.push(result));
+        let mut scratch_visit = Vec::new();
+        tree.query(&query)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .unsorted()
+            .with_scratch(&mut scratch)
+            .visit(|result| scratch_visit.push(result));
+        assert_eq!(tls_visit, stack_visit);
+        assert_eq!(tls_visit, scratch_visit);
+    }
+
+    #[test]
+    fn scratch_can_be_reused_across_mutable_mapped_tree_queries() {
+        type MutableTree = KdTree<f32, u32, Eytzinger, VecOfArrays<f32, u32, 2, 4>, 2, 4>;
+
+        let mut tree = MutableTree::default();
+        for idx in 0..32 {
+            let point = [
+                ((idx * 7) % 23) as f32 / 23.0,
+                ((idx * 11 + 3) % 29) as f32 / 29.0,
+            ];
+            tree.add(&point, idx as u32).unwrap();
+        }
+
+        let mut scratch = tree.create_scratch::<SquaredEuclidean<f32>>();
+        for query in [[0.1, 0.2], [0.45, 0.55], [0.8, 0.25]] {
+            let max_qty = NonZeroUsize::new(5).unwrap();
+            let tls = tree
+                .query(&query)
+                .nearest_n::<SquaredEuclidean<f32>>(max_qty)
+                .within(0.4)
+                .execute();
+            let reused = tree
+                .query(&query)
+                .nearest_n::<SquaredEuclidean<f32>>(max_qty)
+                .within(0.4)
+                .with_scratch(&mut scratch)
+                .execute();
+            assert_eq!(tls, reused);
+        }
+    }
+
+    #[test]
+    fn scratch_queries_handle_empty_trees() {
+        let entries: [(u32, [f64; 2]); 0] = [];
+        let tree = WrapTree::new_from_entries(&entries).unwrap();
+        let query = [0.25, 0.2];
+        let mut scratch = tree.create_scratch::<SquaredEuclidean<f64>>();
+
+        assert_eq!(
+            tree.query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .execute(),
+            tree.query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_scratch(&mut scratch)
+                .execute()
+        );
+        assert_eq!(
+            tree.query(&query)
+                .within::<SquaredEuclidean<f64>>(0.25)
+                .with_stack_scratch()
+                .execute(),
+            Vec::new()
+        );
+    }
+
+    #[cfg(feature = "rkyv_08")]
+    #[test]
+    fn archived_scratch_query_execution_matches_tls_for_cartesian_queries() {
+        type Tree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 32>, 2, 32>;
+        type ArchivedTree =
+            ArchivedKdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 32>, 2, 32>;
+
+        let entries = vec![
+            (10u32, [0.0, 0.0]),
+            (11u32, [0.2, 0.1]),
+            (12u32, [0.4, 0.4]),
+            (13u32, [0.8, 0.2]),
+            (14u32, [0.9, 0.9]),
+            (15u32, [0.3, 0.7]),
+        ];
+        let tree = Tree::new_from_entries(&entries).unwrap();
+        let query = [0.25, 0.2];
+        let max_qty = NonZeroUsize::new(3).unwrap();
+        let radius = 0.25;
+
+        let bytes = rkyv_08::api::high::to_bytes_in::<_, rkyv_08::rancor::Error>(
+            &tree,
+            rkyv_08::util::AlignedVec::<128>::new(),
+        )
+        .unwrap();
+        let archived =
+            rkyv_08::access::<ArchivedTree, rkyv_08::rancor::Error>(bytes.as_slice()).unwrap();
+        let mut scratch = archived.create_scratch::<SquaredEuclidean<f64>>();
+
+        assert_eq!(
+            archived
+                .query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .execute(),
+            archived
+                .query(&query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_stack_scratch()
+                .execute()
+        );
+        assert_eq!(
+            archived
+                .query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .execute(),
+            archived
+                .query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .with_scratch(&mut scratch)
+                .execute()
+        );
+        assert_eq!(
+            archived
+                .query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .within(radius)
+                .execute(),
+            archived
+                .query(&query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .within(radius)
+                .with_stack_scratch()
+                .execute()
+        );
+        assert_eq!(
+            archived
+                .query(&query)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .unsorted()
+                .execute(),
+            archived
+                .query(&query)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .unsorted()
+                .with_scratch(&mut scratch)
+                .execute()
+        );
+
+        let tls_best = archived
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+            .execute()
+            .into_sorted_vec();
+        let stack_best = archived
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+            .with_stack_scratch()
+            .execute()
+            .into_sorted_vec();
+        assert_eq!(tls_best, stack_best);
+
+        let mut tls_visit = Vec::new();
+        archived
+            .query(&query)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .unsorted()
+            .visit(|result| tls_visit.push(result));
+        let mut scratch_visit = Vec::new();
+        archived
+            .query(&query)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .unsorted()
+            .with_scratch(&mut scratch)
+            .visit(|result| scratch_visit.push(result));
+        assert_eq!(tls_visit, scratch_visit);
     }
 
     #[cfg(feature = "rkyv_08")]

--- a/src/kd_tree/query/nearest_n.rs
+++ b/src/kd_tree/query/nearest_n.rs
@@ -36,6 +36,32 @@ where
     {
         self.nearest_n_within::<D>(query, D::Output::max_value(), max_qty, sorted)
     }
+
+    pub(crate) fn nearest_n_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_qty: NonZero<usize>,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_with_scratch::<D>(
+            query,
+            D::Output::max_value(),
+            max_qty,
+            sorted,
+            stack,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -101,6 +101,27 @@ where
         self.nearest_n_within_impl::<D, false>(query, max_dist, max_qty, sorted)
     }
 
+    pub(crate) fn nearest_n_within_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, false>(query, max_dist, max_qty, sorted, stack)
+    }
+
     pub(crate) fn nearest_n_within_impl<D, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
@@ -157,6 +178,65 @@ where
         }
     }
 
+    pub(crate) fn nearest_n_within_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let max_qty: usize = max_qty.get();
+
+        if max_qty == usize::MAX {
+            self.nearest_n_within_inner_with_scratch::<
+                D,
+                Vec<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+            >(query, max_dist, max_qty, sorted, stack)
+        } else if sorted {
+            #[cfg(feature = "small_n_result_collectors")]
+            if max_qty <= SMALL_RESULT_COLLECTION_MAX_QTY {
+                return self.nearest_n_within_inner_with_scratch::<
+                    D,
+                    SmallSortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                    EXCLUSIVE,
+                >(query, max_dist, max_qty, sorted, stack);
+            }
+
+            #[cfg(not(feature = "small_n_result_collectors"))]
+            if max_qty <= MAX_VEC_RESULT_SIZE {
+                return self.nearest_n_within_inner_with_scratch::<
+                    D,
+                    SortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                    EXCLUSIVE,
+                >(query, max_dist, max_qty, sorted, stack);
+            }
+
+            self.nearest_n_within_inner_with_scratch::<
+                D,
+                BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+            >(query, max_dist, max_qty, sorted, stack)
+        } else {
+            self.nearest_n_within_inner_with_scratch::<
+                D,
+                BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+            >(query, max_dist, max_qty, sorted, stack)
+        }
+    }
+
     fn nearest_n_within_inner<D, R, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
@@ -191,6 +271,53 @@ where
                 &mut req_ctx.results,
             );
         });
+
+        if sorted {
+            req_ctx.results.into_sorted_vec()
+        } else {
+            req_ctx.results.into_vec()
+        }
+    }
+
+    fn nearest_n_within_inner_with_scratch<D, R, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: usize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        R: ResultCollection<D::Output, QueryResultItem<(), T, D::Output>>,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let mut req_ctx = NearestNWithinReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
+            query,
+            max_dist,
+            results: R::with_max_qty(max_qty),
+            _phantom: std::marker::PhantomData,
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, req_ctx| {
+                let leaf_max_dist = req_ctx.max_dist();
+                self.process_leaf_nearest_n_within::<D, R, EXCLUSIVE>(
+                    leaf_idx,
+                    query_wide,
+                    leaf_max_dist,
+                    &mut req_ctx.results,
+                );
+            },
+        );
 
         if sorted {
             req_ctx.results.into_sorted_vec()

--- a/src/kd_tree/query/nearest_one.rs
+++ b/src/kd_tree/query/nearest_one.rs
@@ -143,7 +143,7 @@ where
     }
 
     #[inline(always)]
-    fn nearest_one_arithmetic_with_stack<D>(
+    fn nearest_one_arithmetic_with_scratch<D>(
         &self,
         query: &[A; K],
         stack: &mut SS::Stack<D::Output>,
@@ -164,7 +164,7 @@ where
             best_item: T::default(),
         };
 
-        self.arithmetic_query_with_stack::<_, _, D>(
+        self.arithmetic_query_with_scratch::<_, _, D>(
             &mut req_ctx,
             stack,
             |leaf_idx, query_wide, query_ctx| {
@@ -182,7 +182,7 @@ where
 
     #[cfg_attr(not(feature = "cargo_asm"), allow(dead_code))]
     #[inline(always)]
-    pub(crate) fn nearest_one_with_stack<D>(
+    pub(crate) fn nearest_one_with_scratch<D>(
         &self,
         query: &[A; K],
         stack: &mut SS::Stack<D::Output>,
@@ -198,14 +198,14 @@ where
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
         if self.stem_leaf_resolution.uses_arithmetic() {
-            return self.nearest_one_arithmetic_with_stack::<D>(query, stack);
+            return self.nearest_one_arithmetic_with_scratch::<D>(query, stack);
         }
 
-        self.nearest_one_mapped_with_stack::<D>(query, stack)
+        self.nearest_one_mapped_with_scratch::<D>(query, stack)
     }
 
     #[inline(always)]
-    fn nearest_one_mapped_with_stack<D>(
+    fn nearest_one_mapped_with_scratch<D>(
         &self,
         query: &[A; K],
         stack: &mut SS::Stack<D::Output>,
@@ -226,7 +226,7 @@ where
             best_item: T::default(),
         };
 
-        self.backtracking_query_with_stack::<_, _, D>(
+        self.backtracking_query_with_scratch::<_, _, D>(
             &mut req_ctx,
             stack,
             |leaf_idx, query_wide, query_ctx| {
@@ -270,7 +270,7 @@ pub mod cargo_asm {
         query: [f64; 3],
         stack: &mut QueryStack<f64, Eytzinger>,
     ) -> (f64, usize) {
-        tree.nearest_one_with_stack::<SquaredEuclidean<f64>>(&query, stack)
+        tree.nearest_one_with_scratch::<SquaredEuclidean<f64>>(&query, stack)
     }
 
     /// Hook for cargo-asm to render the arithmetic Eytzinger core directly.
@@ -281,7 +281,7 @@ pub mod cargo_asm {
         query: [f64; 3],
         stack: &mut QueryStack<f64, Eytzinger>,
     ) -> (f64, usize) {
-        tree.nearest_one_arithmetic_with_stack::<SquaredEuclidean<f64>>(&query, stack)
+        tree.nearest_one_arithmetic_with_scratch::<SquaredEuclidean<f64>>(&query, stack)
     }
 
     /// Hook for cargo-asm to render the exact nearest-one path for scalar Eytzinger PF-far arena leaves.
@@ -292,7 +292,7 @@ pub mod cargo_asm {
         query: [f64; 3],
         stack: &mut QueryStack<f64, Eytzinger>,
     ) -> (f64, usize) {
-        tree.nearest_one_with_stack::<SquaredEuclidean<f64>>(&query, stack)
+        tree.nearest_one_with_scratch::<SquaredEuclidean<f64>>(&query, stack)
     }
 
     /// Hook for cargo-asm to render the exact nearest-one path for scalar Donnelly.
@@ -303,7 +303,7 @@ pub mod cargo_asm {
         query: [f64; 3],
         stack: &mut QueryStack<f64, Donnelly<3>>,
     ) -> (f64, usize) {
-        tree.nearest_one_with_stack::<SquaredEuclidean<f64>>(&query, stack)
+        tree.nearest_one_with_scratch::<SquaredEuclidean<f64>>(&query, stack)
     }
 
     /// Hook for cargo-asm to render the exact nearest-one path for Block3 Donnelly SIMD.
@@ -314,7 +314,7 @@ pub mod cargo_asm {
         query: [f64; 3],
         stack: &mut <DonnellySimdFull<3> as crate::StemStrategy>::Stack<f64>,
     ) -> (f64, usize) {
-        tree.nearest_one_with_stack::<SquaredEuclidean<f64>>(&query, stack)
+        tree.nearest_one_with_scratch::<SquaredEuclidean<f64>>(&query, stack)
     }
 }
 
@@ -452,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn nearest_one_arithmetic_with_stack_matches_expected_result() {
+    fn nearest_one_arithmetic_with_scratch_matches_expected_result() {
         let points = vec![
             [0.0f64, 0.0, 0.0],
             [1.0, 1.0, 1.0],
@@ -464,7 +464,7 @@ mod tests {
             KdTree::new_from_slice(&points).unwrap();
         let mut stack = QueryStack::<f64, Eytzinger>::default();
 
-        let result = tree.nearest_one_arithmetic_with_stack::<SquaredEuclidean<f64>>(
+        let result = tree.nearest_one_arithmetic_with_scratch::<SquaredEuclidean<f64>>(
             &[0.45, 0.55, 0.65],
             &mut stack,
         );
@@ -475,7 +475,7 @@ mod tests {
     }
 
     #[test]
-    fn nearest_one_with_stack_uses_arithmetic_route_when_available() {
+    fn nearest_one_with_scratch_uses_arithmetic_route_when_available() {
         let points = vec![
             [0.0f64, 0.0, 0.0],
             [1.0, 1.0, 1.0],
@@ -488,7 +488,7 @@ mod tests {
         let mut stack = QueryStack::<f64, Eytzinger>::default();
 
         let result =
-            tree.nearest_one_with_stack::<SquaredEuclidean<f64>>(&[0.45, 0.55, 0.65], &mut stack);
+            tree.nearest_one_with_scratch::<SquaredEuclidean<f64>>(&[0.45, 0.55, 0.65], &mut stack);
 
         assert_float_relative_eq!(result.0, 0.0075, REL_EPS_F64);
         assert_eq!(result.1, 2);
@@ -496,7 +496,7 @@ mod tests {
     }
 
     #[test]
-    fn nearest_one_mapped_with_stack_matches_expected_result() {
+    fn nearest_one_mapped_with_scratch_matches_expected_result() {
         let points = [
             [0.0f32, 0.0],
             [1.0, 1.0],
@@ -513,7 +513,7 @@ mod tests {
 
         let mut stack = QueryStack::<f32, Eytzinger>::default();
         let result =
-            tree.nearest_one_mapped_with_stack::<SquaredEuclidean<f32>>(&[0.5, 0.5], &mut stack);
+            tree.nearest_one_mapped_with_scratch::<SquaredEuclidean<f32>>(&[0.5, 0.5], &mut stack);
 
         assert_float_relative_eq!(result.0, 0.0125, REL_EPS_F32);
         assert_eq!(result.1, 2);
@@ -521,7 +521,7 @@ mod tests {
     }
 
     #[test]
-    fn nearest_one_with_stack_uses_mapped_route_when_arithmetic_is_unavailable() {
+    fn nearest_one_with_scratch_uses_mapped_route_when_arithmetic_is_unavailable() {
         let points = [
             [0.0f32, 0.0],
             [1.0, 1.0],
@@ -537,7 +537,8 @@ mod tests {
         }
 
         let mut stack = QueryStack::<f32, Eytzinger>::default();
-        let result = tree.nearest_one_with_stack::<SquaredEuclidean<f32>>(&[0.5, 0.5], &mut stack);
+        let result =
+            tree.nearest_one_with_scratch::<SquaredEuclidean<f32>>(&[0.5, 0.5], &mut stack);
 
         assert_float_relative_eq!(result.0, 0.0125, REL_EPS_F32);
         assert_eq!(result.1, 2);

--- a/src/kd_tree/query/within.rs
+++ b/src/kd_tree/query/within.rs
@@ -32,6 +32,31 @@ where
     {
         self.nearest_n_within_impl::<D, EXCLUSIVE>(query, max_dist, NonZeroUsize::MAX, true)
     }
+
+    pub(crate) fn within_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+            query,
+            max_dist,
+            NonZeroUsize::MAX,
+            true,
+            stack,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/kd_tree/query/within_unsorted.rs
+++ b/src/kd_tree/query/within_unsorted.rs
@@ -92,6 +92,44 @@ where
     }
 
     #[inline]
+    pub(crate) fn within_unsorted_visit_impl_with_scratch<D, F, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        mut visitor: F,
+        stack: &mut SS::Stack<D::Output>,
+    ) where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+        F: FnMut(QueryResultItem<(), T, D::Output>),
+    {
+        let mut req_ctx = WithinUnsortedVisitReqCtx::<A, D::Output, EXCLUSIVE, K> {
+            query,
+            max_dist,
+            _phantom: std::marker::PhantomData,
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, req_ctx| {
+                self.process_leaf_within_unsorted_visit::<D, F, EXCLUSIVE>(
+                    leaf_idx,
+                    query_wide,
+                    req_ctx.max_dist(),
+                    &mut visitor,
+                );
+            },
+        );
+    }
+
+    #[inline]
     pub(crate) fn within_unsorted_impl<D, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
@@ -108,6 +146,32 @@ where
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
         self.nearest_n_within_impl::<D, EXCLUSIVE>(query, max_dist, NonZeroUsize::MAX, false)
+    }
+
+    #[inline]
+    pub(crate) fn within_unsorted_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+            query,
+            max_dist,
+            NonZeroUsize::MAX,
+            false,
+            stack,
+        )
     }
 
     /// Returns a streaming iterator over all points within a given distance, unsorted.

--- a/src/kd_tree/query_stack.rs
+++ b/src/kd_tree/query_stack.rs
@@ -29,6 +29,42 @@ pub trait StackTrait<A, SS: StemStrategy> {
     fn clear(&mut self);
 }
 
+/// Reusable traversal scratch storage for query builder scratch APIs.
+///
+/// The concrete stack representation is selected by the stem strategy and is
+/// intentionally hidden so it can keep changing during the v6 alpha cycle.
+#[derive(Debug)]
+pub struct QueryScratch<SS: StemStrategy, O> {
+    stack: SS::Stack<O>,
+}
+
+impl<SS: StemStrategy, O> Default for QueryScratch<SS, O> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<SS: StemStrategy, O> QueryScratch<SS, O> {
+    /// Creates empty query traversal scratch storage.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            stack: SS::Stack::<O>::default(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.stack.clear();
+    }
+
+    #[inline]
+    pub(crate) fn stack_mut(&mut self) -> &mut SS::Stack<O> {
+        &mut self.stack
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct ScalarContinuationFar<A, S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ mod custom_serde;
 pub mod kd_tree;
 #[doc(hidden)]
 pub type KdTree<A, T, SS, LS, const K: usize, const B: usize> = kd_tree::KdTree<A, T, SS, LS, K, B>;
+pub use kd_tree::QueryScratch;
 
 /// Distance metrics
 pub mod dist;

--- a/src/rkyv/query.rs
+++ b/src/rkyv/query.rs
@@ -109,6 +109,45 @@ where
 
         (req_ctx.best_dist, req_ctx.best_item)
     }
+
+    /// Finds the nearest point to the query point using caller-provided stack scratch.
+    #[inline(always)]
+    pub(crate) fn nearest_one_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        stack: &mut SS::Stack<D::Output>,
+    ) -> (D::Output, T)
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let mut req_ctx = ArchivedNearestOneReqCtx {
+            query,
+            best_dist: D::Output::max_value(),
+            best_item: T::default(),
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, query_ctx| {
+                self.process_leaf_nearest_one::<D>(
+                    leaf_idx,
+                    query_wide,
+                    &mut query_ctx.best_dist,
+                    &mut query_ctx.best_item,
+                );
+            },
+        );
+
+        (req_ctx.best_dist, req_ctx.best_item)
+    }
 }
 
 impl<A, T, SS, LS, const K: usize, const B: usize> ArchivedKdTree<A, T, SS, LS, K, B>
@@ -267,6 +306,53 @@ where
         self.nearest_n_within::<D>(query, D::Output::max_value(), max_qty, sorted)
     }
 
+    pub(crate) fn nearest_n_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_with_scratch::<D>(
+            query,
+            D::Output::max_value(),
+            max_qty,
+            sorted,
+            stack,
+        )
+    }
+
+    pub(crate) fn nearest_n_within_with_scratch<D>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, false>(query, max_dist, max_qty, sorted, stack)
+    }
+
     pub(crate) fn within_impl<D, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
@@ -283,6 +369,31 @@ where
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
         self.nearest_n_within_impl::<D, EXCLUSIVE>(query, max_dist, NonZeroUsize::MAX, true)
+    }
+
+    pub(crate) fn within_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+            query,
+            max_dist,
+            NonZeroUsize::MAX,
+            true,
+            stack,
+        )
     }
 
     pub(crate) fn within_unsorted_visit_impl<D, F, const EXCLUSIVE: bool>(
@@ -338,6 +449,151 @@ where
             results.push(result)
         });
         results
+    }
+
+    pub(crate) fn within_unsorted_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let mut results = Vec::new();
+        self.within_unsorted_visit_impl_with_scratch::<D, _, EXCLUSIVE>(
+            query,
+            max_dist,
+            |result| results.push(result),
+            stack,
+        );
+        results
+    }
+
+    pub(crate) fn nearest_n_within_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let max_qty = max_qty.get();
+        if max_qty == usize::MAX {
+            self.nearest_n_within_inner_with_scratch::<
+                D,
+                Vec<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+            >(query, max_dist, max_qty, sorted, stack)
+        } else {
+            self.nearest_n_within_inner_with_scratch::<
+                D,
+                BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
+                EXCLUSIVE,
+            >(query, max_dist, max_qty, sorted, stack)
+        }
+    }
+
+    fn nearest_n_within_inner_with_scratch<D, R, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: usize,
+        sorted: bool,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> Vec<QueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        R: ResultCollection<D::Output, QueryResultItem<(), T, D::Output>>,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let mut req_ctx = ArchivedNearestNWithinReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
+            query,
+            max_dist,
+            results: R::with_max_qty(max_qty),
+            _phantom: std::marker::PhantomData,
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, req_ctx| {
+                let leaf_max_dist = req_ctx.max_dist();
+                self.process_leaf_nearest_n_within::<D, R, EXCLUSIVE>(
+                    leaf_idx,
+                    query_wide,
+                    leaf_max_dist,
+                    &mut req_ctx.results,
+                );
+            },
+        );
+
+        if sorted {
+            req_ctx.results.into_sorted_vec()
+        } else {
+            req_ctx.results.into_vec()
+        }
+    }
+
+    pub(crate) fn within_unsorted_visit_impl_with_scratch<D, F, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        mut visitor: F,
+        stack: &mut SS::Stack<D::Output>,
+    ) where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+        F: FnMut(QueryResultItem<(), T, D::Output>),
+    {
+        let mut req_ctx = ArchivedWithinUnsortedVisitReqCtx::<A, D::Output, EXCLUSIVE, K> {
+            query,
+            max_dist,
+            _phantom: std::marker::PhantomData,
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, req_ctx| {
+                let mut results = VisitorResultCollection::new(&mut visitor);
+                self.process_leaf_nearest_n_within::<D, _, EXCLUSIVE>(
+                    leaf_idx,
+                    query_wide,
+                    req_ctx.max_dist(),
+                    &mut results,
+                );
+            },
+        );
     }
 
     /// Returns a streaming iterator over all points within a given distance, unsorted.
@@ -444,6 +700,48 @@ where
                 &mut req_ctx.results,
             );
         });
+
+        req_ctx.results.into_inner()
+    }
+
+    pub(crate) fn best_n_within_impl_with_scratch<D, const EXCLUSIVE: bool>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+        stack: &mut SS::Stack<D::Output>,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output>: StackTrait<D::Output, SS>,
+    {
+        let mut req_ctx = ArchivedBestNWithinReqCtx::<A, D::Output, _, EXCLUSIVE, K> {
+            query,
+            max_dist,
+            results:
+                BinaryHeapResultCollection::<BestQueryResultItem<(), T, D::Output>>::with_max_qty(
+                    max_qty.get(),
+                ),
+        };
+
+        self.backtracking_query_with_scratch::<_, _, D>(
+            &mut req_ctx,
+            stack,
+            |leaf_idx, query_wide, req_ctx| {
+                self.process_leaf_best_n_within::<D, _, EXCLUSIVE>(
+                    leaf_idx,
+                    query_wide,
+                    max_dist,
+                    &mut req_ctx.results,
+                );
+            },
+        );
 
         req_ctx.results.into_inner()
     }

--- a/src/stem_strategy/donnelly/simd_full/mod.rs
+++ b/src/stem_strategy/donnelly/simd_full/mod.rs
@@ -953,7 +953,7 @@ impl StemStrategy for DonnellySimdFull<3> {
         true
     }
 
-    fn backtracking_query_with_stack<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
+    fn backtracking_query_with_scratch<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
         tree: &Tree,
         query_ctx: &mut QC,
         stack: &mut Self::Stack<O>,
@@ -1406,7 +1406,7 @@ impl crate::StemStrategy for DonnellySimdFull<4> {
         true
     }
 
-    fn backtracking_query_with_stack<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
+    fn backtracking_query_with_scratch<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
         tree: &Tree,
         query_ctx: &mut QC,
         stack: &mut Self::Stack<O>,

--- a/src/traits/stem_strategy.rs
+++ b/src/traits/stem_strategy.rs
@@ -370,13 +370,13 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
 
     /// Execute backtracking query with explicit stack.
     ///
-    /// Default implementation delegates to KdTree's backtracking_query_with_stack_impl.
+    /// Default implementation delegates to KdTree's backtracking_query_with_scratch_impl.
     /// Block-based SIMD strategies can override to use SIMD stack with block pruning.
     ///
     /// This method exists to allow strategies to customize backtracking behavior at compile time.
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
-    fn backtracking_query_with_stack<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
+    fn backtracking_query_with_scratch<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
         tree: &Tree,
         query_ctx: &mut QC,
         stack: &mut Self::Stack<O>,
@@ -397,7 +397,7 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
         LS: crate::LeafStrategy<A, T, Self, K2, B>,
         Self::Stack<O>: StackTrait<O, Self>,
     {
-        tree.backtracking_query_with_stack_impl::<QC, O, D>(query_ctx, stack, process_leaf);
+        tree.backtracking_query_with_scratch_impl::<QC, O, D>(query_ctx, stack, process_leaf);
     }
 
     /// Execute arithmetic-resolution backtracking query with explicit stack.
@@ -406,7 +406,7 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
     /// Strategies may override this to provide a more specialized arithmetic walk.
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
-    fn arithmetic_query_with_stack<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
+    fn arithmetic_query_with_scratch<Tree, A, T, O, D, QC, LS, const K2: usize, const B: usize>(
         tree: &Tree,
         query_ctx: &mut QC,
         stack: &mut Self::Stack<O>,
@@ -423,7 +423,7 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
         LS: crate::LeafStrategy<A, T, Self, K2, B>,
         Self::Stack<O>: StackTrait<O, Self>,
     {
-        tree.arithmetic_query_with_stack_impl::<QC, O, D>(query_ctx, stack, process_leaf);
+        tree.arithmetic_query_with_scratch_impl::<QC, O, D>(query_ctx, stack, process_leaf);
     }
 }
 


### PR DESCRIPTION
The first alpha used thread-local storage for storing a query's traversal stack for use when backtracking. The associated TLS lookup was highlighted in https://github.com/sdd/kiddo/issues/394 as being a cause of sub-optimal performance.

Previously, it was possible for some `nearest_one` queries to avoid TLS scratch space, but this PR generalises that capability to most use cases, and does so more ergonomically via the query builder.

Calling `.with_stack_scratch()` on the builder will use scratch space allocated in the query's stack frame.

A second alternative is to use `tree.create_scratch()` to create a stack-allocated scratch space that can be re-used across multiple queries (as long as they are for the same tree type and same distance metric), by passing a mutable reference to the created scratch to the builder's `.with_scratch()` method.