### PR TITLE
ci: add leaf strategy benchmark variant

### DIFF
--- a/.github/workflows/benchmark-report-dispatch.yml
+++ b/.github/workflows/benchmark-report-dispatch.yml
@@ -24,11 +24,16 @@ jobs:
             const comment = context.payload.comment;
             const body = comment.body.trim();
             const association = comment.author_association;
-            const allowedAssociations = new Set(["OWNER", "COLLABORATOR", "CONTRIBUTOR"]);
+            const allowedAssociations = new Set([
+              "OWNER",
+              "MEMBER",
+              "COLLABORATOR",
+              "CONTRIBUTOR",
+            ]);
 
             if (!allowedAssociations.has(association)) {
               core.setFailed(
-                `/${"benchmark"} requires OWNER, COLLABORATOR, or CONTRIBUTOR status. ${comment.user.login} is ${association}.`
+                `/${"benchmark"} requires OWNER, MEMBER, COLLABORATOR, or CONTRIBUTOR status. ${comment.user.login} is ${association}.`
               );
               return;
             }

--- a/.github/workflows/benchmark-report-dispatch.yml
+++ b/.github/workflows/benchmark-report-dispatch.yml
@@ -38,8 +38,10 @@ jobs:
               benchmarkVariant = "eytzinger";
             } else if (body === "/benchmark dist") {
               benchmarkVariant = "dist";
+            } else if (body === "/benchmark leaf") {
+              benchmarkVariant = "leaf";
             } else {
-              core.setFailed("Unsupported benchmark command. Use `/benchmark` or `/benchmark dist`.");
+              core.setFailed("Unsupported benchmark command. Use `/benchmark`, `/benchmark dist`, or `/benchmark leaf`.");
               return;
             }
 
@@ -64,7 +66,11 @@ jobs:
             });
 
             const benchmarkLabel =
-              benchmarkVariant === "dist" ? "dist-focussed" : "eytzinger-focus";
+              benchmarkVariant === "dist"
+                ? "dist-focussed"
+                : benchmarkVariant === "leaf"
+                  ? "leaf-strategy"
+                  : "eytzinger-focus";
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -40,6 +40,7 @@ on:
         options:
           - eytzinger
           - dist
+          - leaf
 
 concurrency:
   group: benchmark-report-${{ inputs.head_ref || github.ref_name }}-${{ inputs.benchmark_variant || 'eytzinger' }}
@@ -126,6 +127,13 @@ jobs:
               just bench-v6-dist-metrics \
                 "${{ steps.meta.outputs.variant_key }}" \
                 ./target/benchmark-results \
+                1000
+              ;;
+            leaf)
+              just bench-v6-leaf-strategies \
+                "${{ steps.meta.outputs.variant_key }}" \
+                ./target/benchmark-results \
+                simd,test_utils,logging_off \
                 1000
               ;;
             *)

--- a/AVAILABLE_CI_BENCHMARK_OPTIONS.md
+++ b/AVAILABLE_CI_BENCHMARK_OPTIONS.md
@@ -16,6 +16,11 @@ rules:
     match_any:
       - src/dist/**
 
+  - command: /benchmark leaf
+    reason: Changes under `src/kd_tree/leaf_strategies/` can affect leaf strategy performance.
+    match_any:
+      - src/kd_tree/leaf_strategies/**
+
   - command: /benchmark
     reason: Changes under `src/` or to `Cargo.toml` can affect core runtime performance.
     match_any:
@@ -31,5 +36,6 @@ rules:
 ## Notes
 
 - `/benchmark dist` is reserved for distance-metric-focused changes and should stay above broader rules.
+- `/benchmark leaf` is reserved for leaf-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark` is the default benchmark suggestion for general source changes.
 - If you add more benchmark commands later, insert the more specific ones above the broader defaults.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,12 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "profile_v6_leaf_strategies_criterion"
+path = "benches/profile_v6_leaf_strategies_criterion.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "profile_v6_stem_exact_stats"
 path = "benches/profile_v6_stem_exact_stats.rs"
 harness = false

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -1,0 +1,124 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::{FlatVec, VecOfArenas, VecOfArrays};
+use kiddo::stem_strategy::Eytzinger;
+use kiddo::SquaredEuclidean;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
+const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
+
+type FlatTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
+type ArenaTree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, K, B>, K, B>;
+type VecOfArraysTree = KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, K, B>, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn build_points(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn run_queries_flat(tree: &FlatTree, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_queries_arena(tree: &ArenaTree, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_queries_vec_of_arrays(tree: &VecOfArraysTree, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn leaf_strategies(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+
+    eprintln!(
+        "benchmarking v6 leaf strategies: dims={} tree_sizes=2^16,2^18,...,2^26 queries={} point_seed={} query_seed={}",
+        K, query_count, POINT_SEED, QUERY_SEED
+    );
+
+    let queries = build_queries(query_count);
+    let mut group = c.benchmark_group("profile_v6_leaf_strategies/f64");
+    group.throughput(Throughput::Elements(query_count as u64));
+
+    for point_count in TREE_SIZES {
+        let points = build_points(point_count);
+
+        let flat_tree: FlatTree = KdTree::new_from_slice(&points).unwrap();
+        group.bench_function(BenchmarkId::new("flat", point_count), |b| {
+            b.iter(|| black_box(run_queries_flat(&flat_tree, &queries)))
+        });
+
+        let arena_tree: ArenaTree = KdTree::new_from_slice(&points).unwrap();
+        group.bench_function(BenchmarkId::new("arena", point_count), |b| {
+            b.iter(|| black_box(run_queries_arena(&arena_tree, &queries)))
+        });
+
+        let vec_of_arrays_tree: VecOfArraysTree = KdTree::new_from_slice(&points).unwrap();
+        group.bench_function(BenchmarkId::new("vec_of_arrays", point_count), |b| {
+            b.iter(|| black_box(run_queries_vec_of_arrays(&vec_of_arrays_tree, &queries)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, leaf_strategies);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -197,6 +197,27 @@ bench-v6-dist-metrics RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='10
     run_mode avx2 "-C target-cpu=x86-64-v2 -C target-feature=+avx2" "$simd_features"
     run_mode avx512 "-C target-cpu=native" "$simd_features"
 
+bench-v6-leaf-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES='1000':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_v6_leaf_strategies_criterion \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-v6-leaf-strategies-${result_key}.json" \
+        profile_v6_leaf_strategies_criterion
+
 chart-benchmark-results VARIANT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
     {{quote(PYTHON)}} scripts/chart_benchmark_results.py {{quote(VARIANT_KEY)}} --results-dir {{quote(RESULTS_DIR)}} --output-dir {{quote(OUTPUT_DIR)}}
 


### PR DESCRIPTION
## Summary
- add a new `/benchmark leaf` CI dispatch option for comparing the three leaf strategies
- add a criterion-based leaf strategy benchmark target so benchmark-report can export chartable results
- extend the benchmark suggestion rules so leaf-strategy changes suggest `/benchmark leaf`

## Testing
- parsed workflow YAML with Ruby
- `cargo check --bench profile_v6_leaf_strategies_criterion --features simd,test_utils,logging_off`
