### PR TITLE
ci: allow benchmark suggestion comment updates

### DIFF
--- a/.github/workflows/benchmark-suggestion.yml
+++ b/.github/workflows/benchmark-suggestion.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   suggest-benchmark:


### PR DESCRIPTION
## Summary
- grant the `benchmark-suggestion` workflow `pull-requests: write` in addition to `issues: write`
- keep the rest of the heuristic benchmark suggestion flow unchanged

## Why
The workflow was able to analyze the PR but failed with `Resource not accessible by integration` when posting the suggestion comment.

## Testing
- parsed `.github/workflows/benchmark-suggestion.yml` with Ruby YAML
