### PR TITLE
ci: add stem strategy benchmark variant

### DIFF
--- a/.github/workflows/benchmark-report-dispatch.yml
+++ b/.github/workflows/benchmark-report-dispatch.yml
@@ -45,8 +45,10 @@ jobs:
               benchmarkVariant = "dist";
             } else if (body === "/benchmark leaf") {
               benchmarkVariant = "leaf";
+            } else if (body === "/benchmark stems") {
+              benchmarkVariant = "stems";
             } else {
-              core.setFailed("Unsupported benchmark command. Use `/benchmark`, `/benchmark dist`, or `/benchmark leaf`.");
+              core.setFailed("Unsupported benchmark command. Use `/benchmark`, `/benchmark dist`, `/benchmark leaf`, or `/benchmark stems`.");
               return;
             }
 
@@ -75,6 +77,8 @@ jobs:
                 ? "dist-focussed"
                 : benchmarkVariant === "leaf"
                   ? "leaf-strategy"
+                  : benchmarkVariant === "stems"
+                    ? "stem-strategy"
                   : "eytzinger-focus";
 
             await github.rest.issues.createComment({

--- a/.github/workflows/benchmark-report-dispatch.yml
+++ b/.github/workflows/benchmark-report-dispatch.yml
@@ -40,7 +40,9 @@ jobs:
 
             let benchmarkVariant;
             if (body === "/benchmark") {
-              benchmarkVariant = "eytzinger";
+              benchmarkVariant = "basic";
+            } else if (body === "/benchmark basic") {
+              benchmarkVariant = "basic";
             } else if (body === "/benchmark dist") {
               benchmarkVariant = "dist";
             } else if (body === "/benchmark leaf") {
@@ -48,7 +50,7 @@ jobs:
             } else if (body === "/benchmark stems") {
               benchmarkVariant = "stems";
             } else {
-              core.setFailed("Unsupported benchmark command. Use `/benchmark`, `/benchmark dist`, `/benchmark leaf`, or `/benchmark stems`.");
+              core.setFailed("Unsupported benchmark command. Use `/benchmark`, `/benchmark basic`, `/benchmark dist`, `/benchmark leaf`, or `/benchmark stems`.");
               return;
             }
 
@@ -79,7 +81,7 @@ jobs:
                   ? "leaf-strategy"
                   : benchmarkVariant === "stems"
                     ? "stem-strategy"
-                  : "eytzinger-focus";
+                  : "basic";
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -138,7 +138,9 @@ jobs:
                 just bench-v6-dist-metrics \
                   "${{ steps.meta.outputs.variant_key }}" \
                   ./target/benchmark-results \
-                  1000
+                  1000 \
+                  test_utils,logging_off \
+                  simd,test_utils,logging_off
                 ;;
               leaf)
                 just bench-v6-leaf-strategies \
@@ -151,7 +153,9 @@ jobs:
                 just bench-v6-stem-strategies \
                   "${{ steps.meta.outputs.variant_key }}" \
                   ./target/benchmark-results \
-                  1000
+                  1000 \
+                  simd,test_utils,logging_off \
+                  simd,test_utils,logging_off
                 ;;
               *)
                 echo "Unknown benchmark variant: $1" >&2

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -1,6 +1,6 @@
 name: benchmark-report
 
-run-name: benchmark-report (${{ inputs.benchmark_variant || 'eytzinger' }}) for ${{ inputs.head_ref || github.ref_name }} @ ${{ inputs.head_sha || github.sha }}
+run-name: benchmark-report (${{ inputs.benchmark_variant || 'basic' }}) for ${{ inputs.head_ref || github.ref_name }} @ ${{ inputs.head_sha || github.sha }}
 
 on:
   push:
@@ -38,15 +38,15 @@ on:
         description: "Benchmark suite variant"
         required: false
         type: choice
-        default: eytzinger
+        default: basic
         options:
-          - eytzinger
+          - basic
           - dist
           - leaf
           - stems
 
 concurrency:
-  group: benchmark-report-${{ inputs.head_ref || github.ref_name }}-${{ inputs.benchmark_variant || 'eytzinger' }}
+  group: benchmark-report-${{ inputs.head_ref || github.ref_name }}-${{ inputs.benchmark_variant || 'basic' }}
   cancel-in-progress: false
 
 permissions:
@@ -61,6 +61,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     outputs:
       benchmark_variant: ${{ steps.meta.outputs.benchmark_variant }}
+      published_variant: ${{ steps.meta.outputs.published_variant }}
       ref_name: ${{ steps.meta.outputs.ref_name }}
       run_sha: ${{ steps.meta.outputs.run_sha }}
       variant_key: ${{ steps.meta.outputs.variant_key }}
@@ -104,12 +105,18 @@ jobs:
         run: |
           ref_name="${{ inputs.head_ref || github.ref_name }}"
           run_sha="${{ inputs.head_sha || github.sha }}"
-          benchmark_variant="${{ inputs.benchmark_variant || 'eytzinger' }}"
+          benchmark_variant="${{ inputs.benchmark_variant || 'basic' }}"
           variant_key=$(python3 scripts/benchmark_site.py derive-key --ref-name "$ref_name")
           repo_name="${GITHUB_REPOSITORY#*/}"
           site_url_base="https://${GITHUB_REPOSITORY_OWNER}.github.io/${repo_name}"
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "master" ]]; then
+            published_variant="all"
+          else
+            published_variant="$benchmark_variant"
+          fi
           {
             echo "benchmark_variant=$benchmark_variant"
+            echo "published_variant=$published_variant"
             echo "ref_name=$ref_name"
             echo "run_sha=$run_sha"
             echo "variant_key=$variant_key"
@@ -118,38 +125,49 @@ jobs:
 
       - name: Run benchmark suite
         run: |
-          case "${{ steps.meta.outputs.benchmark_variant }}" in
-            eytzinger)
-              just bench-v6-eytzinger-focus \
-                "${{ steps.meta.outputs.variant_key }}" \
-                ./target/benchmark-results \
-                simd,test_utils,logging_off \
-                1000
-              ;;
-            dist)
-              just bench-v6-dist-metrics \
-                "${{ steps.meta.outputs.variant_key }}" \
-                ./target/benchmark-results \
-                1000
-              ;;
-            leaf)
-              just bench-v6-leaf-strategies \
-                "${{ steps.meta.outputs.variant_key }}" \
-                ./target/benchmark-results \
-                simd,test_utils,logging_off \
-                1000
-              ;;
-            stems)
-              just bench-v6-stem-strategies \
-                "${{ steps.meta.outputs.variant_key }}" \
-                ./target/benchmark-results \
-                1000
-              ;;
-            *)
-              echo "Unknown benchmark variant: ${{ steps.meta.outputs.benchmark_variant }}" >&2
-              exit 2
-              ;;
-          esac
+          run_variant() {
+            case "$1" in
+              basic)
+                just bench-v6-eytzinger-focus \
+                  "${{ steps.meta.outputs.variant_key }}" \
+                  ./target/benchmark-results \
+                  simd,test_utils,logging_off \
+                  1000
+                ;;
+              dist)
+                just bench-v6-dist-metrics \
+                  "${{ steps.meta.outputs.variant_key }}" \
+                  ./target/benchmark-results \
+                  1000
+                ;;
+              leaf)
+                just bench-v6-leaf-strategies \
+                  "${{ steps.meta.outputs.variant_key }}" \
+                  ./target/benchmark-results \
+                  simd,test_utils,logging_off \
+                  1000
+                ;;
+              stems)
+                just bench-v6-stem-strategies \
+                  "${{ steps.meta.outputs.variant_key }}" \
+                  ./target/benchmark-results \
+                  1000
+                ;;
+              *)
+                echo "Unknown benchmark variant: $1" >&2
+                exit 2
+                ;;
+            esac
+          }
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "master" ]]; then
+            run_variant basic
+            run_variant dist
+            run_variant leaf
+            run_variant stems
+          else
+            run_variant "${{ steps.meta.outputs.benchmark_variant }}"
+          fi
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
@@ -231,6 +249,7 @@ jobs:
           python3 scripts/benchmark_site.py publish-run \
             --ref-name "${{ needs.benchmark.outputs.ref_name }}" \
             --sha "${{ needs.benchmark.outputs.run_sha }}" \
+            --benchmark-variant "${{ needs.benchmark.outputs.published_variant }}" \
             --results-dir ./target/benchmark-results \
             --pages-root ./.benchmark-pages \
             --site-url-base '${{ needs.benchmark.outputs.site_url_base }}' \

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -43,6 +43,7 @@ on:
           - eytzinger
           - dist
           - leaf
+          - stems
 
 concurrency:
   group: benchmark-report-${{ inputs.head_ref || github.ref_name }}-${{ inputs.benchmark_variant || 'eytzinger' }}
@@ -136,6 +137,12 @@ jobs:
                 "${{ steps.meta.outputs.variant_key }}" \
                 ./target/benchmark-results \
                 simd,test_utils,logging_off \
+                1000
+              ;;
+            stems)
+              just bench-v6-stem-strategies \
+                "${{ steps.meta.outputs.variant_key }}" \
+                ./target/benchmark-results \
                 1000
               ;;
             *)

--- a/AVAILABLE_CI_BENCHMARK_OPTIONS.md
+++ b/AVAILABLE_CI_BENCHMARK_OPTIONS.md
@@ -28,7 +28,7 @@ rules:
       - src/kd_tree/leaf_strategies/**
 
   - command: /benchmark
-    reason: Changes under `src/` or to `Cargo.toml` can affect core runtime performance.
+    reason: Changes under `src/` or to `Cargo.toml` can affect core runtime performance and should use the basic benchmark suite.
     match_any:
       - src/**
       - Cargo.toml
@@ -44,5 +44,5 @@ rules:
 - `/benchmark dist` is reserved for distance-metric-focused changes and should stay above broader rules.
 - `/benchmark stems` is reserved for stem-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark leaf` is reserved for leaf-strategy-specific changes and should stay above the broader `/benchmark` rule.
-- `/benchmark` is the default benchmark suggestion for general source changes.
+- `/benchmark` is the default command for the basic benchmark suite and for general source changes.
 - If you add more benchmark commands later, insert the more specific ones above the broader defaults.

--- a/AVAILABLE_CI_BENCHMARK_OPTIONS.md
+++ b/AVAILABLE_CI_BENCHMARK_OPTIONS.md
@@ -16,6 +16,12 @@ rules:
     match_any:
       - src/dist/**
 
+  - command: /benchmark stems
+    reason: Changes under `src/stem_strategy/` or `src/traits/stem_strategy.rs` can affect stem strategy performance.
+    match_any:
+      - src/stem_strategy/**
+      - src/traits/stem_strategy.rs
+
   - command: /benchmark leaf
     reason: Changes under `src/kd_tree/leaf_strategies/` can affect leaf strategy performance.
     match_any:
@@ -36,6 +42,7 @@ rules:
 ## Notes
 
 - `/benchmark dist` is reserved for distance-metric-focused changes and should stay above broader rules.
+- `/benchmark stems` is reserved for stem-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark leaf` is reserved for leaf-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark` is the default benchmark suggestion for general source changes.
 - If you add more benchmark commands later, insert the more specific ones above the broader defaults.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,12 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "profile_v6_stem_strategies"
+path = "benches/profile_v6_stem_strategies.rs"
+harness = false
+required-features = ["simd", "test_utils"]
+
+[[bench]]
 name = "profile_v6_stem_exact_stats"
 path = "benches/profile_v6_stem_exact_stats.rs"
 harness = false

--- a/benches/profile_v6_stem_strategies.rs
+++ b/benches/profile_v6_stem_strategies.rs
@@ -1,0 +1,380 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput};
+use criterion::measurement::WallTime;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::StemStrategy;
+use kiddo::{
+    Donnelly, DonnellyNoPf, DonnellySimdDescent, DonnellySimdFull, DonnellyUnrolled,
+    DonnellyUnrolledBlockDim, Eytzinger, EytzingerFlexPf, EytzingerNoPf, SquaredEuclidean,
+};
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0301;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0302;
+const TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
+
+type F64Tree<SS> = KdTree<f64, u32, SS, FlatVec<f64, u32, K, B>, K, B>;
+type F32Tree<SS> = KdTree<f32, u32, SS, FlatVec<f32, u32, K, B>, K, B>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StemBenchMode {
+    Scalar,
+    Avx2,
+    Avx512,
+}
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn read_mode_env() -> StemBenchMode {
+    match std::env::var("KIDDO_STEM_BENCH_MODE")
+        .ok()
+        .as_deref()
+        .unwrap_or("scalar")
+    {
+        "avx2" => StemBenchMode::Avx2,
+        "avx512" => StemBenchMode::Avx512,
+        _ => StemBenchMode::Scalar,
+    }
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn run_queries_f64<SS: StemStrategy>(tree: &F64Tree<SS>, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_queries_f32<SS: StemStrategy>(tree: &F32Tree<SS>, queries: &[[f32; K]]) -> (f32, u64) {
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn bench_f64_strategy<SS: StemStrategy>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    point_count: usize,
+    points: &[[f64; K]],
+    queries: &[[f64; K]],
+) {
+    let tree: F64Tree<SS> = KdTree::new_from_slice(points).unwrap();
+    group.bench_function(BenchmarkId::new(label, point_count), |b| {
+        b.iter(|| black_box(run_queries_f64(&tree, queries)))
+    });
+}
+
+fn bench_f32_strategy<SS: StemStrategy>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    point_count: usize,
+    points: &[[f32; K]],
+    queries: &[[f32; K]],
+) {
+    let tree: F32Tree<SS> = KdTree::new_from_slice(points).unwrap();
+    group.bench_function(BenchmarkId::new(label, point_count), |b| {
+        b.iter(|| black_box(run_queries_f32(&tree, queries)))
+    });
+}
+
+fn bench_scalar_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[[f64; K]],
+    queries: &[[f64; K]],
+) {
+    bench_f64_strategy::<Eytzinger>(group, "eytzinger", point_count, points, queries);
+    bench_f64_strategy::<EytzingerNoPf>(group, "eytzinger_no_pf", point_count, points, queries);
+    bench_f64_strategy::<EytzingerFlexPf<-1, 0>>(
+        group,
+        "eytzinger_flex_pf_none_t0",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<EytzingerFlexPf<-1, 1>>(
+        group,
+        "eytzinger_flex_pf_none_t1",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<EytzingerFlexPf<0, -1>>(
+        group,
+        "eytzinger_flex_pf_t0_none",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<EytzingerFlexPf<0, 0>>(
+        group,
+        "eytzinger_flex_pf_t0_t0",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<EytzingerFlexPf<1, -1>>(
+        group,
+        "eytzinger_flex_pf_t1_none",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<EytzingerFlexPf<1, 0>>(
+        group,
+        "eytzinger_flex_pf_t1_t0",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<EytzingerFlexPf<1, 1>>(
+        group,
+        "eytzinger_flex_pf_t1_t1",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<DonnellyNoPf<3>>(group, "donnelly_no_pf", point_count, points, queries);
+    bench_f64_strategy::<Donnelly<3>>(group, "donnelly", point_count, points, queries);
+    bench_f64_strategy::<DonnellyUnrolled<3>>(
+        group,
+        "donnelly_unrolled",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<DonnellyUnrolledBlockDim<3>>(
+        group,
+        "donnelly_unrolled_block_dim",
+        point_count,
+        points,
+        queries,
+    );
+}
+
+fn bench_scalar_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[[f32; K]],
+    queries: &[[f32; K]],
+) {
+    bench_f32_strategy::<Eytzinger>(group, "eytzinger", point_count, points, queries);
+    bench_f32_strategy::<EytzingerNoPf>(group, "eytzinger_no_pf", point_count, points, queries);
+    bench_f32_strategy::<EytzingerFlexPf<-1, 0>>(
+        group,
+        "eytzinger_flex_pf_none_t0",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<EytzingerFlexPf<-1, 1>>(
+        group,
+        "eytzinger_flex_pf_none_t1",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<EytzingerFlexPf<0, -1>>(
+        group,
+        "eytzinger_flex_pf_t0_none",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<EytzingerFlexPf<0, 0>>(
+        group,
+        "eytzinger_flex_pf_t0_t0",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<EytzingerFlexPf<1, -1>>(
+        group,
+        "eytzinger_flex_pf_t1_none",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<EytzingerFlexPf<1, 0>>(
+        group,
+        "eytzinger_flex_pf_t1_t0",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<EytzingerFlexPf<1, 1>>(
+        group,
+        "eytzinger_flex_pf_t1_t1",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<DonnellyNoPf<4>>(group, "donnelly_no_pf", point_count, points, queries);
+    bench_f32_strategy::<Donnelly<4>>(group, "donnelly", point_count, points, queries);
+    bench_f32_strategy::<DonnellyUnrolled<4>>(
+        group,
+        "donnelly_unrolled",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<DonnellyUnrolledBlockDim<4>>(
+        group,
+        "donnelly_unrolled_block_dim",
+        point_count,
+        points,
+        queries,
+    );
+}
+
+fn bench_simd_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[[f64; K]],
+    queries: &[[f64; K]],
+) {
+    bench_f64_strategy::<DonnellySimdDescent<3>>(
+        group,
+        "donnelly_simd_descent",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f64_strategy::<DonnellySimdFull<3>>(
+        group,
+        "donnelly_simd_full",
+        point_count,
+        points,
+        queries,
+    );
+}
+
+fn bench_simd_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[[f32; K]],
+    queries: &[[f32; K]],
+) {
+    bench_f32_strategy::<DonnellySimdDescent<3>>(
+        group,
+        "donnelly_simd_descent",
+        point_count,
+        points,
+        queries,
+    );
+    bench_f32_strategy::<DonnellySimdFull<4>>(
+        group,
+        "donnelly_simd_full",
+        point_count,
+        points,
+        queries,
+    );
+}
+
+fn stem_strategies(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let mode = read_mode_env();
+
+    eprintln!(
+        "benchmarking v6 stem strategies: dims={} tree_sizes=2^16..2^26 queries={} mode={:?} point_seed={} query_seed={}",
+        K, query_count, mode, POINT_SEED, QUERY_SEED
+    );
+
+    let f64_queries = build_queries_f64(query_count);
+    let mut f64_group = c.benchmark_group("profile_v6_stem_strategies/f64");
+    f64_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f64(point_count);
+        match mode {
+            StemBenchMode::Scalar => {
+                bench_scalar_f64(&mut f64_group, point_count, &points, &f64_queries)
+            }
+            StemBenchMode::Avx2 | StemBenchMode::Avx512 => {
+                bench_simd_f64(&mut f64_group, point_count, &points, &f64_queries)
+            }
+        }
+    }
+    f64_group.finish();
+
+    let f32_queries = build_queries_f32(query_count);
+    let mut f32_group = c.benchmark_group("profile_v6_stem_strategies/f32");
+    f32_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f32(point_count);
+        match mode {
+            StemBenchMode::Scalar => {
+                bench_scalar_f32(&mut f32_group, point_count, &points, &f32_queries)
+            }
+            StemBenchMode::Avx2 | StemBenchMode::Avx512 => {
+                bench_simd_f32(&mut f32_group, point_count, &points, &f32_queries)
+            }
+        }
+    }
+    f32_group.finish();
+}
+
+criterion_group!(benches, stem_strategies);
+criterion_main!(benches);

--- a/benches/profile_v6_stem_strategies.rs
+++ b/benches/profile_v6_stem_strategies.rs
@@ -1,8 +1,10 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(coverage_nightly, coverage(off))]
 
-use criterion::{criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput};
 use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
 use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::FlatVec;
 use kiddo::StemStrategy;

--- a/justfile
+++ b/justfile
@@ -218,6 +218,47 @@ bench-v6-leaf-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
         "$output_dir/bench_result-v6-leaf-strategies-${result_key}.json" \
         profile_v6_leaf_strategies_criterion
 
+bench-v6-stem-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='1000' SCALAR_FEATURES='simd,test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    scalar_features={{quote(SCALAR_FEATURES)}}
+    simd_features={{quote(SIMD_FEATURES)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    host=$(rustc -vV | sed -n 's/^host: //p')
+    if [[ "$host" != x86_64-* ]]; then
+        echo "bench-v6-stem-strategies currently requires an x86-64 host; found $host" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+
+    run_mode() {
+        local mode=$1
+        local rustflags=$2
+        local features=$3
+
+        RUSTC_WRAPPER= \
+            KIDDO_STEM_BENCH_MODE="$mode" \
+            KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+            RUSTFLAGS="$rustflags" \
+            cargo criterion \
+                --target "$host" \
+                --bench profile_v6_stem_strategies \
+                --features "$features"
+        cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+            target/criterion \
+            "$output_dir/bench_result-v6-stem-strategies-${mode}-${result_key}.json" \
+            profile_v6_stem_strategies
+    }
+
+    run_mode scalar "-C target-cpu=x86-64-v2" "$scalar_features"
+    run_mode avx2 "-C target-cpu=x86-64-v2 -C target-feature=+avx2" "$simd_features"
+    run_mode avx512 "-C target-cpu=native" "$simd_features"
+
 chart-benchmark-results VARIANT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
     {{quote(PYTHON)}} scripts/chart_benchmark_results.py {{quote(VARIANT_KEY)}} --results-dir {{quote(RESULTS_DIR)}} --output-dir {{quote(OUTPUT_DIR)}}
 

--- a/scripts/benchmark_site.py
+++ b/scripts/benchmark_site.py
@@ -15,7 +15,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Iterable
@@ -42,6 +42,7 @@ class RunSummary:
     run_id: str
     ref_name: str
     sha: str
+    benchmark_variant: str
     variant_key: str
     branch_path_key: str
     is_baseline: bool
@@ -56,7 +57,7 @@ class RunSummary:
 
 
 def now_utc() -> datetime:
-    return datetime.now(UTC).replace(microsecond=0)
+    return datetime.now(timezone.utc).replace(microsecond=0)
 
 
 def format_timestamp(value: datetime) -> str:
@@ -133,11 +134,27 @@ def write_text(path: Path, value: str) -> None:
 
 def load_run_summary(path: Path) -> RunSummary:
     value = read_json(path)
+    value.setdefault("benchmark_variant", infer_benchmark_variant(value))
     return RunSummary(**value)
 
 
 def save_run_summary(path: Path, summary: RunSummary) -> None:
     write_json(path, asdict(summary))
+
+
+def infer_benchmark_variant(value: dict[str, Any]) -> str:
+    result_files = value.get("result_files")
+    if not isinstance(result_files, list):
+        return "basic"
+
+    names = [name for name in result_files if isinstance(name, str)]
+    if any(name.startswith("bench_result-v6-dist-metrics-") for name in names):
+        return "dist"
+    if any(name.startswith("bench_result-v6-leaf-strategies-") for name in names):
+        return "leaf"
+    if any(name.startswith("bench_result-v6-stem-strategies-") for name in names):
+        return "stems"
+    return "basic"
 
 
 def run_dirs_for(summary: RunSummary) -> tuple[Path, Path]:
@@ -271,13 +288,15 @@ def render_run_page(
         if summary.baseline_run_id
         else "<p>No baseline comparison was available for this run.</p>"
     )
+    run_link = f'<a href="{run_url}">{run_url}</a>' if run_url else ""
     body = f"""
 <p><a href="{home_rel}">Home</a></p>
 <h1>Benchmark run: {summary.ref_name}</h1>
 <p class="meta"><code>{summary.sha}</code> · {summary.created_at}</p>
+<p>Benchmark suite: <code>{summary.benchmark_variant}</code></p>
 <p>{'Baseline publication' if summary.is_baseline else 'Branch comparison run'}</p>
 {baseline_text}
-<p>{f'<a href="{run_url}">{run_url}</a>' if run_url else ''}</p>
+<p>{run_link}</p>
 <section>
   <h2>Result exports</h2>
   <ul>{results_links}</ul>
@@ -300,14 +319,16 @@ def render_branch_index(
     for run in runs:
         run_dir, _ = run_dirs_for(run)
         run_url = site_join(site_url_base, (run_dir / "index.html").as_posix())
+        public_link = f'<a href="{run_url}">public</a>' if run_url else "—"
         rows.append(
             "<tr>"
             f"<td><a href=\"history/{run.run_id}/index.html\">{run.run_id}</a></td>"
+            f"<td><code>{run.benchmark_variant}</code></td>"
             f"<td><code>{run.sha[:12]}</code></td>"
             f"<td>{run.created_at}</td>"
             f"<td>{len(run.chart_files)}</td>"
             f"<td>{run.baseline_run_id or '—'}</td>"
-            f"<td>{f'<a href=\"{run_url}\">public</a>' if run_url else '—'}</td>"
+            f"<td>{public_link}</td>"
             "</tr>"
         )
     body = f"""
@@ -318,7 +339,7 @@ def render_branch_index(
 <section>
   <table>
     <thead>
-      <tr><th>Run</th><th>SHA</th><th>Created</th><th>Charts</th><th>Baseline</th><th>Public URL</th></tr>
+      <tr><th>Run</th><th>Suite</th><th>SHA</th><th>Created</th><th>Charts</th><th>Baseline</th><th>Public URL</th></tr>
     </thead>
     <tbody>{''.join(rows)}</tbody>
   </table>
@@ -342,7 +363,9 @@ def render_baseline_trends(pages_root: Path) -> list[str]:
     _, plt = import_matplotlib()
     trends: dict[tuple[str, str, str], list[tuple[datetime, str, list[Point]]]] = {}
     for run in reversed(runs):
-        run_dt = datetime.strptime(run.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+        run_dt = datetime.strptime(run.created_at, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
         run_dir, _ = run_dirs_for(run)
         suites = load_suite_series(pages_root / run_dir / "results")
         for suite, series_map in suites.items():
@@ -427,6 +450,7 @@ def render_root_index(pages_root: Path, site_url_base: str | None) -> None:
             {
                 "branch_path_key": branch_key,
                 "ref_name": latest.ref_name,
+                "benchmark_variant": latest.benchmark_variant,
                 "latest_run_id": latest.run_id,
                 "latest_run_page_path": (run_dir / "index.html").as_posix(),
                 "latest_run_page_url": site_join(site_url_base, (run_dir / "index.html").as_posix()),
@@ -436,6 +460,7 @@ def render_root_index(pages_root: Path, site_url_base: str | None) -> None:
         branch_rows.append(
             "<tr>"
             f"<td><a href=\"branches/{branch_key}/index.html\">{latest.ref_name}</a></td>"
+            f"<td><code>{latest.benchmark_variant}</code></td>"
             f"<td>{len(runs)}</td>"
             f"<td><a href=\"branches/{branch_key}/latest/index.html\">{latest.run_id}</a></td>"
             f"<td><code>{latest.sha[:12]}</code></td>"
@@ -456,19 +481,25 @@ def render_root_index(pages_root: Path, site_url_base: str | None) -> None:
                 [asdict(run) for run in runs],
             )
 
+    latest_baseline_text = (
+        f'Latest baseline run: <a href="baseline/latest/index.html">{baseline_latest.run_id}</a> '
+        f'· <code>{baseline_latest.sha[:12]}</code> · suite <code>{baseline_latest.benchmark_variant}</code>'
+        if baseline_latest
+        else "No baseline runs published yet."
+    )
     body = f"""
 <h1>Kiddo benchmark reports</h1>
 <p>This site publishes Criterion exports, branch-vs-baseline comparisons, and baseline history from the repo benchmark workflow.</p>
 <section>
   <h2>Baseline</h2>
-  <p>{f'Latest baseline run: <a href="baseline/latest/index.html">{baseline_latest.run_id}</a> · <code>{baseline_latest.sha[:12]}</code>' if baseline_latest else 'No baseline runs published yet.'}</p>
+  <p>{latest_baseline_text}</p>
   <p><a href="baseline/trends/index.html">View baseline history and trend charts</a></p>
 </section>
 <section>
   <h2>Branches</h2>
   <table>
-    <thead><tr><th>Branch</th><th>Runs</th><th>Latest run</th><th>SHA</th><th>Created</th></tr></thead>
-    <tbody>{''.join(branch_rows) if branch_rows else '<tr><td colspan="5">No branch runs published yet.</td></tr>'}</tbody>
+    <thead><tr><th>Branch</th><th>Latest suite</th><th>Runs</th><th>Latest run</th><th>SHA</th><th>Created</th></tr></thead>
+    <tbody>{''.join(branch_rows) if branch_rows else '<tr><td colspan="6">No branch runs published yet.</td></tr>'}</tbody>
   </table>
 </section>
 """
@@ -503,6 +534,7 @@ def rebuild_site(pages_root: Path, site_url_base: str | None) -> None:
 def publish_run(
     ref_name: str,
     sha: str,
+    benchmark_variant: str,
     results_dir: Path,
     pages_root: Path,
     site_url_base: str | None,
@@ -524,6 +556,7 @@ def publish_run(
         run_id=run_id,
         ref_name=ref_name,
         sha=sha,
+        benchmark_variant=benchmark_variant,
         variant_key=variant_key,
         branch_path_key=branch_path_key,
         is_baseline=is_baseline,
@@ -586,6 +619,7 @@ def render_pr_comment(summary: RunSummary, site_url_base: str | None) -> str:
         "## Benchmark report",
         "",
         f"- Branch: `{summary.ref_name}`",
+        f"- Benchmark suite: `{summary.benchmark_variant}`",
         f"- Commit: `{summary.sha[:12]}`",
         f"- Published run: `{summary.run_id}`",
     ]
@@ -697,7 +731,7 @@ def find_pr_numbers(repo: str, ref_name: str) -> list[int]:
 def parse_timestamp(value: str | None) -> datetime | None:
     if value is None:
         return None
-    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
 
 
 def args_parser() -> argparse.ArgumentParser:
@@ -713,6 +747,7 @@ def args_parser() -> argparse.ArgumentParser:
     publish = subparsers.add_parser("publish-run", help="publish one benchmark run into a pages tree")
     publish.add_argument("--ref-name", required=True)
     publish.add_argument("--sha", required=True)
+    publish.add_argument("--benchmark-variant", required=True)
     publish.add_argument("--results-dir", type=Path, required=True)
     publish.add_argument("--pages-root", type=Path, required=True)
     publish.add_argument("--site-url-base")
@@ -754,6 +789,7 @@ def main(argv: list[str] | None = None) -> int:
         summary = publish_run(
             ref_name=args.ref_name,
             sha=args.sha,
+            benchmark_variant=args.benchmark_variant,
             results_dir=args.results_dir,
             pages_root=args.pages_root,
             site_url_base=args.site_url_base,


### PR DESCRIPTION
## Summary
- add a new `/benchmark stems` CI dispatch option for comparing stem strategy variants
- add a criterion-based stem strategy benchmark target that exports chartable scalar, AVX2, and AVX512 results
- extend the benchmark suggestion rules so stem-strategy changes suggest `/benchmark stems`

## Coverage
- Eytzinger
- EytzingerNoPf
- all remaining EytzingerFlexPf prefetch combinations
- DonnellyNoPf
- Donnelly
- DonnellyUnrolled
- DonnellyUnrolledBlockDim
- DonnellySimdDescent (AVX2 and AVX512 builds)
- DonnellySimdFull (AVX2 and AVX512 builds)
- both `f32` and `f64`
- every power-of-two tree size from `2^16` through `2^26`

## Testing
- parsed workflow YAML with Ruby
- `cargo check --bench profile_v6_stem_strategies --features simd,test_utils,logging_off`
