### PR TITLE
ci: clarify benchmark run names

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -1,5 +1,7 @@
 name: benchmark-report
 
+run-name: benchmark-report (${{ inputs.benchmark_variant || 'eytzinger' }}) for ${{ inputs.head_ref || github.ref_name }} @ ${{ inputs.head_sha || github.sha }}
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- add an explicit `run-name` to `benchmark-report`
- show the benchmark variant, PR head branch, and PR head SHA in the Actions UI

## Why
Comment-dispatched benchmark runs currently appear under `master` in the Actions UI, which is confusing even though the workflow checks out the PR head commit.

## Testing
- parsed `.github/workflows/benchmark-report.yml` with Ruby YAML
