### PR TITLE
Add example showing embedding a serialized k-d tree within an executable 

### DIFF
--- a/.github/scripts/prepare-example-artifacts.sh
+++ b/.github/scripts/prepare-example-artifacts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p examples/data
+
+python3 <<'PY'
+import csv
+from pathlib import Path
+
+header = [
+    "geonameid",
+    "name",
+    "asciiname",
+    "alternatenames",
+    "latitude",
+    "longitude",
+    "feature class",
+    "feature code",
+    "country code",
+    "cc2",
+    "admin1 code",
+    "admin2 code",
+    "admin3 code",
+    "admin4 code",
+    "population",
+    "elevation",
+    "dem",
+    "timezone",
+    "modification date",
+]
+
+rows = [
+    ["2643743", "London", "London", "", "51.5085", "-0.1257", "P", "PPLC", "GB", "", "ENG", "GLA", "", "", "8961989", "", "", "Europe/London", "2024-01-01"],
+    ["5128581", "New York City", "New York City", "", "40.7143", "-74.0060", "P", "PPLA", "US", "", "NY", "061", "", "", "8804190", "", "", "America/New_York", "2024-01-01"],
+    ["2988507", "Paris", "Paris", "", "48.8534", "2.3488", "P", "PPLC", "FR", "", "11", "075", "", "", "2138551", "", "", "Europe/Paris", "2024-01-01"],
+    ["1850147", "Tokyo", "Tokyo", "", "35.6895", "139.6917", "P", "PPLC", "JP", "", "40", "13101", "", "", "13929286", "", "", "Asia/Tokyo", "2024-01-01"],
+    ["2147714", "Sydney", "Sydney", "", "-33.8679", "151.2073", "P", "PPLA", "AU", "", "NSW", "", "", "", "5312163", "", "", "Australia/Sydney", "2024-01-01"],
+    ["6058560", "London", "London", "", "42.9834", "-81.2330", "P", "PPLA", "CA", "", "ON", "", "", "", "422324", "", "", "America/Toronto", "2024-01-01"],
+    ["6295630", "Earth Observation Point", "Earth Observation Point", "", "0.0000", "0.0000", "S", "OBS", "ZZ", "", "", "", "", "", "0", "", "", "UTC", "2024-01-01"],
+]
+
+path = Path("examples/data/geonames.csv")
+with path.open("w", newline="") as fh:
+    writer = csv.writer(fh)
+    writer.writerow(header)
+    writer.writerows(rows)
+PY
+
+cargo run --example build-float-doctest-tree-rkyv_08 --features rkyv_08
+cargo run --example build-immutable-doctest-tree-rkyv_08 --features rkyv_08
+cargo run --example build-geonames-embedded-rkyv --features csv,rkyv_08

--- a/.github/workflows/build-msrv.yml
+++ b/.github/workflows/build-msrv.yml
@@ -48,6 +48,9 @@ jobs:
           components: clippy
           toolchain: ${{ env.MSRV_RUST_VERSION }}
 
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
       - name: Run Clippy
         run: cargo clippy --features=serde,rkyv_08,test_utils --no-deps
 
@@ -90,13 +93,14 @@ jobs:
           components: clippy
           toolchain: ${{ env.MSRV_RUST_VERSION }}
 
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
       - name: Cargo nextest
         run: |
-          cargo run --example build-float-doctest-tree-rkyv_08 --features="rkyv_08"
-          cargo run --example build-immutable-doctest-tree-rkyv_08 --features="rkyv_08"
           cargo nextest run --workspace --features=serde,rkyv_08,test_utils
 
       - name: Cargo test (Doctests)

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -50,6 +50,9 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
 
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
       - name: Clippy (Nightly)
         uses: LoliGothick/clippy-check@ad7a7d94820528f03680550b984f5b43dd8af294
         if: github.actor != 'dependabot[bot]'
@@ -102,13 +105,14 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
 
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
       - name: Cargo nextest (dev build)
         run: |
-          cargo run --example build-float-doctest-tree-rkyv_08 --features="rkyv_08"
-          cargo run --example build-immutable-doctest-tree-rkyv_08 --features="rkyv_08"
           cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
 
       - name: Cargo nextest (release build)

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
       - name: Run Clippy
         run: cargo clippy --features=serde,rkyv_08,test_utils --no-deps
 
@@ -84,13 +87,14 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
       - name: Cargo nextest
         run: |
-          cargo run --example build-float-doctest-tree-rkyv_08 --features="rkyv_08"
-          cargo run --example build-immutable-doctest-tree-rkyv_08 --features="rkyv_08"
           cargo nextest run --workspace --features=serde,rkyv_08,test_utils
 
       - name: Cargo test (Doctests)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,12 +151,17 @@ radians = "0.3"
 rand = "0.10"
 rand_distr = "0.6"
 rayon = "1"
+reqwest = { version = "0.12", default-features = false, features = [
+  "blocking",
+  "rustls-tls",
+] }
 rstest = "0.26"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 tracing-subscriber = "0.3"
 trybuild = "1"
 ubyte = "0.10"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 zzz = "0.3.2"
 
 [lints.rust]
@@ -501,6 +506,21 @@ required-features = ["rkyv_08"]
 name = "immutable-rkyv_08-deserialize"
 path = "examples/immutable-rkyv_08-deserialize.rs"
 required-features = ["rkyv_08"]
+
+[[example]]
+name = "embedded-rkyv_08-deserialize"
+path = "examples/embedded-rkyv_08-deserialize.rs"
+required-features = ["rkyv_08"]
+
+[[example]]
+name = "download-geonames-data"
+path = "examples/download-geonames-data.rs"
+required-features = ["csv"]
+
+[[example]]
+name = "build-geonames-embedded-rkyv"
+path = "examples/build-geonames-embedded-rkyv.rs"
+required-features = ["csv", "rkyv_08"]
 
 [[example]]
 name = "immutable-large-eytz-build-and-serialize-f32"

--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,5 @@ fn main() {
             host, target
         );
     }
-
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/examples/build-geonames-embedded-rkyv.rs
+++ b/examples/build-geonames-embedded-rkyv.rs
@@ -1,0 +1,122 @@
+mod geonames_embedded_types;
+
+use csv::Reader;
+use elapsed::ElapsedDuration;
+use rkyv_08::{rancor::Error as RkyvError, to_bytes};
+use serde::Deserialize;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+
+use geonames_embedded_types::{EmbeddedCity, EmbeddedGeoNames, Tree};
+
+const CSV_PATH: &str = "./examples/data/geonames.csv";
+const ARCHIVE_PATH: &str = "./examples/data/geonames-embedded.rkyv";
+
+#[derive(Debug, Deserialize)]
+struct GeoNameRecord {
+    name: String,
+    #[serde(rename = "latitude")]
+    lat: String,
+    #[serde(rename = "longitude")]
+    lng: String,
+    #[serde(rename = "feature class")]
+    feature_class: String,
+    #[serde(rename = "country code")]
+    country_code: String,
+    population: String,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    if !Path::new(CSV_PATH).exists() {
+        return Err(format!(
+            "{} not found. Run `cargo run --example download-geonames-data --features csv` first.",
+            CSV_PATH
+        )
+        .into());
+    }
+
+    let start = Instant::now();
+    let mut rdr = Reader::from_path(CSV_PATH)?;
+    let mut cities = Vec::new();
+    for record in rdr.deserialize::<GeoNameRecord>() {
+        let record = match record {
+            Ok(record) => record,
+            Err(_) => continue,
+        };
+        if record.feature_class != "P" {
+            continue;
+        }
+
+        let lat: f32 = match record.lat.parse() {
+            Ok(lat) => lat,
+            Err(_) => continue,
+        };
+        let lng: f32 = match record.lng.parse() {
+            Ok(lng) => lng,
+            Err(_) => continue,
+        };
+        let population: u32 = match record.population.parse() {
+            Ok(population) => population,
+            Err(_) => continue,
+        };
+
+        cities.push(EmbeddedCity {
+            name: record.name,
+            country_code: record.country_code,
+            lat,
+            lng,
+            population,
+        });
+    }
+    println!(
+        "Filtered {} populated places from {} ({})",
+        cities.len(),
+        CSV_PATH,
+        ElapsedDuration::new(start.elapsed())
+    );
+
+    cities.sort_by(|a, b| {
+        b.population
+            .cmp(&a.population)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    let start = Instant::now();
+    let entries: Vec<(u32, [f32; 3])> = cities
+        .iter()
+        .enumerate()
+        .map(|(idx, city)| {
+            (
+                idx as u32,
+                degrees_lat_lng_to_unit_sphere(city.lat, city.lng),
+            )
+        })
+        .collect();
+    let tree: Tree = Tree::new_from_entries(&entries)?;
+    println!(
+        "Built embedded tree with {} items ({})",
+        tree.size(),
+        ElapsedDuration::new(start.elapsed())
+    );
+
+    let start = Instant::now();
+    let embedded = EmbeddedGeoNames { tree, cities };
+    let bytes = to_bytes::<RkyvError>(&embedded)?;
+    fs::write(ARCHIVE_PATH, &bytes)?;
+    println!(
+        "Serialized archive to {} ({} bytes, {})",
+        ARCHIVE_PATH,
+        bytes.len(),
+        ElapsedDuration::new(start.elapsed())
+    );
+
+    Ok(())
+}
+
+fn degrees_lat_lng_to_unit_sphere(lat: f32, lng: f32) -> [f32; 3] {
+    let lat = lat.to_radians();
+    let lng = lng.to_radians();
+    [lat.cos() * lng.cos(), lat.cos() * lng.sin(), lat.sin()]
+}

--- a/examples/download-geonames-data.rs
+++ b/examples/download-geonames-data.rs
@@ -1,0 +1,105 @@
+use csv::Writer;
+use elapsed::ElapsedDuration;
+use reqwest::blocking::Client;
+use std::error::Error;
+use std::fs::{self, File};
+use std::io::{copy, BufWriter};
+use std::path::Path;
+use std::time::Instant;
+use zip::ZipArchive;
+
+const GEONAMES_URL: &str = "https://download.geonames.org/export/dump/allCountries.zip";
+const DATA_DIR: &str = "./examples/data";
+const ZIP_PATH: &str = "./examples/data/allCountries.zip";
+const CSV_PATH: &str = "./examples/data/geonames.csv";
+
+const HEADER: [&str; 19] = [
+    "geonameid",
+    "name",
+    "asciiname",
+    "alternatenames",
+    "latitude",
+    "longitude",
+    "feature class",
+    "feature code",
+    "country code",
+    "cc2",
+    "admin1 code",
+    "admin2 code",
+    "admin3 code",
+    "admin4 code",
+    "population",
+    "elevation",
+    "dem",
+    "timezone",
+    "modification date",
+];
+
+fn main() -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(DATA_DIR)?;
+
+    if Path::new(CSV_PATH).exists() {
+        println!("GeoNames CSV already present at {}", CSV_PATH);
+        return Ok(());
+    }
+
+    ensure_zip_downloaded()?;
+    convert_zip_to_csv()?;
+    Ok(())
+}
+
+fn ensure_zip_downloaded() -> Result<(), Box<dyn Error>> {
+    if Path::new(ZIP_PATH).exists() {
+        println!("GeoNames zip already present at {}", ZIP_PATH);
+        return Ok(());
+    }
+
+    let start = Instant::now();
+    let client = Client::builder().build()?;
+    let mut response = client.get(GEONAMES_URL).send()?.error_for_status()?;
+    let mut file = BufWriter::new(File::create(ZIP_PATH)?);
+    copy(&mut response, &mut file)?;
+
+    println!(
+        "Downloaded {} to {} ({})",
+        GEONAMES_URL,
+        ZIP_PATH,
+        ElapsedDuration::new(start.elapsed())
+    );
+
+    Ok(())
+}
+
+fn convert_zip_to_csv() -> Result<(), Box<dyn Error>> {
+    let start = Instant::now();
+    let file = File::open(ZIP_PATH)?;
+    let mut archive = ZipArchive::new(file)?;
+    let zipped = archive.by_name("allCountries.txt")?;
+
+    let mut rdr = csv::ReaderBuilder::new()
+        .delimiter(b'\t')
+        .has_headers(false)
+        .flexible(true)
+        .from_reader(zipped);
+    let mut wtr = Writer::from_path(CSV_PATH)?;
+    wtr.write_record(HEADER)?;
+
+    let mut rows = 0usize;
+    for record in rdr.records() {
+        let record = record?;
+        if record.len() >= HEADER.len() {
+            wtr.write_record(record.iter().take(HEADER.len()))?;
+            rows += 1;
+        }
+    }
+    wtr.flush()?;
+
+    println!(
+        "Wrote {} rows to {} ({})",
+        rows,
+        CSV_PATH,
+        ElapsedDuration::new(start.elapsed())
+    );
+
+    Ok(())
+}

--- a/examples/embedded-rkyv_08-deserialize.rs
+++ b/examples/embedded-rkyv_08-deserialize.rs
@@ -1,0 +1,146 @@
+mod geonames_embedded_types;
+
+use std::error::Error;
+use std::fmt::Write as _;
+use std::num::NonZeroUsize;
+use std::time::Instant;
+
+use elapsed::ElapsedDuration;
+use kiddo::SquaredEuclidean;
+use rkyv_08::access_unchecked;
+
+use geonames_embedded_types::ArchivedEmbeddedGeoNames;
+
+const EARTH_RADIUS_IN_KM: f32 = 6371.0;
+
+#[repr(align(128))]
+struct AlignedBytes<const N: usize>([u8; N]);
+
+static EMBEDDED_ARCHIVE_BYTES: AlignedBytes<
+    { include_bytes!("data/geonames-embedded.rkyv").len() },
+> = AlignedBytes(*include_bytes!("data/geonames-embedded.rkyv"));
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let lat_arg = args.next().ok_or("missing latitude arg, e.g. `52.5N`")?;
+    let lon_arg = args.next().ok_or("missing longitude arg, e.g. `1.9W`")?;
+    if args.next().is_some() {
+        return Err("expected exactly two args: `<lat> <lon>`".into());
+    }
+
+    let lat = parse_lat(&lat_arg)?;
+    let lon = parse_lon(&lon_arg)?;
+    let query = degrees_lat_lng_to_unit_sphere(lat, lon);
+
+    let bytes = &EMBEDDED_ARCHIVE_BYTES.0[..];
+
+    let start = Instant::now();
+    let archived_unchecked = unsafe { access_unchecked::<ArchivedEmbeddedGeoNames>(bytes) };
+    let unchecked_elapsed = start.elapsed();
+    println!(
+        "zero-copy deserialized embedded tree: city_count={} ({})",
+        archived_unchecked.cities.len(),
+        ElapsedDuration::new(unchecked_elapsed)
+    );
+
+    let start = Instant::now();
+    let nearest = archived_unchecked
+        .tree
+        .query(&query)
+        .nearest_one::<SquaredEuclidean<f32>>()
+        .execute();
+    let query_elapsed = start.elapsed();
+
+    let city = archived_unchecked
+        .cities
+        .get(nearest.item as usize)
+        .ok_or("nearest item index out of bounds for embedded city data")?;
+    println!(
+        "Nearest city to {} {}: {}, {} ({:.4}, {:.4}), pop. {}, {:.1}km ({})",
+        format_coord(lat, true),
+        format_coord(lon, false),
+        city.name.as_str(),
+        city.country_code.as_str(),
+        city.lat,
+        city.lng,
+        city.population,
+        unit_sphere_squared_euclidean_to_kilometres(nearest.distance),
+        ElapsedDuration::new(query_elapsed)
+    );
+
+    let start = Instant::now();
+    let nearest_five = archived_unchecked
+        .tree
+        .query(&query)
+        .nearest_n::<SquaredEuclidean<f32>>(NonZeroUsize::new(5).unwrap())
+        .execute();
+    let knn_elapsed = start.elapsed();
+
+    println!("Nearest 5 cities ({})", ElapsedDuration::new(knn_elapsed));
+    for result in nearest_five {
+        let city = archived_unchecked
+            .cities
+            .get(result.item as usize)
+            .ok_or("nearest_n item index out of bounds for embedded city data")?;
+        println!(
+            "  - {}, {} ({:.1}km)",
+            city.name.as_str(),
+            city.country_code.as_str(),
+            unit_sphere_squared_euclidean_to_kilometres(result.distance)
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_lat(raw: &str) -> Result<f32, Box<dyn Error>> {
+    parse_coord(raw, true)
+}
+
+fn parse_lon(raw: &str) -> Result<f32, Box<dyn Error>> {
+    parse_coord(raw, false)
+}
+
+fn parse_coord(raw: &str, is_lat: bool) -> Result<f32, Box<dyn Error>> {
+    let trimmed = raw.trim();
+    let mut chars = trimmed.chars();
+    let last = chars.next_back().ok_or("empty coordinate")?;
+
+    let (number_str, sign) = match last {
+        'N' | 'n' if is_lat => (chars.as_str(), 1.0),
+        'S' | 's' if is_lat => (chars.as_str(), -1.0),
+        'E' | 'e' if !is_lat => (chars.as_str(), 1.0),
+        'W' | 'w' if !is_lat => (chars.as_str(), -1.0),
+        _ => (trimmed, 1.0),
+    };
+
+    let value: f32 = number_str.trim().parse()?;
+    Ok(value * sign)
+}
+
+fn format_coord(value: f32, is_lat: bool) -> String {
+    let suffix = if is_lat {
+        if value >= 0.0 {
+            'N'
+        } else {
+            'S'
+        }
+    } else if value >= 0.0 {
+        'E'
+    } else {
+        'W'
+    };
+    let mut out = String::new();
+    let _ = write!(&mut out, "{:.4}{}", value.abs(), suffix);
+    out
+}
+
+fn degrees_lat_lng_to_unit_sphere(lat: f32, lng: f32) -> [f32; 3] {
+    let lat = lat.to_radians();
+    let lng = lng.to_radians();
+    [lat.cos() * lng.cos(), lat.cos() * lng.sin(), lat.sin()]
+}
+
+fn unit_sphere_squared_euclidean_to_kilometres(sq_euc_dist: f32) -> f32 {
+    sq_euc_dist.sqrt() * EARTH_RADIUS_IN_KM
+}

--- a/examples/geonames_embedded_types.rs
+++ b/examples/geonames_embedded_types.rs
@@ -1,0 +1,20 @@
+use kiddo::{Eytzinger, KdTree, VecOfArenas};
+
+#[derive(Debug, Clone, rkyv_08::Archive, rkyv_08::Serialize, rkyv_08::Deserialize)]
+#[rkyv(crate = rkyv_08)]
+pub struct EmbeddedCity {
+    pub name: String,
+    pub country_code: String,
+    pub lat: f32,
+    pub lng: f32,
+    pub population: u32,
+}
+
+pub type Tree = KdTree<f32, u32, Eytzinger, VecOfArenas<f32, u32, 3, 32>, 3, 32>;
+
+#[derive(rkyv_08::Archive, rkyv_08::Serialize, rkyv_08::Deserialize)]
+#[rkyv(crate = rkyv_08)]
+pub struct EmbeddedGeoNames {
+    pub tree: Tree,
+    pub cities: Vec<EmbeddedCity>,
+}


### PR DESCRIPTION
Adds an example showing how to embed a serialized Kiddo k-d tree _within_ an executable itself and then zero-copy deserialize it at startup and query it:

<img width="694" height="152" alt="image" src="https://github.com/user-attachments/assets/990ac6f4-6403-4694-ac55-8478382da399" />
