### PR TITLE
bench: add v5 eytzinger profile benchmarks

### DIFF
--- a/.github/workflows/bencher-base-benchmarks.yml
+++ b/.github/workflows/bencher-base-benchmarks.yml
@@ -1,0 +1,60 @@
+env:
+  LATEST_STABLE_RUST_VERSION: "TBD"
+
+on:
+  push:
+    branches: v5.x.x
+
+jobs:
+  benchmark_base_branch:
+    name: Continuous Benchmarking with Bencher
+    permissions:
+      checks: write
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - name: Get latest stable Rust version
+        run: |
+          echo "LATEST_STABLE_RUST_VERSION=$(gh api /repos/rust-lang/rust/releases --jq ".[0].tag_name")" >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Toolchain
+        uses: actions/cache@v6
+        with:
+          path: ~/.rustup
+          key: toolchain-x86-64-${{ env.LATEST_STABLE_RUST_VERSION }}
+
+      - name: Install `stable` Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+
+      - name: Ensure CMake is installed
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y cmake
+          fi
+          cmake --version
+
+      - uses: bencherdev/bencher@main
+      - name: Track base branch benchmarks with Bencher
+        run: |
+          bencher run \
+          --project kiddo \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
+          --branch v5.x.x \
+          --testbed ubuntu-latest \
+          --threshold-measure latency \
+          --threshold-test t_test \
+          --threshold-max-sample-size 64 \
+          --threshold-upper-boundary 0.99 \
+          --thresholds-reset \
+          --error-on-alert \
+          --adapter rust_criterion \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          "cargo bench --bench profile_v5_nearest_one_eytzinger --bench profile_v5_nearest_n_eytzinger --features test_utils -- --noplot"

--- a/.github/workflows/bencher-pr-benchmarks.yml
+++ b/.github/workflows/bencher-pr-benchmarks.yml
@@ -1,0 +1,61 @@
+env:
+  LATEST_STABLE_RUST_VERSION: "TBD"
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  benchmark_pr_branch:
+    name: Continuous Benchmarking PRs with Bencher
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      checks: write
+      pull-requests: write
+    runs-on: [self-hosted]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - name: Get latest stable Rust version
+        run: |
+          echo "LATEST_STABLE_RUST_VERSION=$(gh api /repos/rust-lang/rust/releases --jq ".[0].tag_name")" >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Toolchain
+        uses: actions/cache@v6
+        with:
+          path: ~/.rustup
+          key: toolchain-x86-64-${{ env.LATEST_STABLE_RUST_VERSION }}
+
+      - name: Install `stable` Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+
+      - name: Ensure CMake is installed
+        run: |
+          if ! command -v cmake >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y cmake
+          fi
+          cmake --version
+
+      - uses: bencherdev/bencher@main
+      - name: Track PR Benchmarks with Bencher
+        run: |
+          bencher run \
+          --project kiddo \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
+          --branch "$GITHUB_HEAD_REF" \
+          --start-point "$GITHUB_BASE_REF" \
+          --start-point-hash '${{ github.event.pull_request.base.sha }}' \
+          --start-point-clone-thresholds \
+          --start-point-reset \
+          --testbed ubuntu-latest \
+          --error-on-alert \
+          --adapter rust_criterion \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          "cargo bench --bench profile_v5_nearest_one_eytzinger --bench profile_v5_nearest_n_eytzinger --features test_utils -- --noplot"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,18 +3,24 @@ name: codspeed-benchmarks
 on:
   push:
     branches:
-      - "master"
+      - "v5.x.x"
     paths:
       - "src/**"
+      - "benches/**"
       - "Cargo.toml"
+      - "Cargo.lock"
       - ".cargo/**"
+      - ".github/workflows/codspeed.yml"
   pull_request:
     branches:
-      - "master"
+      - "v5.x.x"
     paths:
       - "src/**"
+      - "benches/**"
       - "Cargo.toml"
+      - "Cargo.lock"
       - ".cargo/**"
+      - ".github/workflows/codspeed.yml"
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,18 @@ name = "best_n"
 harness = false
 required-features = ["test_utils"]
 
+[[bench]]
+name = "profile_v5_nearest_one_eytzinger"
+path = "benches/profile_v5_nearest_one_eytzinger.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
+name = "profile_v5_nearest_n_eytzinger"
+path = "benches/profile_v5_nearest_n_eytzinger.rs"
+harness = false
+required-features = ["test_utils"]
+
 [[example]]
 name = "avx2-check"
 path = "examples/avx2-check.rs"

--- a/benches/profile_v5_nearest_n_eytzinger.rs
+++ b/benches/profile_v5_nearest_n_eytzinger.rs
@@ -1,0 +1,145 @@
+use codspeed_criterion_compat::{
+    criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
+};
+use kiddo::immutable::float::kdtree::ImmutableKdTree;
+use kiddo::SquaredEuclidean;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+use std::num::NonZero;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+const TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
+const MAX_QTYS: [usize; 3] = [5, 20, 50];
+
+type F64Tree = ImmutableKdTree<f64, u32, K, B>;
+type F32Tree = ImmutableKdTree<f32, u32, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn run_queries_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    max_qty: NonZero<usize>,
+) -> (usize, f64, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree.nearest_n::<SquaredEuclidean>(black_box(query), max_qty);
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_queries_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    max_qty: NonZero<usize>,
+) -> (usize, f32, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree.nearest_n::<SquaredEuclidean>(black_box(query), max_qty);
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn nearest_n(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+
+    eprintln!(
+        "benchmarking v5 nearest_n: dims={} tree_sizes=2^16..2^26 queries={} ks={:?} point_seed={} query_seed={}",
+        K, query_count, MAX_QTYS, POINT_SEED, QUERY_SEED
+    );
+
+    let f64_queries = build_queries_f64(query_count);
+    let mut f64_group = c.benchmark_group("profile_v5_nearest_n_eytzinger/f64");
+    f64_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f64(point_count);
+        let tree: F64Tree = ImmutableKdTree::new_from_slice(&points);
+        for max_qty in MAX_QTYS {
+            let max_qty = NonZero::new(max_qty).unwrap();
+            f64_group.bench_function(
+                BenchmarkId::new(format!("nearest_n_k{}", max_qty), point_count),
+                |b| b.iter(|| black_box(run_queries_f64(&tree, &f64_queries, max_qty))),
+            );
+        }
+    }
+    f64_group.finish();
+
+    let f32_queries = build_queries_f32(query_count);
+    let mut f32_group = c.benchmark_group("profile_v5_nearest_n_eytzinger/f32");
+    f32_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f32(point_count);
+        let tree: F32Tree = ImmutableKdTree::new_from_slice(&points);
+        for max_qty in MAX_QTYS {
+            let max_qty = NonZero::new(max_qty).unwrap();
+            f32_group.bench_function(
+                BenchmarkId::new(format!("nearest_n_k{}", max_qty), point_count),
+                |b| b.iter(|| black_box(run_queries_f32(&tree, &f32_queries, max_qty))),
+            );
+        }
+    }
+    f32_group.finish();
+}
+
+criterion_group!(benches, nearest_n);
+criterion_main!(benches);

--- a/benches/profile_v5_nearest_one_eytzinger.rs
+++ b/benches/profile_v5_nearest_one_eytzinger.rs
@@ -1,0 +1,119 @@
+use codspeed_criterion_compat::{
+    criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
+};
+use kiddo::immutable::float::kdtree::ImmutableKdTree;
+use kiddo::SquaredEuclidean;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+const TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
+
+type F64Tree = ImmutableKdTree<f64, u32, K, B>;
+type F32Tree = ImmutableKdTree<f32, u32, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn run_queries_f64(tree: &F64Tree, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree.nearest_one::<SquaredEuclidean>(black_box(query));
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_queries_f32(tree: &F32Tree, queries: &[[f32; K]]) -> (f32, u64) {
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree.nearest_one::<SquaredEuclidean>(black_box(query));
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn nearest_one(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+
+    eprintln!(
+        "benchmarking v5 nearest_one: dims={} tree_sizes=2^16..2^26 queries={} point_seed={} query_seed={}",
+        K, query_count, POINT_SEED, QUERY_SEED
+    );
+
+    let f64_queries = build_queries_f64(query_count);
+    let mut f64_group = c.benchmark_group("profile_v5_nearest_one_eytzinger/f64");
+    f64_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f64(point_count);
+        let tree: F64Tree = ImmutableKdTree::new_from_slice(&points);
+        f64_group.bench_function(BenchmarkId::new("nearest_one", point_count), |b| {
+            b.iter(|| black_box(run_queries_f64(&tree, &f64_queries)));
+        });
+    }
+    f64_group.finish();
+
+    let f32_queries = build_queries_f32(query_count);
+    let mut f32_group = c.benchmark_group("profile_v5_nearest_one_eytzinger/f32");
+    f32_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f32(point_count);
+        let tree: F32Tree = ImmutableKdTree::new_from_slice(&points);
+        f32_group.bench_function(BenchmarkId::new("nearest_one", point_count), |b| {
+            b.iter(|| black_box(run_queries_f32(&tree, &f32_queries)));
+        });
+    }
+    f32_group.finish();
+}
+
+criterion_group!(benches, nearest_one);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add profile_v5 immutable-tree nearest_one and nearest_n benchmark suites for f32/f64, 3D, and tree sizes 2^16 through 2^26
- cover nearest_n with k = 5, 20, and 50 so both short-result and standard collection paths are exercised
- add Bencher workflows for the v5.x.x branch and update CodSpeed triggers so these benchmark changes run in CI

## Verification
- cargo fmt --check
- cargo bench --bench profile_v5_nearest_one_eytzinger --bench profile_v5_nearest_n_eytzinger --features test_utils --no-run
- reduced sample run of profile_v5_nearest_n_eytzinger with KIDDO_PROFILE_QUERIES=50