### PR TITLE
perf: replace `SortedVecResultCollection` with O(1) Vec collector

### DIFF
--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -9,7 +9,7 @@ use crate::leaf_view_chunked::nearest_n_within::{
     nearest_n_within_with_query_wide, nearest_n_within_with_query_wide_arena,
 };
 #[cfg(not(feature = "small_n_result_collectors"))]
-use crate::results::result_collection::SortedVecResultCollection;
+use crate::results::result_collection::ThresholdVecResultCollection;
 use crate::results::result_collection::{BinaryHeapResultCollection, ResultCollection};
 #[cfg(feature = "small_n_result_collectors")]
 use crate::results::result_collection::{
@@ -159,7 +159,7 @@ where
             if max_qty <= MAX_VEC_RESULT_SIZE {
                 return self.nearest_n_within_inner::<
                     D,
-                    SortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
                 >(query, max_dist, max_qty, sorted);
             }

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -159,7 +159,7 @@ where
             if max_qty <= MAX_VEC_RESULT_SIZE {
                 return self.nearest_n_within_inner::<
                     D,
-                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>, D::Output>,
                     EXCLUSIVE,
                 >(query, max_dist, max_qty, sorted);
             }

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -159,7 +159,7 @@ where
             if max_qty <= MAX_VEC_RESULT_SIZE {
                 return self.nearest_n_within_inner::<
                     D,
-                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>, D::Output>,
+                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
                 >(query, max_dist, max_qty, sorted);
             }
@@ -218,7 +218,7 @@ where
             if max_qty <= MAX_VEC_RESULT_SIZE {
                 return self.nearest_n_within_inner_with_scratch::<
                     D,
-                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>, D::Output>,
+                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
                 >(query, max_dist, max_qty, sorted, stack);
             }

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -145,7 +145,7 @@ where
             self.nearest_n_within_inner::<D, Vec<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
                 query, max_dist, max_qty, sorted,
             )
-        } else if sorted {
+        } else {
             #[cfg(feature = "small_n_result_collectors")]
             if max_qty <= SMALL_RESULT_COLLECTION_MAX_QTY {
                 return self.nearest_n_within_inner::<
@@ -164,17 +164,9 @@ where
                 >(query, max_dist, max_qty, sorted);
             }
 
-            self.nearest_n_within_inner::<
-                D,
-                BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
-                EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted)
-        } else {
-            self.nearest_n_within_inner::<
-                D,
-                BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
-                EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted)
+            self.nearest_n_within_inner::<D, BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
+                query, max_dist, max_qty, sorted,
+            )
         }
     }
 
@@ -204,7 +196,7 @@ where
                 Vec<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
             >(query, max_dist, max_qty, sorted, stack)
-        } else if sorted {
+        } else {
             #[cfg(feature = "small_n_result_collectors")]
             if max_qty <= SMALL_RESULT_COLLECTION_MAX_QTY {
                 return self.nearest_n_within_inner_with_scratch::<
@@ -223,12 +215,6 @@ where
                 >(query, max_dist, max_qty, sorted, stack);
             }
 
-            self.nearest_n_within_inner_with_scratch::<
-                D,
-                BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
-                EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted, stack)
-        } else {
             self.nearest_n_within_inner_with_scratch::<
                 D,
                 BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -218,7 +218,7 @@ where
             if max_qty <= MAX_VEC_RESULT_SIZE {
                 return self.nearest_n_within_inner_with_scratch::<
                     D,
-                    SortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                    ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>, D::Output>,
                     EXCLUSIVE,
                 >(query, max_dist, max_qty, sorted, stack);
             }

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -511,6 +511,15 @@ mod tests {
             .within(radius)
             .execute();
         assert_eq!(results.len(), 10);
+
+        // Exercise BinaryHeapResultCollection fallback (k > MAX_VEC_RESULT_SIZE)
+        let max_qty_large = NonZeroUsize::new(21).unwrap();
+        let results_large = tree
+            .query(&query_point)
+            .nearest_n::<SquaredEuclidean<f32>>(max_qty_large)
+            .within(radius)
+            .execute();
+        assert_eq!(results_large.len(), 21);
     }
 
     #[test]

--- a/src/kd_tree/query/periodic.rs
+++ b/src/kd_tree/query/periodic.rs
@@ -818,7 +818,7 @@ where
                 SS,
                 LS,
                 D,
-                ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>, D::Output>,
                 EXCLUSIVE,
                 K,
                 B,

--- a/src/kd_tree/query/periodic.rs
+++ b/src/kd_tree/query/periodic.rs
@@ -8,7 +8,7 @@ use crate::kd_tree::query_context::QueryContext;
 use crate::kd_tree::{KdTreeAccessor, KdTreeQueryOps, StemLeafResolution};
 use crate::leaf_view::LeafView;
 #[cfg(not(feature = "small_n_result_collectors"))]
-use crate::results::result_collection::SortedVecResultCollection;
+use crate::results::result_collection::ThresholdVecResultCollection;
 use crate::results::result_collection::{BinaryHeapResultCollection, ResultCollection};
 #[cfg(feature = "small_n_result_collectors")]
 use crate::results::result_collection::{
@@ -818,7 +818,7 @@ where
                 SS,
                 LS,
                 D,
-                SortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
+                ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
                 K,
                 B,

--- a/src/kd_tree/query/periodic.rs
+++ b/src/kd_tree/query/periodic.rs
@@ -818,7 +818,7 @@ where
                 SS,
                 LS,
                 D,
-                ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>, D::Output>,
+                ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
                 K,
                 B,

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -127,34 +127,20 @@ where
 
 /// Vec-based result collection for small-k nearest_n queries.
 ///
-/// Inserts candidates via plain `Vec::push` (O(1)) and tracks the current
-/// k-th best distance via a full scan (O(k)) only when the collection is
-/// full. At extraction time `into_sorted_vec` does a
-/// `select_nth_unstable` + sort on at most k elements (k <= 20).
+/// Inserts candidates via plain `Vec::push` (O(1)) and tracks the threshold
+/// as the max distance of the first k accepted candidates. Once the
+/// initial k slots are filled, the threshold is frozen and only candidates
+/// closer than it are accepted. At extraction time `into_vec` does a
+/// `select_nth_unstable` + truncate on the oversized vec.
 ///
-/// Compared to `SortedVecResultCollection` (binary-search + memmove insert
-/// at O(k)), this is strictly cheaper for small k. The extra extraction
-/// cost (sorting k elements in O(k log k)) is negligible.
+/// This design relies on the tree visiting leaves in proximity order,
+/// so the first k candidates are representative of the true k nearest.
 #[cfg(not(feature = "small_n_result_collectors"))]
 #[derive(Debug)]
 pub(crate) struct ThresholdVecResultCollection<E, O> {
     max_qty: usize,
     inner: Vec<E>,
-    threshold: Option<O>,
-}
-
-#[cfg(not(feature = "small_n_result_collectors"))]
-impl<O: PartialOrd + Copy, T> ThresholdVecResultCollection<QueryResultItem<(), T, O>, O> {
-    #[inline]
-    fn farthest_idx(&self) -> usize {
-        let mut farthest = 0;
-        for i in 1..self.inner.len() {
-            if self.inner[i].distance > self.inner[farthest].distance {
-                farthest = i;
-            }
-        }
-        farthest
-    }
+    threshold: O,
 }
 
 #[cfg(not(feature = "small_n_result_collectors"))]
@@ -164,8 +150,8 @@ impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
     fn with_max_qty(max_qty: usize) -> Self {
         Self {
             max_qty,
-            inner: Vec::with_capacity(max_qty),
-            threshold: None,
+            inner: Vec::with_capacity(max_qty * 2),
+            threshold: O::min_value(),
         }
     }
 
@@ -178,36 +164,40 @@ impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
     }
 
     fn add(&mut self, entry: QueryResultItem<(), T, O>) {
-        match self.threshold {
-            None => {
-                if self.inner.len() < self.max_qty {
-                    self.inner.push(entry);
-                    if self.inner.len() == self.max_qty {
-                        self.threshold = Some(self.inner[self.farthest_idx()].distance);
-                    }
-                }
+        if self.inner.len() < self.max_qty {
+            if entry.distance > self.threshold {
+                self.threshold = entry.distance;
             }
-            Some(farthest_dist) if entry.distance < farthest_dist => {
-                let farthest = self.farthest_idx();
-                self.inner[farthest] = entry;
-                self.threshold = Some(self.inner[self.farthest_idx()].distance);
-            }
-            _ => {}
+            self.inner.push(entry);
+        } else if entry.distance < self.threshold {
+            self.inner.push(entry);
         }
     }
 
     fn threshold_distance(&self) -> Option<O> {
-        self.threshold
+        if self.inner.len() < self.max_qty {
+            None
+        } else {
+            Some(self.threshold)
+        }
     }
 
-    fn into_vec(self) -> Vec<QueryResultItem<(), T, O>> {
+    fn into_vec(mut self) -> Vec<QueryResultItem<(), T, O>> {
+        if self.inner.len() > self.max_qty {
+            self.inner.select_nth_unstable_by(self.max_qty - 1, |a, b| {
+                a.distance
+                    .partial_cmp(&b.distance)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            self.inner.truncate(self.max_qty);
+        }
         self.inner
     }
 
-    fn into_sorted_vec(mut self) -> Vec<QueryResultItem<(), T, O>> {
-        self.inner
-            .sort_unstable_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
-        self.inner
+    fn into_sorted_vec(self) -> Vec<QueryResultItem<(), T, O>> {
+        let mut result = self.into_vec();
+        result.sort_unstable_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+        result
     }
 }
 
@@ -1373,7 +1363,7 @@ mod tests {
     }
 
     #[test]
-    fn threshold_vec_evicts_farthest() {
+    fn threshold_vec_select_nth_unstable() {
         let mut results =
             ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(3);
         for entry in INPUTS.iter().take(3) {

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -125,6 +125,85 @@ where
     }
 }
 
+/// Vec-based result collection for small-k nearest_n queries.
+///
+/// Inserts candidates via plain `Vec::push` (O(1)) and tracks the current
+/// k-th best distance via a full scan (O(k)) only when the collection is
+/// full. At extraction time `into_sorted_vec` does a
+/// `select_nth_unstable` + sort on at most k elements (k <= 20).
+///
+/// Compared to `SortedVecResultCollection` (binary-search + memmove insert
+/// at O(k)), this is strictly cheaper for small k. The extra extraction
+/// cost (sorting k elements in O(k log k)) is negligible.
+#[cfg(not(feature = "small_n_result_collectors"))]
+#[derive(Debug)]
+pub(crate) struct ThresholdVecResultCollection<E> {
+    max_qty: usize,
+    inner: Vec<E>,
+}
+
+#[cfg(not(feature = "small_n_result_collectors"))]
+impl<O: PartialOrd, T> ThresholdVecResultCollection<QueryResultItem<(), T, O>> {
+    #[inline]
+    fn farthest_idx(&self) -> usize {
+        let mut farthest = 0;
+        for i in 1..self.inner.len() {
+            if self.inner[i].distance > self.inner[farthest].distance {
+                farthest = i;
+            }
+        }
+        farthest
+    }
+}
+
+#[cfg(not(feature = "small_n_result_collectors"))]
+impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
+    for ThresholdVecResultCollection<QueryResultItem<(), T, O>>
+{
+    fn with_max_qty(max_qty: usize) -> Self {
+        Self {
+            max_qty,
+            inner: Vec::with_capacity(max_qty),
+        }
+    }
+
+    fn max_qty(&self) -> usize {
+        self.max_qty
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn add(&mut self, entry: QueryResultItem<(), T, O>) {
+        if self.inner.len() < self.max_qty {
+            self.inner.push(entry);
+        } else {
+            let farthest = self.farthest_idx();
+            if entry.distance < self.inner[farthest].distance {
+                self.inner[farthest] = entry;
+            }
+        }
+    }
+
+    fn threshold_distance(&self) -> Option<O> {
+        if self.inner.len() < self.max_qty {
+            return None;
+        }
+        Some(self.inner[self.farthest_idx()].distance)
+    }
+
+    fn into_vec(self) -> Vec<QueryResultItem<(), T, O>> {
+        self.inner
+    }
+
+    fn into_sorted_vec(mut self) -> Vec<QueryResultItem<(), T, O>> {
+        self.inner
+            .sort_unstable_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
+        self.inner
+    }
+}
+
 #[doc(hidden)]
 pub trait BestNeighbourResultCollection<O: Axis<Coord = O>, T: Content + PartialOrd>:
     ResultCollection<O, BestQueryResultItem<(), T, O>>
@@ -140,6 +219,7 @@ pub(crate) struct BinaryHeapResultCollection<E> {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "small_n_result_collectors", allow(dead_code))]
+#[allow(dead_code)]
 pub(crate) struct SortedVecResultCollection<E: Ord> {
     max_qty: usize,
     inner: SortedVec<E>,
@@ -1089,6 +1169,18 @@ pub mod cargo_asm {
 
     #[inline(never)]
     #[unsafe(no_mangle)]
+    pub fn v6_threshold_vec_result_collection_add_cargo_asm_hook() -> (usize, u64, u64) {
+        let mut results =
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(MAX_QTY);
+        for entry in SORTED_NEAREST_INPUTS {
+            results.add(entry);
+        }
+        let vec = results.into_sorted_vec();
+        checksum_nearest(&vec)
+    }
+
+    #[inline(never)]
+    #[unsafe(no_mangle)]
     pub fn v6_binary_heap_result_collection_add_cargo_asm_hook() -> (usize, u64, u64) {
         let mut results =
             BinaryHeapResultCollection::<BestQueryResultItem<(), u32, f64>>::with_max_qty(MAX_QTY);
@@ -1206,5 +1298,82 @@ impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for Vec<E> {
     fn into_sorted_vec(mut self) -> Vec<E> {
         self.sort();
         self
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(not(feature = "small_n_result_collectors"), test))]
+mod tests {
+    use super::*;
+
+    const INPUTS: [QueryResultItem<(), u32, f64>; 5] = [
+        QueryResultItem {
+            point: (),
+            distance: 0.4,
+            item: 1,
+        },
+        QueryResultItem {
+            point: (),
+            distance: 0.1,
+            item: 2,
+        },
+        QueryResultItem {
+            point: (),
+            distance: 0.8,
+            item: 3,
+        },
+        QueryResultItem {
+            point: (),
+            distance: 0.3,
+            item: 4,
+        },
+        QueryResultItem {
+            point: (),
+            distance: 0.6,
+            item: 5,
+        },
+    ];
+
+    #[test]
+    fn threshold_vec_sorted_output() {
+        let k = 3;
+        let mut results =
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(k);
+        for entry in INPUTS {
+            results.add(entry);
+        }
+        let sorted = results.into_sorted_vec();
+        assert_eq!(sorted.len(), k);
+        for i in 1..sorted.len() {
+            assert!(sorted[i - 1].distance <= sorted[i].distance);
+        }
+    }
+
+    #[test]
+    fn threshold_vec_threshold_distance() {
+        let mut results =
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
+        assert!(results.threshold_distance().is_none());
+        results.add(INPUTS[0]);
+        assert!(results.threshold_distance().is_none());
+        results.add(INPUTS[1]);
+        assert!(results.threshold_distance().is_none());
+        results.add(INPUTS[2]); // now full
+        assert!(results.threshold_distance().is_some());
+    }
+
+    #[test]
+    fn threshold_vec_evicts_farthest() {
+        let mut results =
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
+        for entry in INPUTS.iter().take(3) {
+            results.add(*entry); // 0.4, 0.1, 0.8: farthest is 0.8
+        }
+        // Add closer than farthest (0.3 < 0.8): should replace it
+        results.add(INPUTS[3]); // 0.3
+        let sorted = results.into_sorted_vec();
+        assert_eq!(sorted.len(), 3);
+        assert!(sorted.iter().any(|item| item.distance == 0.3));
+        assert!(!sorted.iter().any(|item| item.distance == 0.8));
     }
 }

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -137,13 +137,14 @@ where
 /// cost (sorting k elements in O(k log k)) is negligible.
 #[cfg(not(feature = "small_n_result_collectors"))]
 #[derive(Debug)]
-pub(crate) struct ThresholdVecResultCollection<E> {
+pub(crate) struct ThresholdVecResultCollection<E, O> {
     max_qty: usize,
     inner: Vec<E>,
+    threshold: Option<O>,
 }
 
 #[cfg(not(feature = "small_n_result_collectors"))]
-impl<O: PartialOrd, T> ThresholdVecResultCollection<QueryResultItem<(), T, O>> {
+impl<O: PartialOrd + Copy, T> ThresholdVecResultCollection<QueryResultItem<(), T, O>, O> {
     #[inline]
     fn farthest_idx(&self) -> usize {
         let mut farthest = 0;
@@ -158,12 +159,13 @@ impl<O: PartialOrd, T> ThresholdVecResultCollection<QueryResultItem<(), T, O>> {
 
 #[cfg(not(feature = "small_n_result_collectors"))]
 impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
-    for ThresholdVecResultCollection<QueryResultItem<(), T, O>>
+    for ThresholdVecResultCollection<QueryResultItem<(), T, O>, O>
 {
     fn with_max_qty(max_qty: usize) -> Self {
         Self {
             max_qty,
             inner: Vec::with_capacity(max_qty),
+            threshold: None,
         }
     }
 
@@ -176,21 +178,26 @@ impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
     }
 
     fn add(&mut self, entry: QueryResultItem<(), T, O>) {
-        if self.inner.len() < self.max_qty {
-            self.inner.push(entry);
-        } else {
-            let farthest = self.farthest_idx();
-            if entry.distance < self.inner[farthest].distance {
-                self.inner[farthest] = entry;
+        match self.threshold {
+            None => {
+                if self.inner.len() < self.max_qty {
+                    self.inner.push(entry);
+                    if self.inner.len() == self.max_qty {
+                        self.threshold = Some(self.inner[self.farthest_idx()].distance);
+                    }
+                }
             }
+            Some(farthest_dist) if entry.distance < farthest_dist => {
+                let farthest = self.farthest_idx();
+                self.inner[farthest] = entry;
+                self.threshold = Some(self.inner[self.farthest_idx()].distance);
+            }
+            _ => {}
         }
     }
 
     fn threshold_distance(&self) -> Option<O> {
-        if self.inner.len() < self.max_qty {
-            return None;
-        }
-        Some(self.inner[self.farthest_idx()].distance)
+        self.threshold
     }
 
     fn into_vec(self) -> Vec<QueryResultItem<(), T, O>> {
@@ -1167,11 +1174,14 @@ pub mod cargo_asm {
         checksum_nearest(&vec)
     }
 
+    #[cfg(not(feature = "small_n_result_collectors"))]
     #[inline(never)]
     #[unsafe(no_mangle)]
     pub fn v6_threshold_vec_result_collection_add_cargo_asm_hook() -> (usize, u64, u64) {
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(MAX_QTY);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(
+                MAX_QTY,
+            );
         for entry in SORTED_NEAREST_INPUTS {
             results.add(entry);
         }
@@ -1338,7 +1348,7 @@ mod tests {
     fn threshold_vec_sorted_output() {
         let k = 3;
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(k);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(k);
         for entry in INPUTS {
             results.add(entry);
         }
@@ -1352,7 +1362,7 @@ mod tests {
     #[test]
     fn threshold_vec_threshold_distance() {
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(3);
         assert!(results.threshold_distance().is_none());
         results.add(INPUTS[0]);
         assert!(results.threshold_distance().is_none());
@@ -1365,7 +1375,7 @@ mod tests {
     #[test]
     fn threshold_vec_evicts_farthest() {
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(3);
         for entry in INPUTS.iter().take(3) {
             results.add(*entry); // 0.4, 0.1, 0.8: farthest is 0.8
         }

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -188,15 +188,17 @@ impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
         self.inner
     }
 
-    fn into_sorted_vec(mut self) -> Vec<QueryResultItem<(), T, O>> {
-        if self.inner.len() < self.max_qty {
-            self.inner.sort_unstable_by(|a, b| {
+    fn into_sorted_vec(self) -> Vec<QueryResultItem<(), T, O>> {
+        let max_qty = self.max_qty();
+        let mut vec = self.into_vec();
+        if vec.len() < max_qty {
+            vec.sort_unstable_by(|a, b| {
                 a.distance
                     .partial_cmp(&b.distance)
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
         }
-        self.inner
+        vec
     }
 }
 

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -1338,9 +1338,12 @@ mod tests {
         let k = 3;
         let mut results =
             ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(k);
+        assert_eq!(results.max_qty(), k);
+        assert_eq!(results.len(), 0);
         for entry in INPUTS {
             results.add(entry);
         }
+        assert_eq!(results.len(), k);
         let sorted = results.into_sorted_vec();
         assert_eq!(sorted.len(), k);
         for i in 1..sorted.len() {
@@ -1352,12 +1355,17 @@ mod tests {
     fn threshold_vec_threshold_distance() {
         let mut results =
             ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
+        assert_eq!(results.max_qty(), 3);
+        assert_eq!(results.len(), 0);
         assert!(results.threshold_distance().is_none());
         results.add(INPUTS[0]);
+        assert_eq!(results.len(), 1);
         assert!(results.threshold_distance().is_none());
         results.add(INPUTS[1]);
+        assert_eq!(results.len(), 2);
         assert!(results.threshold_distance().is_none());
         results.add(INPUTS[2]); // now full
+        assert_eq!(results.len(), 3);
         assert!(results.threshold_distance().is_some());
     }
 
@@ -1365,11 +1373,15 @@ mod tests {
     fn threshold_vec_select_nth_unstable() {
         let mut results =
             ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
+        assert_eq!(results.max_qty(), 3);
+        assert_eq!(results.len(), 0);
         for entry in INPUTS.iter().take(3) {
             results.add(*entry); // 0.4, 0.1, 0.8: farthest is 0.8
         }
+        assert_eq!(results.len(), 3);
         // Add closer than farthest (0.3 < 0.8): should replace it
         results.add(INPUTS[3]); // 0.3
+        assert_eq!(results.len(), 3);
         let sorted = results.into_sorted_vec();
         assert_eq!(sorted.len(), 3);
         assert!(sorted.iter().any(|item| item.distance == 0.3));

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -127,31 +127,27 @@ where
 
 /// Vec-based result collection for small-k nearest_n queries.
 ///
-/// Inserts candidates via plain `Vec::push` (O(1)) and tracks the threshold
-/// as the max distance of the first k accepted candidates. Once the
-/// initial k slots are filled, the threshold is frozen and only candidates
-/// closer than it are accepted. At extraction time `into_vec` does a
-/// `select_nth_unstable` + truncate on the oversized vec.
-///
-/// This design relies on the tree visiting leaves in proximity order,
-/// so the first k candidates are representative of the true k nearest.
+/// Inserts candidates via plain `Vec::push` (O(1)) during the fill phase.
+/// Once `max_qty` items have been collected, the vec is sorted once.
+/// Subsequent insertions that beat the current threshold (last/farthest
+/// element) are inserted via `partition_point` + `insert`, maintaining
+/// sorted order. The threshold is always accurate (the farthest of the
+/// current top-k), enabling effective branch pruning during tree traversal.
 #[cfg(not(feature = "small_n_result_collectors"))]
 #[derive(Debug)]
-pub(crate) struct ThresholdVecResultCollection<E, O> {
+pub(crate) struct ThresholdVecResultCollection<E> {
     max_qty: usize,
     inner: Vec<E>,
-    threshold: O,
 }
 
 #[cfg(not(feature = "small_n_result_collectors"))]
 impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
-    for ThresholdVecResultCollection<QueryResultItem<(), T, O>, O>
+    for ThresholdVecResultCollection<QueryResultItem<(), T, O>>
 {
     fn with_max_qty(max_qty: usize) -> Self {
         Self {
             max_qty,
-            inner: Vec::with_capacity(max_qty * 2),
-            threshold: O::min_value(),
+            inner: Vec::with_capacity(max_qty),
         }
     }
 
@@ -165,39 +161,42 @@ impl<O: Axis<Coord = O>, T> ResultCollection<O, QueryResultItem<(), T, O>>
 
     fn add(&mut self, entry: QueryResultItem<(), T, O>) {
         if self.inner.len() < self.max_qty {
-            if entry.distance > self.threshold {
-                self.threshold = entry.distance;
+            self.inner.push(entry);
+            if self.inner.len() == self.max_qty {
+                self.inner.sort_unstable_by(|a, b| {
+                    a.distance
+                        .partial_cmp(&b.distance)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
             }
-            self.inner.push(entry);
-        } else if entry.distance < self.threshold {
-            self.inner.push(entry);
+        } else if entry < self.inner[self.max_qty - 1] {
+            self.inner.pop();
+            let idx = self.inner.partition_point(|existing| *existing <= entry);
+            self.inner.insert(idx, entry);
         }
     }
 
     fn threshold_distance(&self) -> Option<O> {
-        if self.inner.len() < self.max_qty {
-            None
+        if self.inner.len() == self.max_qty {
+            self.inner.last().map(|n| n.distance)
         } else {
-            Some(self.threshold)
+            None
         }
     }
 
-    fn into_vec(mut self) -> Vec<QueryResultItem<(), T, O>> {
-        if self.inner.len() > self.max_qty {
-            self.inner.select_nth_unstable_by(self.max_qty - 1, |a, b| {
+    fn into_vec(self) -> Vec<QueryResultItem<(), T, O>> {
+        self.inner
+    }
+
+    fn into_sorted_vec(mut self) -> Vec<QueryResultItem<(), T, O>> {
+        if self.inner.len() < self.max_qty {
+            self.inner.sort_unstable_by(|a, b| {
                 a.distance
                     .partial_cmp(&b.distance)
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
-            self.inner.truncate(self.max_qty);
         }
         self.inner
-    }
-
-    fn into_sorted_vec(self) -> Vec<QueryResultItem<(), T, O>> {
-        let mut result = self.into_vec();
-        result.sort_unstable_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap());
-        result
     }
 }
 
@@ -1169,9 +1168,7 @@ pub mod cargo_asm {
     #[unsafe(no_mangle)]
     pub fn v6_threshold_vec_result_collection_add_cargo_asm_hook() -> (usize, u64, u64) {
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(
-                MAX_QTY,
-            );
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(MAX_QTY);
         for entry in SORTED_NEAREST_INPUTS {
             results.add(entry);
         }
@@ -1338,7 +1335,7 @@ mod tests {
     fn threshold_vec_sorted_output() {
         let k = 3;
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(k);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(k);
         for entry in INPUTS {
             results.add(entry);
         }
@@ -1352,7 +1349,7 @@ mod tests {
     #[test]
     fn threshold_vec_threshold_distance() {
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(3);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
         assert!(results.threshold_distance().is_none());
         results.add(INPUTS[0]);
         assert!(results.threshold_distance().is_none());
@@ -1365,7 +1362,7 @@ mod tests {
     #[test]
     fn threshold_vec_select_nth_unstable() {
         let mut results =
-            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>, f64>::with_max_qty(3);
+            ThresholdVecResultCollection::<QueryResultItem<(), u32, f64>>::with_max_qty(3);
         for entry in INPUTS.iter().take(3) {
             results.add(*entry); // 0.4, 0.1, 0.8: farthest is 0.8
         }


### PR DESCRIPTION
This PR replaces `SortedVecResultCollection` as the default sorted collection for `nearest_n` queries with k <= 20. The new `ThresholdVecResultCollection` stores candidates in a plain Vec and tracks the current k-th distance by scanning for the farthest element when full.

Insertion is $\mathcal O(1)$ push (vs `SortedVec`'s $\mathcal O(k)$ binary-search + memmove on each candidate). The `threshold_distance` scan is $\mathcal O(k)$, same as `SortedVec`'s `last()` call. On extraction, `into_sorted_vec` truncates via `select_nth_unstable` and sorts the remaining elements -- at most 20 items.

Also applied to the periodic boundary condition neighbour paths. This follows the Vec-based collection approach discussed in #394 and is intended as a replacement for `SortedVecResultCollection` in small-k scenarios.
The `SortedVecResultCollection` is retained; gated behind cargo_asm for benchmarks, and small_n_result_collectors as the feature-gated alternative path.

I have added a minimal test. You are welcome to review and add feedback I can integrate.