### PR TITLE
perf: pre-allocate unsorted result Vec with capacity 64

### DIFF
--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -1166,7 +1166,10 @@ pub mod cargo_asm {
 impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for Vec<E> {
     fn with_max_qty(max_qty: usize) -> Self {
         if max_qty == usize::MAX {
-            Vec::new()
+            // Unsorted query path: start with reasonable capacity to avoid
+            // the first several realloc waves when many candidates fall within
+            // the radius. 64 elements (1.55 KB at 24 B/elem) is negligible.
+            Vec::with_capacity(64)
         } else {
             Vec::with_capacity(max_qty)
         }


### PR DESCRIPTION
The unsorted query path `within().unsorted().execute()` collects results in a plain `Vec<QueryResultItem>` that starts at capacity 0. In low-dimensional dense datasets where most points are within the radius, the vec grows from 0 to thousands of elements through repeated realloc cycles, each triggering memmove of all existing entries. WallTime flamegraphs show `__memcpy_avx_unaligned_erms` consuming up to nearly a third of query time from `Vec::grow_one`.

Using `Vec::with_capacity(64)` instead of `Vec::new()` avoids about the first six realloc waves (0, 4, 8, 16, 32, 64) for negligible memory cost (1.5 KB per query). Sorted paths (`nearest_n` etc.) are unaffected since they already use `Vec::with_capacity(max_qty)` with a concrete $k$ value.