### PR TITLE
ci: split nightly debug and release tests

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -74,13 +74,14 @@ jobs:
       - name: Cargo Hack (check all targets and features)
         run: cargo hack check --workspace --each-feature --all-targets
 
-  test-nightly:
-    name: Test (Nightly)
+  test-nightly-debug:
+    name: Test (Nightly / Debug)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
     env:
+      CARGO_TARGET_DIR: target/nightly-debug
       RUSTFLAGS: "-C target-feature=+avx2"
     steps:
       - uses: actions/checkout@v7
@@ -99,6 +100,14 @@ jobs:
           path: ~/.rustup
           key: toolchain-x86-64-nightly-${{ env.TODAY_DATE }}
 
+      - name: Cache Cargo target dir (Debug)
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}
+          key: nightly-target-${{ runner.os }}-${{ env.TODAY_DATE }}-debug-${{ hashFiles('Cargo.lock', '.github/workflows/build-nightly.yml') }}
+          restore-keys: |
+            nightly-target-${{ runner.os }}-${{ env.TODAY_DATE }}-debug-
+
       - name: Install `nightly` Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -115,10 +124,66 @@ jobs:
         run: |
           cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
 
+      - name: Cargo test (Doctests)
+        run: |
+          cargo test --workspace --doc --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
+
+  test-nightly-release:
+    name: Test (Nightly / Release)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    env:
+      CARGO_TARGET_DIR: target/nightly-release
+      RUSTFLAGS: "-C target-feature=+avx2"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - name: Get date
+        run: |
+          echo "TODAY_DATE=$(date -Idate)" >> "$GITHUB_ENV"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Toolchain
+        uses: actions/cache@v6
+        with:
+          path: ~/.rustup
+          key: toolchain-x86-64-nightly-${{ env.TODAY_DATE }}
+
+      - name: Cache Cargo target dir (Release)
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}
+          key: nightly-target-${{ runner.os }}-${{ env.TODAY_DATE }}-release-${{ hashFiles('Cargo.lock', '.github/workflows/build-nightly.yml') }}
+          restore-keys: |
+            nightly-target-${{ runner.os }}-${{ env.TODAY_DATE }}-release-
+
+      - name: Install `nightly` Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+
+      - name: Prepare example artifacts
+        run: bash .github/scripts/prepare-example-artifacts.sh
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Cargo nextest (release build)
         run: |
           cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils" --release
 
-      - name: Cargo test (Doctests)
-        run: |
-          cargo test --workspace --doc --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
+  test-nightly:
+    name: Test (Nightly)
+    runs-on: ubuntu-latest
+    needs:
+      - test-nightly-debug
+      - test-nightly-release
+    steps:
+      - name: Nightly tests complete
+        run: echo "Debug and release nightly test jobs passed."


### PR DESCRIPTION
## Summary
- split nightly test execution into parallel debug and release jobs
- give debug and release separate `CARGO_TARGET_DIR` values and separate daily caches
- keep the existing `Test (Nightly)` check name as a small aggregate job so branch protection stays stable

## Why
Running debug tests and then release tests in a single job causes release intermediates to clobber debug ones and vice versa. Separate target dirs let repeated runs on the same day reuse both caches independently.

## Testing
- parsed `.github/workflows/build-nightly.yml` with Ruby YAML
