### PR TITLE
Introduce QueryMetric public trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,3 +617,7 @@ path = "tests/builder_ui.rs"
 [[test]]
 name = "custom_metric_block_fallback"
 path = "tests/custom_metric_block_fallback.rs"
+
+[[test]]
+name = "custom_query_metric"
+path = "tests/custom_query_metric.rs"

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -54,6 +54,9 @@ pub(crate) use distance_metric_core::DistanceMetricScalar as DistanceMetricCore;
 ))]
 use std::any::TypeId;
 
+use crate::leaf_view::TlsLeafScratch;
+use crate::stem_strategy::donnelly::simd_full::{BacktrackBlock3, BacktrackBlock4};
+use crate::stem_strategy::{SimdPrune, SimdSelectBestChildBlock3};
 use crate::Axis;
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
@@ -76,6 +79,78 @@ pub use manhattan::Manhattan;
 pub use minkowski::Minkowski;
 #[doc(inline)]
 pub use squared_euclidean::SquaredEuclidean;
+
+/// Widened distance/output types that Kiddo's executable query paths support.
+///
+/// This is mainly useful as part of [`QueryMetric`]. Most library users should
+/// not need to name this trait directly.
+pub trait QueryDistance:
+    SimdPrune + SimdSelectBestChildBlock3 + BacktrackBlock3 + BacktrackBlock4 + TlsLeafScratch + 'static
+{
+}
+
+impl<T> QueryDistance for T where
+    T: SimdPrune
+        + SimdSelectBestChildBlock3
+        + BacktrackBlock3
+        + BacktrackBlock4
+        + TlsLeafScratch
+        + 'static
+{
+}
+
+mod query_metric_sealed {
+    use super::{DistanceMetric, QueryDistance};
+
+    pub trait Sealed<A: Copy> {}
+
+    impl<T, A: Copy> Sealed<A> for T where T: DistanceMetric<A, Output: QueryDistance> {}
+}
+
+/// Public bound for distance metrics that can be used with query-builder APIs
+/// that finish with `.execute()` or `.execute_with_scratch(...)`.
+///
+/// Implementing [`DistanceMetric`] is still enough to define a custom metric.
+/// `QueryMetric` is the stronger bound required when a generic helper wants to
+/// execute a query built with that metric.
+///
+/// In practice, this means the metric's widened [`DistanceMetric::Output`] type
+/// must be one of Kiddo's supported query distance/output types. Metrics using
+/// the usual widened output types such as `f32` or `f64` continue to work.
+/// Metrics with a brand new output type will not satisfy this bound unless that
+/// output type also supports Kiddo's internal query-execution operations.
+///
+/// # Example
+///
+/// ```ignore
+/// use kiddo::KdTree;
+/// use kiddo::dist::{QueryMetric, SquaredEuclidean};
+/// use kiddo::Axis;
+/// use std::num::NonZeroUsize;
+///
+/// fn query<A, M, const K: usize>(
+///     tree: &KdTree<A, u32, _, _, K, 32>,
+///     point: &[A; K],
+///     n: NonZeroUsize,
+/// ) -> Vec<u32>
+/// where
+///     A: Axis<Coord = A> + Copy + 'static,
+///     M: QueryMetric<A>,
+/// {
+///     tree.query(point)
+///         .nearest_n::<M>(n)
+///         .execute()
+///         .into_iter()
+///         .map(|result| result.item)
+///         .collect()
+/// }
+/// ```
+pub trait QueryMetric<A: Copy>:
+    DistanceMetric<A, Output: QueryDistance> + query_metric_sealed::Sealed<A>
+{
+}
+
+impl<T, A: Copy> QueryMetric<A> for T where T: DistanceMetric<A, Output: QueryDistance> {}
 
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
@@ -1359,7 +1434,7 @@ impl<T, A: Copy> DistanceMetric<A> for T where
 mod tests {
     use super::{
         Chebyshev, DistanceMetric, DistanceMetricScalar, DotProduct, Manhattan, Minkowski,
-        SquaredEuclidean,
+        QueryMetric, SquaredEuclidean,
     };
 
     #[test]
@@ -1416,6 +1491,14 @@ mod tests {
         assert_unified::<SquaredEuclidean<f64>>();
         assert_unified::<Chebyshev<f64>>();
         assert_unified::<Minkowski<3, f64>>();
+    }
+
+    #[test]
+    fn v3_query_metric_bound_is_satisfied() {
+        fn assert_query_metric<M: QueryMetric<f64>>() {}
+        assert_query_metric::<SquaredEuclidean<f64>>();
+        assert_query_metric::<Chebyshev<f64>>();
+        assert_query_metric::<Minkowski<3, f64>>();
     }
 
     #[test]

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -5,7 +5,7 @@ use std::collections::BinaryHeap;
 use std::marker::PhantomData;
 use std::num::{NonZero, NonZeroUsize};
 
-use crate::dist::{DistanceMetric, DistanceMetricCore};
+use crate::dist::{DistanceMetric, DistanceMetricCore, QueryMetric};
 use crate::kd_tree::query_stack::StackTrait;
 #[cfg(feature = "rkyv_08")]
 use crate::kd_tree::ArchivedKdTree;
@@ -1754,7 +1754,7 @@ where
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
+    D: QueryMetric<A>,
     D::Output: crate::stem_strategy::SimdPrune
         + SimdSelectBestChildBlock3
         + BacktrackBlock3
@@ -2129,7 +2129,7 @@ where
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: KdTreeAccessor<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
+    D: QueryMetric<A>,
     D::Output: crate::stem_strategy::SimdPrune
         + SimdSelectBestChildBlock3
         + BacktrackBlock3
@@ -3721,13 +3721,7 @@ where
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
+    D: QueryMetric<A>,
     SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     I: ProjectionField<T>,
     Dp: ProjectionField<D::Output>,
@@ -3783,13 +3777,7 @@ where
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
+    D: QueryMetric<A>,
     SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     I: ProjectionField<T>,
     Dp: ProjectionField<D::Output>,
@@ -3850,13 +3838,7 @@ where
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
+    D: QueryMetric<A>,
     SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     I: ProjectionField<T>,
     Dp: ProjectionField<D::Output>,
@@ -3918,13 +3900,7 @@ where
     SS: StemStrategy,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
+    D: QueryMetric<A>,
     SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     I: ProjectionField<T>,
     Dp: ProjectionField<D::Output>,
@@ -4487,13 +4463,7 @@ where
     SS: StemStrategy + 'static,
     LS: LeafStrategy<A, T, SS, K, B>,
     Tree: QueryBuilderTreeOps<A, T, SS, LS, K, B>,
-    D: DistanceMetric<A>,
-    D::Output: crate::stem_strategy::SimdPrune
-        + SimdSelectBestChildBlock3
-        + BacktrackBlock3
-        + BacktrackBlock4
-        + TlsLeafScratch
-        + 'static,
+    D: QueryMetric<A>,
     SS::Stack<D::Output>: StackTrait<D::Output, SS> + Default + 'static,
     P: PointProjectionField<A, K>,
     I: ProjectionField<T>,
@@ -5498,7 +5468,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::dist::SquaredEuclidean;
+    use crate::dist::{QueryMetric, SquaredEuclidean};
     #[cfg(feature = "rkyv_08")]
     use crate::kd_tree::ArchivedKdTree;
     use crate::kd_tree::KdTree;
@@ -5506,6 +5476,7 @@ mod tests {
     use crate::leaf_strategy::VecOfArenas;
     use crate::leaf_strategy::{FlatVec, VecOfArrays};
     use crate::stem_strategy::Eytzinger;
+    use crate::Axis;
     use std::num::NonZeroUsize;
 
     type WrapTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 32>, 2, 32>;
@@ -5935,5 +5906,44 @@ mod tests {
                 .within(0.05)
                 .execute()
         );
+    }
+
+    #[test]
+    fn generic_query_metric_helper_can_execute_nearest_n() {
+        fn query<A, M, const K: usize>(
+            tree: &KdTree<A, u32, Eytzinger, VecOfArrays<A, u32, K, 32>, K, 32>,
+            point: &[A; K],
+            n: NonZeroUsize,
+        ) -> Vec<u32>
+        where
+            A: Axis<Coord = A> + Copy + 'static,
+            M: QueryMetric<A>,
+        {
+            tree.query(point)
+                .nearest_n::<M>(n)
+                .execute()
+                .into_iter()
+                .map(|result| result.item)
+                .collect()
+        }
+
+        let points = [
+            (10u32, [0.0f64, 0.0]),
+            (20u32, [1.0, 1.0]),
+            (30u32, [2.0, 2.0]),
+        ];
+        let tree =
+            KdTree::<f64, u32, Eytzinger, VecOfArrays<f64, u32, 2, 32>, 2, 32>::new_from_entries(
+                &points,
+            )
+            .unwrap();
+
+        let results = query::<f64, SquaredEuclidean<f64>, 2>(
+            &tree,
+            &[0.1, 0.1],
+            NonZeroUsize::new(2).unwrap(),
+        );
+
+        assert_eq!(results, vec![10, 20]);
     }
 }

--- a/tests/custom_query_metric.rs
+++ b/tests/custom_query_metric.rs
@@ -1,0 +1,89 @@
+use std::cmp::Ordering;
+use std::num::NonZeroUsize;
+
+use kiddo::dist::{
+    DistanceMetric, DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon,
+    DistanceMetricScalar, QueryMetric,
+};
+use kiddo::leaf_strategies::VecOfArrays;
+use kiddo::{Axis, Eytzinger, KdTree};
+
+struct AbsDistance;
+
+impl DistanceMetricScalar<f64> for AbsDistance {
+    type Output = f64;
+    const ORDERING: Ordering = Ordering::Less;
+
+    fn widen_coord(a: f64) -> Self::Output {
+        a
+    }
+
+    fn dist1(a: Self::Output, b: Self::Output) -> Self::Output {
+        (a - b).abs()
+    }
+}
+
+impl DistanceMetricAvx512<f64> for AbsDistance {
+    #[cfg(all(feature = "simd", target_feature = "avx512f"))]
+    type Avx512F64Ops = kiddo::traits::dist::UnsupportedAvx512F64LeafOps;
+
+    #[cfg(all(feature = "simd", target_feature = "avx512f"))]
+    type Avx512F32Ops = kiddo::traits::dist::UnsupportedAvx512F32LeafOps;
+}
+
+impl DistanceMetricAvx2<f64> for AbsDistance {
+    #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
+    type Avx2F64Ops = kiddo::traits::dist::UnsupportedAvx2F64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
+    type Avx2F32Ops = kiddo::traits::dist::UnsupportedAvx2F32LeafOps;
+}
+
+impl DistanceMetricNeon<f64> for AbsDistance {
+    #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
+    type NeonF64Ops = kiddo::traits::dist::UnsupportedNeonF64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
+    type NeonF32Ops = kiddo::traits::dist::UnsupportedNeonF32LeafOps;
+}
+
+type TestTree = KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, 2, 32>, 2, 32>;
+
+fn assert_distance_metric<M: DistanceMetric<f64>>() {}
+
+fn assert_query_metric<M: QueryMetric<f64>>() {}
+
+fn query_items<A, M, const K: usize>(
+    tree: &KdTree<A, u32, Eytzinger, VecOfArrays<A, u32, K, 32>, K, 32>,
+    point: &[A; K],
+    n: NonZeroUsize,
+) -> Vec<u32>
+where
+    A: Axis<Coord = A> + Copy + 'static,
+    M: QueryMetric<A>,
+{
+    tree.query(point)
+        .nearest_n::<M>(n)
+        .execute()
+        .into_iter()
+        .map(|result| result.item)
+        .collect()
+}
+
+#[test]
+fn external_metric_satisfies_query_metric_and_generic_execute_helper() {
+    assert_distance_metric::<AbsDistance>();
+    assert_query_metric::<AbsDistance>();
+
+    let points = [
+        (10u32, [0.0f64, 0.0]),
+        (20u32, [1.0, 1.0]),
+        (30u32, [2.0, 2.0]),
+    ];
+    let tree: TestTree = KdTree::new_from_entries(&points).unwrap();
+
+    let items =
+        query_items::<f64, AbsDistance, 2>(&tree, &[0.1, 0.1], NonZeroUsize::new(2).unwrap());
+
+    assert_eq!(items, vec![10, 20]);
+}


### PR DESCRIPTION
This permits code outside of the crate to be generic over `DistanceMetric`s.

Also added an integration test that implements a DistanceMetric from outside the crate, to act as a regression test to ensure that this remains possible to do in future.

Fixes: https://github.com/sdd/kiddo/issues/390