### PR TITLE
ci: rank featured chart by relative change

### DIFF
--- a/scripts/chart_benchmark_results.py
+++ b/scripts/chart_benchmark_results.py
@@ -253,8 +253,10 @@ def change_score(baseline: list[Point], variant: list[Point]) -> float:
     for baseline_point, variant_point in zip(baseline, variant):
         if baseline_point.tree_log2 != variant_point.tree_log2:
             raise RuntimeError("cannot score series with mismatched tree sizes")
-        delta = variant_point.duration_ns - baseline_point.duration_ns
-        score += delta * delta
+        delta_fraction = (
+            variant_point.duration_ns - baseline_point.duration_ns
+        ) / baseline_point.duration_ns
+        score += delta_fraction * delta_fraction
     return score
 
 


### PR DESCRIPTION
## Summary
- change the featured PR comment chart scoring from absolute squared delta to squared relative delta
- make the inline chart selection reflect the benchmark with the largest proportional baseline change

## Validation
- python3 -m py_compile scripts/chart_benchmark_results.py
- recomputed the published PR 430 run against its linked result JSON files
- verified profile_v6_nearest_one_eytzinger/f64 nearest_one now ranks highest
