### PR TITLE
feat: Configurable `ResultCollection` types for unsorted query path

### DIFF
--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -8,6 +8,7 @@ use crate::leaf_view::TlsLeafScratch;
 use crate::leaf_view_chunked::nearest_n_within::{
     nearest_n_within_with_query_wide, nearest_n_within_with_query_wide_arena,
 };
+use crate::results::result_buffer::FixedResultCollection;
 #[cfg(not(feature = "small_n_result_collectors"))]
 use crate::results::result_collection::SortedVecResultCollection;
 use crate::results::result_collection::{BinaryHeapResultCollection, ResultCollection};

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -6,6 +6,8 @@ pub mod query_result_item;
 
 pub(crate) mod result_collection;
 
+pub mod result_buffer;
+
 #[cfg(feature = "result_collection_stats")]
 #[doc(hidden)]
 pub mod result_collection_stats;

--- a/src/results/result_buffer.rs
+++ b/src/results/result_buffer.rs
@@ -1,0 +1,238 @@
+use crate::results::result_collection::ResultCollection;
+use crate::Axis;
+
+/// Pre-allocated result collection for the unsorted query path.
+///
+/// Avoids the first several `Vec` realloc waves (Brodnik et al., WADS 1999)
+/// by starting at a compile-time constant capacity. `FixedResultCollection<_, 256>`
+/// skips 8 waves. No single constant works universally.
+pub struct FixedResultCollection<E, const CAP: usize = 64>(Vec<E>);
+
+pub type DefaultFixedResultCollection<E> = FixedResultCollection<E, 256>;
+
+impl<E, const CAP: usize> FixedResultCollection<E, CAP> {
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+}
+
+impl<E, const CAP: usize> Default for FixedResultCollection<E, CAP> {
+    fn default() -> Self {
+        Self(Vec::with_capacity(CAP))
+    }
+}
+
+impl<O: Axis<Coord = O>, E: Ord, const CAP: usize> ResultCollection<O, E>
+    for FixedResultCollection<E, CAP>
+{
+    fn with_max_qty(_max_qty: usize) -> Self {
+        Self(Vec::with_capacity(CAP))
+    }
+    fn max_qty(&self) -> usize {
+        usize::MAX
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+    fn add(&mut self, entry: E) {
+        self.0.push(entry)
+    }
+    fn threshold_distance(&self) -> Option<O> {
+        None
+    }
+    fn into_vec(self) -> Vec<E> {
+        self.0
+    }
+    fn into_sorted_vec(self) -> Vec<E> {
+        self.0
+    }
+}
+
+/// Result collection that pre-allocates from the tree's leaf count.
+///
+/// Capacity = (leaf_count * bucket_size) / 4, reflecting that a range query
+/// typically visits 25-40% of leaves on uniform data. The worst-case kd-tree
+/// range query visits O(N^(1-1/K)) nodes (Lee & Wong, Acta Informatica 1977).
+///
+/// Constructed via `LeafCountResultCollection::with_leaf_estimate(leaves, bsize)`.
+pub struct LeafCountResultCollection<E>(Vec<E>);
+
+impl<E> LeafCountResultCollection<E> {
+    pub fn with_leaf_estimate(leaf_count: usize, bucket_size: usize) -> Self {
+        let capacity = (leaf_count * bucket_size / 4).max(64);
+        Self(Vec::with_capacity(capacity))
+    }
+}
+
+impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for LeafCountResultCollection<E> {
+    fn with_max_qty(_max_qty: usize) -> Self {
+        Self(Vec::with_capacity(64))
+    }
+    fn max_qty(&self) -> usize {
+        usize::MAX
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+    fn add(&mut self, entry: E) {
+        self.0.push(entry)
+    }
+    fn threshold_distance(&self) -> Option<O> {
+        None
+    }
+    fn into_vec(self) -> Vec<E> {
+        self.0
+    }
+    fn into_sorted_vec(self) -> Vec<E> {
+        self.0
+    }
+}
+
+/// Result collection that pre-allocates using the spatial selectivity formula.
+///
+/// capacity = N * (query_radius / bounding_box_diagonal)^K
+///
+/// From the R*-tree cost model (Beckmann et al., SIGMOD 1990, Section 4.2).
+/// Constructed via `RadiusResultCollection::with_radius_estimate::<K>(N, r, diag)`.
+pub struct RadiusResultCollection<E>(Vec<E>);
+
+impl<E> RadiusResultCollection<E> {
+    pub fn with_radius_estimate<const K: usize>(
+        dataset_size: usize,
+        radius: f64,
+        bounding_box_diagonal: f64,
+    ) -> Self {
+        let selectivity = (radius / bounding_box_diagonal).min(1.0);
+        let estimate = (dataset_size as f64 * selectivity.powi(K as i32)).ceil() as usize;
+        Self(Vec::with_capacity(estimate.max(64)))
+    }
+}
+
+impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for RadiusResultCollection<E> {
+    fn with_max_qty(_max_qty: usize) -> Self {
+        Self(Vec::with_capacity(64))
+    }
+    fn max_qty(&self) -> usize {
+        usize::MAX
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+    fn add(&mut self, entry: E) {
+        self.0.push(entry)
+    }
+    fn threshold_distance(&self) -> Option<O> {
+        None
+    }
+    fn into_vec(self) -> Vec<E> {
+        self.0
+    }
+    fn into_sorted_vec(self) -> Vec<E> {
+        self.0
+    }
+}
+
+/// Shared state for the adaptive result collection.
+///
+/// Created once before a query loop and passed to each
+/// `AdaptiveResultCollection::new()`. Converges within 3-4 queries
+/// for stable workloads, inspired by ALEX's adaptive node sizing
+/// (Ding et al., SIGMOD 2020, arXiv: 1905.08898).
+pub struct AdaptiveState {
+    observed: usize,
+    running_sum: usize,
+}
+
+impl AdaptiveState {
+    pub fn new() -> Self {
+        Self {
+            observed: 0,
+            running_sum: 0,
+        }
+    }
+
+    pub fn record(&mut self, count: usize) {
+        self.observed += 1;
+        self.running_sum += count;
+    }
+
+    fn estimate(&self) -> usize {
+        if self.observed == 0 {
+            64
+        } else {
+            (self.running_sum / self.observed).max(64)
+        }
+    }
+}
+
+/// Self-tuning result collection using a running average of observed sizes.
+///
+/// Created via `AdaptiveResultCollection::new(&mut state)`.
+pub struct AdaptiveResultCollection<E> {
+    inner: Vec<E>,
+}
+
+impl<E> AdaptiveResultCollection<E> {
+    pub fn new(state: &mut AdaptiveState) -> Self {
+        Self {
+            inner: Vec::with_capacity(state.estimate()),
+        }
+    }
+}
+
+impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for AdaptiveResultCollection<E> {
+    fn with_max_qty(_max_qty: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(64),
+        }
+    }
+    fn max_qty(&self) -> usize {
+        usize::MAX
+    }
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+    fn add(&mut self, entry: E) {
+        self.inner.push(entry)
+    }
+    fn threshold_distance(&self) -> Option<O> {
+        None
+    }
+    fn into_vec(self) -> Vec<E> {
+        self.inner
+    }
+    fn into_sorted_vec(self) -> Vec<E> {
+        self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_collection_defaults_to_capacity_64() {
+        let coll: FixedResultCollection<u32> = Default::default();
+        assert!(coll.capacity() >= 64);
+    }
+
+    #[test]
+    fn leaf_count_constructs() {
+        let _ = LeafCountResultCollection::<u32>::with_leaf_estimate(157, 32);
+    }
+
+    #[test]
+    fn radius_constructs() {
+        let _ = RadiusResultCollection::<u32>::with_radius_estimate::<1>(5000, 0.5, 10.0);
+    }
+
+    #[test]
+    fn adaptive_collection_converges() {
+        let mut state = AdaptiveState::new();
+        assert_eq!(state.estimate(), 64);
+        state.record(2000);
+        assert_eq!(state.estimate(), 2000);
+        state.record(4000);
+        assert_eq!(state.estimate(), 3000);
+    }
+}

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -1166,7 +1166,10 @@ pub mod cargo_asm {
 impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for Vec<E> {
     fn with_max_qty(max_qty: usize) -> Self {
         if max_qty == usize::MAX {
-            Vec::new()
+            // Unsorted query path: start with reasonable capacity to avoid
+            // the first several realloc waves when many candidates fall within
+            // the radius. 64 elements (1.55 KB at 24 B/elem) is negligible.
+            Vec::with_capacity(64)
         } else {
             Vec::with_capacity(max_qty)
         }


### PR DESCRIPTION
While #401 just set the minimal vector size for unsorted results, I was playing around a bit. This is just a proof of concept, not a necessity.

While `nearest_n` and `best_n_within` are bounded, `within().unsorted()` can grow to N, as talked abount in #401. For this I implemented four concrete types `ResultCollection<O, E>`. Generally we could keep it as is with `Vec::with_capacity(64)` now, or select another one of the four.

This PRs commit is as a proof of concept for making the unsorted query result buffer a configurable type parameter, analogous to `StemStrategy` and `LeafStrategy` in the tree. I did not change any default as of now. From simple to more involved:

- `FixedResultCollection` (like now): constant pre-allocation at a compile-time `CAP`. `FixedResultCollection<_, 256>` skips the first 8 `Vec` realloc waves, avoiding O(n) element copies from `Vec`'s exponential growth strategy (Brodnik et al., WADS 1999). No single constant works universally. The effectiveness depends on cardinality relative to `CAP`.
- `LeafCountResultCollection`: pre-allocates from `(leaf_count * bucket_size) / 4`, reflecting that uniform-data range queries typically visit 25-40% of leaves. The worst-case kd-tree range query visits O(N^(1-1/K)) nodes (Lee & Wong, Acta Informatica 1980). Constructed via `with_leaf_estimate(leaves, bsize)` before the query loop.
- `RadiusResultCollection`: pre-allocates using the spatial selectivity formula `N * (radius / diagonal)^K` from the R*-tree cost model (Beckmann et al., SIGMOD 1990, Section 4.2). For kd-trees the estimate is conservative since axis-aligned partitions produce non-overlapping rectangles. Constructed via `with_radius_estimate::<K>(N, r, diag)`.
- `AdaptiveResultCollection`: self-tuning via a running average of observed result sizes, inspired by ALEX's adaptive node sizing (Ding et al., SIGMOD 2020, arXiv: 1905.08898). A shared `AdaptiveState` is created before the query loop and passed to each `AdaptiveResultCollection::new()`. Converges within 3-4 queries for stable workloads. Starts at 64 (initial guess), then converges to the true cardinality.


The types are imported in `nearest_n_within.rs` and compile against the existing dispatch. Replacing `Vec<QueryResultItem<..., D::Output>>` at the two `max_qty == usize::MAX` dispatch sites with any of these types works . The import is present dmeonstratively. No builder method is added yet.

Adding this as a type would need `.with_result_collection::<R>()` to the query builder after `.within().unsorted()`, allowing callers to select a collection type at query construction time. It would follow the same pattern as `.with_scratch()`.

Again, while I think this feature would give the users another small possibility to choose what is most efficient for them, this PR can also be closed as not planned and I think it is not needed for the first stable v6.

References:

Lee & Wong, (1977): https://doi.org/10.1007/BF00263763
Beckmann et al., (1990): https://doi.org/10.1145/93597.98741
Brodnik et al., (1999): https://doi.org/10.1007/3-540-48447-7_4
Ding et al. (2020): https://doi.org/10.1145/3318464.3389711 , https://arxiv.org/abs/1905.08898