### PR TITLE
ci: use heuristic benchmark suggestions

### DIFF
--- a/.github/workflows/benchmark-suggestion.yml
+++ b/.github/workflows/benchmark-suggestion.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   issues: write
-  models: read
   pull-requests: read
 
 jobs:
@@ -18,17 +17,12 @@ jobs:
         uses: actions/github-script@v9
         env:
           BENCHMARK_COMMENT_MARKER: "<!-- kiddo-benchmark-suggestion -->"
-          GITHUB_TOKEN: ${{ github.token }}
         with:
           script: |
             const marker = process.env.BENCHMARK_COMMENT_MARKER;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pull_number = context.payload.pull_request.number;
-            const token = process.env.GITHUB_TOKEN;
-
-            const MAX_FILES = 40;
-            const MAX_PATCH_CHARS = 1800;
 
             const { data: pr } = await github.rest.pulls.get({
               owner,
@@ -48,34 +42,13 @@ jobs:
               per_page: 100,
             });
 
-            const truncatedFiles = files.slice(0, MAX_FILES).map((file) => ({
-              filename: file.filename,
-              status: file.status,
-              additions: file.additions,
-              deletions: file.deletions,
-              changes: file.changes,
-              patch: file.patch ? file.patch.slice(0, MAX_PATCH_CHARS) : null,
-            }));
-
-            const fileSummaries = truncatedFiles
-              .map((file) => {
-                const parts = [
-                  `file: ${file.filename}`,
-                  `status: ${file.status}`,
-                  `changes: +${file.additions} -${file.deletions}`,
-                ];
-                if (file.patch) {
-                  parts.push(`patch:\n${file.patch}`);
-                }
-                return parts.join("\n");
-              })
-              .join("\n\n---\n\n");
+            const changedFiles = files.map((file) => file.filename);
 
             const benchmarkOptions = await github.rest.repos.getContent({
               owner,
               repo,
               path: "AVAILABLE_CI_BENCHMARK_OPTIONS.md",
-              ref: pr.base.ref,
+              ref: pr.head.sha,
             });
 
             if (!("content" in benchmarkOptions.data)) {
@@ -88,111 +61,118 @@ jobs:
               "base64"
             ).toString("utf8");
 
-            const prompt = [
-              "You are reviewing a pull request for a high-performance Rust kd-tree library.",
-              "Decide whether the PR should receive a comment suggesting a benchmark command.",
-              "Use AVAILABLE_CI_BENCHMARK_OPTIONS.md as the authoritative guide.",
-              "Prefer no suggestion unless there is a plausible performance impact.",
-              "Return JSON only with this exact shape:",
-              '{"should_suggest":true,"command":"/benchmark","reason":"short reason","confidence":"high"}',
-              'Valid command values: "/benchmark", "/benchmark dist", or null.',
-              'Valid confidence values: "high", "medium", or "low".',
-              "Do not wrap the JSON in markdown fences.",
-              "",
-              "AVAILABLE_CI_BENCHMARK_OPTIONS.md:",
-              benchmarkOptionsText,
-              "",
-              "Pull request metadata:",
-              JSON.stringify(
-                {
-                  title: pr.title,
-                  body: pr.body,
-                  base_ref: pr.base.ref,
-                  head_ref: pr.head.ref,
-                  changed_files: pr.changed_files,
-                },
-                null,
-                2
-              ),
-              "",
-              `Changed files analyzed (${truncatedFiles.length}${files.length > truncatedFiles.length ? ` of ${files.length}` : ""}):`,
-              fileSummaries,
-            ].join("\n");
-
-            const response = await fetch("https://models.github.ai/inference/chat/completions", {
-              method: "POST",
-              headers: {
-                Accept: "application/vnd.github+json",
-                Authorization: `Bearer ${token}`,
-                "Content-Type": "application/json",
-                "X-GitHub-Api-Version": "2026-03-10",
-              },
-              body: JSON.stringify({
-                model: "openai/gpt-4.1-mini",
-                temperature: 0.1,
-                max_tokens: 300,
-                messages: [
-                  {
-                    role: "system",
-                    content:
-                      "You classify pull requests for benchmark reminder comments. Be conservative and return valid JSON only.",
-                  },
-                  {
-                    role: "user",
-                    content: prompt,
-                  },
-                ],
-              }),
-            });
-
-            if (!response.ok) {
-              const body = await response.text();
-              core.setFailed(`Model inference failed: ${response.status} ${body}`);
+            const yamlMatch = benchmarkOptionsText.match(/```yaml\n([\s\S]*?)\n```/);
+            if (!yamlMatch) {
+              core.setFailed(
+                "AVAILABLE_CI_BENCHMARK_OPTIONS.md does not contain a parseable YAML code block."
+              );
               return;
             }
 
-            const payload = await response.json();
-            const message = payload?.choices?.[0]?.message?.content;
-            const content = Array.isArray(message)
-              ? message.map((part) => part?.text ?? "").join("")
-              : message;
+            const parseRules = (yamlText) => {
+              const rules = [];
+              let currentRule = null;
+              let inMatchAny = false;
 
-            if (typeof content !== "string") {
-              core.setFailed("Model response did not include string content.");
-              return;
-            }
+              for (const rawLine of yamlText.split("\n")) {
+                const line = rawLine.replace(/\s+$/, "");
 
-            let decision;
-            try {
-              decision = JSON.parse(content);
-            } catch (error) {
-              core.setFailed(`Failed to parse model response as JSON: ${content}`);
-              return;
-            }
+                if (line === "" || line === "rules:") {
+                  continue;
+                }
 
-            const normalized = {
-              should_suggest: Boolean(decision.should_suggest),
-              command: decision.command,
-              reason:
-                typeof decision.reason === "string" ? decision.reason.trim() : "",
-              confidence:
-                typeof decision.confidence === "string"
-                  ? decision.confidence.toLowerCase()
-                  : "",
+                const commandMatch = line.match(/^  - command:\s*(.+)$/);
+                if (commandMatch) {
+                  currentRule = {
+                    command:
+                      commandMatch[1] === "null" ? null : commandMatch[1],
+                    reason: "",
+                    match_any: [],
+                  };
+                  rules.push(currentRule);
+                  inMatchAny = false;
+                  continue;
+                }
+
+                if (currentRule === null) {
+                  throw new Error(`Unexpected line before first rule: ${line}`);
+                }
+
+                const reasonMatch = line.match(/^    reason:\s*(.+)$/);
+                if (reasonMatch) {
+                  currentRule.reason = reasonMatch[1];
+                  inMatchAny = false;
+                  continue;
+                }
+
+                if (line === "    match_any:") {
+                  inMatchAny = true;
+                  continue;
+                }
+
+                const patternMatch = line.match(/^      -\s*(.+)$/);
+                if (patternMatch && inMatchAny) {
+                  const pattern = patternMatch[1].replace(/^"(.*)"$/, "$1");
+                  currentRule.match_any.push(pattern);
+                  continue;
+                }
+
+                throw new Error(`Could not parse rule line: ${line}`);
+              }
+
+              return rules;
             };
 
-            const validCommands = new Set(["/benchmark", "/benchmark dist", null]);
-            const validConfidence = new Set(["high", "medium", "low"]);
-
-            if (!validCommands.has(normalized.command)) {
-              core.setFailed(`Model returned invalid command: ${normalized.command}`);
+            let rules;
+            try {
+              rules = parseRules(yamlMatch[1]);
+            } catch (error) {
+              core.setFailed(`Failed to parse benchmark options YAML: ${error.message}`);
               return;
             }
 
-            if (!validConfidence.has(normalized.confidence)) {
-              core.setFailed(
-                `Model returned invalid confidence: ${normalized.confidence}`
-              );
+            if (rules.length === 0) {
+              core.setFailed("No benchmark suggestion rules were found.");
+              return;
+            }
+
+            const escapeRegex = (value) =>
+              value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+
+            const globToRegExp = (glob) => {
+              let pattern = escapeRegex(glob);
+              pattern = pattern.replace(/\*\*/g, "::DOUBLE_STAR::");
+              pattern = pattern.replace(/\*/g, "[^/]*");
+              pattern = pattern.replace(/::DOUBLE_STAR::/g, ".*");
+              return new RegExp(`^${pattern}$`);
+            };
+
+            const matchers = rules.map((rule, index) => {
+              if (!Array.isArray(rule?.match_any) || rule.match_any.length === 0) {
+                throw new Error(`Rule ${index + 1} is missing match_any patterns.`);
+              }
+
+              return {
+                command: rule.command ?? null,
+                reason:
+                  typeof rule.reason === "string"
+                    ? rule.reason.trim()
+                    : "Potential impact area matches this benchmark rule.",
+                patterns: rule.match_any.map((pattern) => ({
+                  raw: pattern,
+                  regex: globToRegExp(pattern),
+                })),
+              };
+            });
+
+            const matchedRule = matchers.find((rule) =>
+              changedFiles.some((file) =>
+                rule.patterns.some((pattern) => pattern.regex.test(file))
+              )
+            );
+
+            if (!matchedRule) {
+              core.info("No benchmark suggestion rule matched.");
               return;
             }
 
@@ -211,9 +191,7 @@ jobs:
             );
 
             if (
-              !normalized.should_suggest ||
-              normalized.command === null ||
-              normalized.confidence === "low"
+              matchedRule.command === null
             ) {
               if (existingComment) {
                 await github.rest.issues.deleteComment({
@@ -232,9 +210,9 @@ jobs:
               marker,
               "Performance impact looks plausible here.",
               "",
-              `Suggested command: \`${normalized.command}\``,
+              `Suggested command: \`${matchedRule.command}\``,
               "",
-              `Why: ${normalized.reason || "Potential impact area matches this benchmark suite."}`,
+              `Why: ${matchedRule.reason}`,
               "",
               "_This is an automated suggestion based on the PR diff and `AVAILABLE_CI_BENCHMARK_OPTIONS.md`._",
             ].join("\n");

--- a/AVAILABLE_CI_BENCHMARK_OPTIONS.md
+++ b/AVAILABLE_CI_BENCHMARK_OPTIONS.md
@@ -2,44 +2,34 @@
 
 This file is the authoritative guide for choosing which benchmark command, if any, should be suggested for a pull request.
 
-Prefer no suggestion unless the changed code has a plausible performance impact.
+The workflow reads the YAML block below.
 
-## `/benchmark`
+- Rules are evaluated in order, top to bottom.
+- The first matching rule wins.
+- Put the most specific rules first.
+- Use `command: null` for "no suggestion".
 
-Suggest `/benchmark` when the change is most likely to affect the main query and traversal hot paths, especially:
+```yaml
+rules:
+  - command: /benchmark dist
+    reason: Changes under `src/dist/` can affect distance metric performance.
+    match_any:
+      - src/dist/**
 
-- tree traversal logic
-- nearest-neighbour query logic
-- branch layout or cache-locality-sensitive code
-- Eytzinger-specific code
-- benchmark harness changes that primarily affect the Eytzinger-focused benchmark suite
-- other performance-sensitive changes where the Eytzinger-focused suite is the closest fit
+  - command: /benchmark
+    reason: Changes under `src/` or to `Cargo.toml` can affect core runtime performance.
+    match_any:
+      - src/**
+      - Cargo.toml
 
-## `/benchmark dist`
+  - command: null
+    reason: No benchmark suggestion is needed when none of the higher-priority rules match.
+    match_any:
+      - "**"
+```
 
-Suggest `/benchmark dist` when the change is most likely to affect distance metric computation or pruning behavior driven by the metric, especially:
+## Notes
 
-- code under `src/dist/`
-- metric-specific pruning logic
-- ISA-specific distance implementations
-- metric widening, accumulation, or comparison changes
-- benchmark harness changes that primarily affect the distance-metrics benchmark suite
-
-## No Benchmark Suggestion
-
-Do not suggest a benchmark command for changes that are unlikely to affect runtime performance, for example:
-
-- documentation
-- changelog updates
-- release automation
-- formatting-only changes
-- CI-only changes unrelated to benchmark execution
-- refactors that do not change hot-path behavior
-- tests added around unchanged implementation code
-
-## Decision Rules
-
-- If the change plausibly affects both categories, choose the command that best matches the dominant risk area.
-- If the impact is broad but primarily query/traversal-oriented, prefer `/benchmark`.
-- If the impact is speculative or weak, prefer no suggestion.
-- The workflow should suggest at most one benchmark command.
+- `/benchmark dist` is reserved for distance-metric-focused changes and should stay above broader rules.
+- `/benchmark` is the default benchmark suggestion for general source changes.
+- If you add more benchmark commands later, insert the more specific ones above the broader defaults.


### PR DESCRIPTION
## Summary
- replace the GitHub Models benchmark suggestion workflow with a deterministic heuristic workflow
- make `AVAILABLE_CI_BENCHMARK_OPTIONS.md` partly machine-readable with ordered first-match rules
- default to `/benchmark dist` for `src/dist/**` changes and `/benchmark` for `src/**` or `Cargo.toml` changes

## Testing
- parsed `.github/workflows/benchmark-suggestion.yml` with Ruby YAML
- verified the new branch is based on current `master`
