### PR TITLE
chore: release v6.0.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Kiddo Changelog
 
+## [6.0.0-alpha.3] - 2026-07-21
+
+### ✨ Features
+
+- Make local query scratch the default ([@sdd](https://github.com/sdd))
+
+
+### 🐛 Bug Fixes
+
+- Remove broken dot product dist metric and associated code ([@sdd](https://github.com/sdd))
+
+
+### ⚡️ Performance
+
+- Alternate path to avoid wasted calcs on descent ([@sdd](https://github.com/sdd))
+
+- Add IS_SIGNED assoc value to Axis ([@sdd](https://github.com/sdd))
+
+- Dist1 on Manhattan and Chebyshev use saturating_dist ([@sdd](https://github.com/sdd))
+
+- Improved offset update for Chebyshev and Manhattah ([@sdd](https://github.com/sdd))
+
+- Use fused linear insertion for threshold vec results ([@sdd](https://github.com/sdd))
+
+- Tune sorted and unsorted threshold vec limits ([@sdd](https://github.com/sdd))
+
+
+### 🤖 CI
+
+- Harden pre-release string updater workflow against no changes ([@sdd](https://github.com/sdd))
+
+- Publish custom benchmark reports ([@sdd](https://github.com/sdd))
+
+- Add bench chart justfile tasks ([@sdd](https://github.com/sdd))
+
+- Fix benchmark workflow bootstrap ([@sdd](https://github.com/sdd))
+
+- Derive benchmark key without just ([@sdd](https://github.com/sdd))
+
+- Pass benchmark args to just correctly ([@sdd](https://github.com/sdd))
+
+- Pass benchmark recipe arguments positionally ([@sdd](https://github.com/sdd))
+
+- Authenticate initial benchmark pages push ([@sdd](https://github.com/sdd))
+
+- Rank featured chart by relative change ([@sdd](https://github.com/sdd))
+
+- Add distance metric ISA matrix ([@sdd](https://github.com/sdd))
+
+- Fix distance metric ISA benchmark builds ([@sdd](https://github.com/sdd))
+
+- Simplify benchmark workflows ([@sdd](https://github.com/sdd))
+
+- Fix benchmark workflow shellcheck ([@sdd](https://github.com/sdd))
+
+- Suggest benchmarks for performance-sensitive PRs ([@sdd](https://github.com/sdd))
+
+- Use heuristic benchmark suggestions ([@sdd](https://github.com/sdd))
+
+- Allow benchmark suggestion comment updates ([@sdd](https://github.com/sdd))
+
+- Add leaf strategy benchmark variant ([@sdd](https://github.com/sdd))
+
+- Allow org members to trigger benchmark runs ([@sdd](https://github.com/sdd))
+
+- Clarify benchmark run names ([@sdd](https://github.com/sdd))
+
+- Split nightly debug and release tests ([@sdd](https://github.com/sdd))
+
+
+### 🧹 Chore
+
+- Bump actions/setup-node from 6 to 7 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
+- Update las requirement in the cargo-dependencies group ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
 ## [6.0.0-alpha.2] - 2026-07-17
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@
 
 - Make local query scratch the default ([@sdd](https://github.com/sdd))
 
-
 ### 🐛 Bug Fixes
 
 - Remove broken dot product dist metric and associated code ([@sdd](https://github.com/sdd))
-
 
 ### ⚡️ Performance
 
@@ -25,7 +23,6 @@
 - Use fused linear insertion for threshold vec results ([@sdd](https://github.com/sdd))
 
 - Tune sorted and unsorted threshold vec limits ([@sdd](https://github.com/sdd))
-
 
 ### 🤖 CI
 
@@ -68,7 +65,6 @@
 - Clarify benchmark run names ([@sdd](https://github.com/sdd))
 
 - Split nightly debug and release tests ([@sdd](https://github.com/sdd))
-
 
 ### 🧹 Chore
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "6.0.0-alpha.2"
+version = "6.0.0-alpha.3"
 edition = "2021"
 rust-version = "1.89.0"
 authors = ["Scott Donnelly <scott@donnel.ly>"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add `kiddo` to `Cargo.toml`
 
 ```toml
 [dependencies]
-kiddo = "6.0.0-alpha.2"
+kiddo = "6.0.0-alpha.3"
 ```
 
 Add points to a k-d tree and query the nearest points with a distance metric:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/6.0.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/kiddo/6.0.0-alpha.3")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 #![allow(clippy::pointers_in_nomem_asm_block)]
 #![allow(clippy::too_many_arguments)]
@@ -105,7 +105,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "6.0.0-alpha.2"
+//! kiddo = "6.0.0-alpha.3"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION



## 🤖 New release

* `kiddo`: 6.0.0-alpha.2 -> 6.0.0-alpha.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.0-alpha.3] - 2026-07-21

### ✨ Features

- Make local query scratch the default ([@sdd](https://github.com/sdd))


### 🐛 Bug Fixes

- Remove broken dot product dist metric and associated code ([@sdd](https://github.com/sdd))


### ⚡️ Performance

- Alternate path to avoid wasted calcs on descent ([@sdd](https://github.com/sdd))

- Add IS_SIGNED assoc value to Axis ([@sdd](https://github.com/sdd))

- Dist1 on Manhattan and Chebyshev use saturating_dist ([@sdd](https://github.com/sdd))

- Improved offset update for Chebyshev and Manhattah ([@sdd](https://github.com/sdd))

- Use fused linear insertion for threshold vec results ([@sdd](https://github.com/sdd))

- Tune sorted and unsorted threshold vec limits ([@sdd](https://github.com/sdd))


### 🤖 CI

- Harden pre-release string updater workflow against no changes ([@sdd](https://github.com/sdd))

- Publish custom benchmark reports ([@sdd](https://github.com/sdd))

- Add bench chart justfile tasks ([@sdd](https://github.com/sdd))

- Fix benchmark workflow bootstrap ([@sdd](https://github.com/sdd))

- Derive benchmark key without just ([@sdd](https://github.com/sdd))

- Pass benchmark args to just correctly ([@sdd](https://github.com/sdd))

- Pass benchmark recipe arguments positionally ([@sdd](https://github.com/sdd))

- Authenticate initial benchmark pages push ([@sdd](https://github.com/sdd))

- Rank featured chart by relative change ([@sdd](https://github.com/sdd))

- Add distance metric ISA matrix ([@sdd](https://github.com/sdd))

- Fix distance metric ISA benchmark builds ([@sdd](https://github.com/sdd))

- Simplify benchmark workflows ([@sdd](https://github.com/sdd))

- Fix benchmark workflow shellcheck ([@sdd](https://github.com/sdd))

- Suggest benchmarks for performance-sensitive PRs ([@sdd](https://github.com/sdd))

- Use heuristic benchmark suggestions ([@sdd](https://github.com/sdd))

- Allow benchmark suggestion comment updates ([@sdd](https://github.com/sdd))

- Add leaf strategy benchmark variant ([@sdd](https://github.com/sdd))

- Allow org members to trigger benchmark runs ([@sdd](https://github.com/sdd))

- Clarify benchmark run names ([@sdd](https://github.com/sdd))

- Split nightly debug and release tests ([@sdd](https://github.com/sdd))


### 🧹 Chore

- Bump actions/setup-node from 6 to 7 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)

- Update las requirement in the cargo-dependencies group ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).