### PR TITLE
ci: ensure git-cliff emits well-formatted md

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,41 +25,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           show-progress: false
-          fetch-depth: 1
 
       - name: Detect source changes
+        # Coverage is relevant when library code or integration tests change.
         id: changes
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            base_sha="${{ github.event.pull_request.base.sha }}"
-            head_sha="${{ github.event.pull_request.head.sha }}"
-          else
-            base_sha="${{ github.event.before }}"
-            head_sha="${{ github.sha }}"
-          fi
-
-          # First push to a branch can have an empty/zero before SHA; run coverage in that case.
-          if [[ -z "$base_sha" || "$base_sha" == "0000000000000000000000000000000000000000" ]]; then
-            echo "coverage=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --depth=1 origin "$base_sha"
-          fi
-
-          if ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --depth=1 origin "$head_sha"
-          fi
-
-          if git diff --name-only "$base_sha" "$head_sha" -- 'src/**' 'tests/**' | grep -q .; then
-            echo "coverage=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "coverage=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            coverage:
+              - 'src/**'
+              - 'tests/**'
 
       - name: Get date
         if: steps.changes.outputs.coverage == 'true'

--- a/git-cliff.toml
+++ b/git-cliff.toml
@@ -20,11 +20,11 @@ body = """
     {% for commit in commits %}
         - {{ commit.message | upper_first }}\
           {%- if commit.remote and commit.remote.username and commit.remote.pr_number and remote.github %}
-            [\\[@{{ commit.remote.username }}, #{{ commit.remote.pr_number }}\\]](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/pull/{{ commit.remote.pr_number }})\
+            \n  [\\[@{{ commit.remote.username }}, #{{ commit.remote.pr_number }}\\]](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/pull/{{ commit.remote.pr_number }})\
           {%- elif commit.remote and commit.remote.username %}
-            [\\[@{{ commit.remote.username }}\\]](https://github.com/{{ commit.remote.username }})\
+            \n  [\\[@{{ commit.remote.username }}\\]](https://github.com/{{ commit.remote.username }})\
           {%- elif commit.author and commit.author.name %}
-            [{{ commit.author.name }}]\
+            \n  [{{ commit.author.name }}]\
           {%- endif %}\
           {% for footer in commit.footers -%}
             , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\


### PR DESCRIPTION
revert to dornt/paths-filter again too now that
the github API is behaving