### PR TITLE
test: add v6 release parity benchmark suites

### DIFF
--- a/.github/workflows/benchmark-report-dispatch.yml
+++ b/.github/workflows/benchmark-report-dispatch.yml
@@ -38,33 +38,55 @@ jobs:
               return;
             }
 
-            let benchmarkVariant;
-            if (body === "/benchmark") {
-              benchmarkVariant = "basic";
-            } else if (body === "/benchmark basic") {
-              benchmarkVariant = "basic";
-            } else if (body === "/benchmark dist") {
-              benchmarkVariant = "dist";
-            } else if (body === "/benchmark leaf") {
-              benchmarkVariant = "leaf";
-            } else if (body === "/benchmark stems") {
-              benchmarkVariant = "stems";
-            } else {
-              core.setFailed("Unsupported benchmark command. Use `/benchmark`, `/benchmark basic`, `/benchmark dist`, `/benchmark leaf`, or `/benchmark stems`.");
-              return;
-            }
-
             const { data: pr } = await github.rest.pulls.get({
               owner,
               repo,
               pull_number: issueNumber,
             });
 
+            const workflowRef = pr.base.ref;
+            const supportedCommandsByRef = new Map([
+              [
+                "master",
+                new Map([
+                  ["/benchmark", "basic"],
+                  ["/benchmark basic", "basic"],
+                  ["/benchmark extended", "extended"],
+                  ["/benchmark dist", "dist"],
+                  ["/benchmark leaf", "leaf"],
+                  ["/benchmark stems", "stems"],
+                ]),
+              ],
+              [
+                "v5.x.x",
+                new Map([
+                  ["/benchmark", "basic"],
+                  ["/benchmark basic", "basic"],
+                  ["/benchmark extended", "extended"],
+                ]),
+              ],
+            ]);
+            const supportedCommands = supportedCommandsByRef.get(workflowRef);
+            if (!supportedCommands) {
+              core.setFailed(
+                `No benchmark workflow is configured for PR base branch ${workflowRef}.`
+              );
+              return;
+            }
+
+            const benchmarkVariant = supportedCommands.get(body);
+            if (!benchmarkVariant) {
+              core.setFailed(
+                `Unsupported benchmark command for ${workflowRef}. Allowed commands: ${[...supportedCommands.keys()].join(", ")}.`
+              );
+              return;
+            }
+
             await github.rest.actions.createWorkflowDispatch({
               owner,
               repo,
               workflow_id: "benchmark-report.yml",
-              ref: pr.base.ref,
+              ref: workflowRef,
               inputs: {
                 pr_number: String(pr.number),
                 head_sha: pr.head.sha,
@@ -77,6 +99,8 @@ jobs:
             const benchmarkLabel =
               benchmarkVariant === "dist"
                 ? "dist-focussed"
+                : benchmarkVariant === "extended"
+                  ? "query-family"
                 : benchmarkVariant === "leaf"
                   ? "leaf-strategy"
                   : benchmarkVariant === "stems"

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -41,6 +41,7 @@ on:
         default: basic
         options:
           - basic
+          - extended
           - dist
           - leaf
           - stems
@@ -142,6 +143,13 @@ jobs:
                   test_utils,logging_off \
                   simd,test_utils,logging_off
                 ;;
+              extended)
+                just bench-v6-query-family \
+                  "${{ steps.meta.outputs.variant_key }}" \
+                  ./target/benchmark-results \
+                  simd,test_utils,logging_off \
+                  1000
+                ;;
               leaf)
                 just bench-v6-leaf-strategies \
                   "${{ steps.meta.outputs.variant_key }}" \
@@ -166,6 +174,7 @@ jobs:
 
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" == "master" ]]; then
             run_variant basic
+            run_variant extended
             run_variant dist
             run_variant leaf
             run_variant stems
@@ -239,6 +248,19 @@ jobs:
           fi
           echo "prs=$prs" >> "$GITHUB_OUTPUT"
 
+      - name: Migrate legacy v6 gh-pages layout
+        run: |
+          mkdir -p ./.benchmark-pages/v6
+          if [[ ! -e ./.benchmark-pages/v6/baseline && -d ./.benchmark-pages/baseline ]]; then
+            mv ./.benchmark-pages/baseline ./.benchmark-pages/v6/
+          fi
+          if [[ ! -e ./.benchmark-pages/v6/branches && -d ./.benchmark-pages/branches ]]; then
+            mv ./.benchmark-pages/branches ./.benchmark-pages/v6/
+          fi
+          if [[ ! -e ./.benchmark-pages/v6/data && -d ./.benchmark-pages/data ]]; then
+            mv ./.benchmark-pages/data ./.benchmark-pages/v6/
+          fi
+
       - name: Publish run into gh-pages tree
         env:
           PRS_JSON: ${{ steps.prs.outputs.prs }}
@@ -254,11 +276,18 @@ jobs:
             --ref-name "${{ needs.benchmark.outputs.ref_name }}" \
             --sha "${{ needs.benchmark.outputs.run_sha }}" \
             --benchmark-variant "${{ needs.benchmark.outputs.published_variant }}" \
+            --baseline-ref-name master \
             --results-dir ./target/benchmark-results \
-            --pages-root ./.benchmark-pages \
-            --site-url-base '${{ needs.benchmark.outputs.site_url_base }}' \
+            --pages-root ./.benchmark-pages/v6 \
+            --site-url-base '${{ needs.benchmark.outputs.site_url_base }}/v6' \
             --summary-path ./target/benchmark-summary.json \
             "${PR_ARGS[@]}"
+
+      - name: Rebuild top-level benchmark index
+        run: |
+          python3 scripts/benchmark_site_root.py \
+            --pages-root ./.benchmark-pages \
+            --site-url-base '${{ needs.benchmark.outputs.site_url_base }}'
 
       - name: Commit and push gh-pages
         run: |

--- a/AVAILABLE_CI_BENCHMARK_OPTIONS.md
+++ b/AVAILABLE_CI_BENCHMARK_OPTIONS.md
@@ -27,6 +27,11 @@ rules:
     match_any:
       - src/kd_tree/leaf_strategies/**
 
+  - command: /benchmark extended
+    reason: Changes under `src/kd_tree/query/` can affect within/nearest-within query performance and should use the extended query-family benchmark suite.
+    match_any:
+      - src/kd_tree/query/**
+
   - command: /benchmark
     reason: Changes under `src/` or to `Cargo.toml` can affect core runtime performance and should use the basic benchmark suite.
     match_any:
@@ -44,5 +49,6 @@ rules:
 - `/benchmark dist` is reserved for distance-metric-focused changes and should stay above broader rules.
 - `/benchmark stems` is reserved for stem-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark leaf` is reserved for leaf-strategy-specific changes and should stay above the broader `/benchmark` rule.
+- `/benchmark extended` is reserved for query-pipeline changes and should stay above the broader `/benchmark` rule.
 - `/benchmark` is the default command for the basic benchmark suite and for general source changes.
 - If you add more benchmark commands later, insert the more specific ones above the broader defaults.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,12 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "profile_v6_approx_nearest_one_eytzinger"
+path = "benches/profile_v6_approx_nearest_one_eytzinger.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "profile_v6_dist_metrics"
 path = "benches/profile_v6_dist_metrics.rs"
 harness = false
@@ -257,6 +263,12 @@ required-features = ["test_utils"]
 [[bench]]
 name = "profile_v6_nearest_n_eytzinger"
 path = "benches/profile_v6_nearest_n_eytzinger.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
+name = "profile_v6_query_family_eytzinger"
+path = "benches/profile_v6_query_family_eytzinger.rs"
 harness = false
 required-features = ["test_utils"]
 

--- a/benches/profile_v6_approx_nearest_one_eytzinger.rs
+++ b/benches/profile_v6_approx_nearest_one_eytzinger.rs
@@ -1,0 +1,130 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::Eytzinger;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+const TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
+
+type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
+type F32Tree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, K, B>, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn run_queries_f64(tree: &F64Tree, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .approx()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_queries_f32(tree: &F32Tree, queries: &[[f32; K]]) -> (f32, u64) {
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .approx()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(result.item as u64);
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn approx_nearest_one(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+
+    eprintln!(
+        "benchmarking v6 approx_nearest_one: dims={} tree_sizes=2^16..2^26 queries={} point_seed={} query_seed={}",
+        K, query_count, POINT_SEED, QUERY_SEED
+    );
+
+    let f64_queries = build_queries_f64(query_count);
+    let mut f64_group = c.benchmark_group("profile_v6_approx_nearest_one_eytzinger/f64");
+    f64_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f64(point_count);
+        let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
+        f64_group.bench_function(BenchmarkId::new("approx_nearest_one", point_count), |b| {
+            b.iter(|| black_box(run_queries_f64(&tree, &f64_queries)));
+        });
+    }
+    f64_group.finish();
+
+    let f32_queries = build_queries_f32(query_count);
+    let mut f32_group = c.benchmark_group("profile_v6_approx_nearest_one_eytzinger/f32");
+    f32_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f32(point_count);
+        let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
+        f32_group.bench_function(BenchmarkId::new("approx_nearest_one", point_count), |b| {
+            b.iter(|| black_box(run_queries_f32(&tree, &f32_queries)));
+        });
+    }
+    f32_group.finish();
+}
+
+criterion_group!(benches, approx_nearest_one);
+criterion_main!(benches);

--- a/benches/profile_v6_query_family_eytzinger.rs
+++ b/benches/profile_v6_query_family_eytzinger.rs
@@ -1,0 +1,389 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::Eytzinger;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+use std::num::NonZeroUsize;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+const MAX_DIST: f64 = 0.0025;
+const MAX_QTYS: [usize; 3] = [5, 20, 50];
+const TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
+
+type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
+type F32Tree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, K, B>, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn run_within_f64(tree: &F64Tree, queries: &[[f64; K]]) -> (usize, f64, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(MAX_DIST)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_within_f32(tree: &F32Tree, queries: &[[f32; K]]) -> (usize, f32, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f32>>(MAX_DIST as f32)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_within_unsorted_f64(tree: &F64Tree, queries: &[[f64; K]]) -> (usize, f64, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(MAX_DIST)
+            .unsorted()
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_within_unsorted_f32(tree: &F32Tree, queries: &[[f32; K]]) -> (usize, f32, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f32>>(MAX_DIST as f32)
+            .unsorted()
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_nearest_n_within_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, f64, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .within(MAX_DIST)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_nearest_n_within_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, f32, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f32>>(max_qty)
+            .within(MAX_DIST as f32)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_nearest_n_within_unsorted_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, f64, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .within(MAX_DIST)
+            .unsorted()
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_nearest_n_within_unsorted_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, f32, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .nearest_n::<SquaredEuclidean<f32>>(max_qty)
+            .within(MAX_DIST as f32)
+            .unsorted()
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_best_n_within_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, f64, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .best_n_within::<SquaredEuclidean<f64>>(MAX_DIST, max_qty)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results.into_vec() {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn run_best_n_within_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    max_qty: NonZeroUsize,
+) -> (usize, f32, u64) {
+    let mut checksum_len = 0usize;
+    let mut checksum_dist = 0.0f32;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .best_n_within::<SquaredEuclidean<f32>>(MAX_DIST as f32, max_qty)
+            .execute();
+        checksum_len = checksum_len.wrapping_add(results.len());
+        for result in results.into_vec() {
+            checksum_dist += result.distance;
+            checksum_item = checksum_item.wrapping_add(result.item as u64);
+        }
+    }
+
+    (checksum_len, checksum_dist, checksum_item)
+}
+
+fn query_family(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+
+    eprintln!(
+        "benchmarking v6 query family: dims={} tree_sizes=2^16..2^26 queries={} max_dist={} ks={:?} point_seed={} query_seed={}",
+        K, query_count, MAX_DIST, MAX_QTYS, POINT_SEED, QUERY_SEED
+    );
+
+    let f64_queries = build_queries_f64(query_count);
+    let mut f64_group = c.benchmark_group("profile_v6_query_family_eytzinger/f64");
+    f64_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f64(point_count);
+        let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
+        f64_group.bench_function(BenchmarkId::new("within", point_count), |b| {
+            b.iter(|| black_box(run_within_f64(&tree, &f64_queries)));
+        });
+        f64_group.bench_function(BenchmarkId::new("within_unsorted", point_count), |b| {
+            b.iter(|| black_box(run_within_unsorted_f64(&tree, &f64_queries)));
+        });
+        for max_qty in MAX_QTYS {
+            let max_qty = NonZeroUsize::new(max_qty).unwrap();
+            f64_group.bench_function(
+                BenchmarkId::new(format!("nearest_n_within_k{}", max_qty), point_count),
+                |b| b.iter(|| black_box(run_nearest_n_within_f64(&tree, &f64_queries, max_qty))),
+            );
+            f64_group.bench_function(
+                BenchmarkId::new(
+                    format!("nearest_n_within_unsorted_k{}", max_qty),
+                    point_count,
+                ),
+                |b| {
+                    b.iter(|| {
+                        black_box(run_nearest_n_within_unsorted_f64(
+                            &tree,
+                            &f64_queries,
+                            max_qty,
+                        ))
+                    })
+                },
+            );
+            f64_group.bench_function(
+                BenchmarkId::new(format!("best_n_within_k{}", max_qty), point_count),
+                |b| b.iter(|| black_box(run_best_n_within_f64(&tree, &f64_queries, max_qty))),
+            );
+        }
+    }
+    f64_group.finish();
+
+    let f32_queries = build_queries_f32(query_count);
+    let mut f32_group = c.benchmark_group("profile_v6_query_family_eytzinger/f32");
+    f32_group.throughput(Throughput::Elements(query_count as u64));
+    for point_count in TREE_SIZES {
+        let points = build_points_f32(point_count);
+        let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
+        f32_group.bench_function(BenchmarkId::new("within", point_count), |b| {
+            b.iter(|| black_box(run_within_f32(&tree, &f32_queries)));
+        });
+        f32_group.bench_function(BenchmarkId::new("within_unsorted", point_count), |b| {
+            b.iter(|| black_box(run_within_unsorted_f32(&tree, &f32_queries)));
+        });
+        for max_qty in MAX_QTYS {
+            let max_qty = NonZeroUsize::new(max_qty).unwrap();
+            f32_group.bench_function(
+                BenchmarkId::new(format!("nearest_n_within_k{}", max_qty), point_count),
+                |b| b.iter(|| black_box(run_nearest_n_within_f32(&tree, &f32_queries, max_qty))),
+            );
+            f32_group.bench_function(
+                BenchmarkId::new(
+                    format!("nearest_n_within_unsorted_k{}", max_qty),
+                    point_count,
+                ),
+                |b| {
+                    b.iter(|| {
+                        black_box(run_nearest_n_within_unsorted_f32(
+                            &tree,
+                            &f32_queries,
+                            max_qty,
+                        ))
+                    })
+                },
+            );
+            f32_group.bench_function(
+                BenchmarkId::new(format!("best_n_within_k{}", max_qty), point_count),
+                |b| b.iter(|| black_box(run_best_n_within_f32(&tree, &f32_queries, max_qty))),
+            );
+        }
+    }
+    f32_group.finish();
+}
+
+criterion_group!(benches, query_family);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -136,7 +136,7 @@ bench-v6-eytzinger-focus RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
     fi
     mkdir -p "$output_dir"
     RUSTC_WRAPPER= \
-        KIDDO_BENCH_QUERIES={{quote(QUERIES)}} \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
         RUSTFLAGS='-C target-cpu=native' \
         cargo criterion \
             --bench profile_v6_nearest_n_eytzinger \
@@ -146,7 +146,7 @@ bench-v6-eytzinger-focus RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
         "$output_dir/bench_result-v6-nearest_n-eytzinger-${result_key}.json" \
         profile_v6_nearest_n_eytzinger
     RUSTC_WRAPPER= \
-        KIDDO_BENCH_QUERIES={{quote(QUERIES)}} \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
         RUSTFLAGS='-C target-cpu=native' \
         cargo criterion \
             --bench profile_v6_nearest_one_eytzinger \
@@ -155,6 +155,37 @@ bench-v6-eytzinger-focus RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
         target/criterion \
         "$output_dir/bench_result-v6-nearest_one-eytzinger-${result_key}.json" \
         profile_v6_nearest_one_eytzinger
+    RUSTC_WRAPPER= \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_v6_approx_nearest_one_eytzinger \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-v6-approx_nearest_one-eytzinger-${result_key}.json" \
+        profile_v6_approx_nearest_one_eytzinger
+
+bench-v6-query-family RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES='1000':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_v6_query_family_eytzinger \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-v6-query-family-eytzinger-${result_key}.json" \
+        profile_v6_query_family_eytzinger
 
 bench-v6-dist-metrics RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='1000' SCALAR_FEATURES='test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
     #!/usr/bin/env bash

--- a/scripts/benchmark_site.py
+++ b/scripts/benchmark_site.py
@@ -43,6 +43,7 @@ class RunSummary:
     ref_name: str
     sha: str
     benchmark_variant: str
+    baseline_ref_name: str
     variant_key: str
     branch_path_key: str
     is_baseline: bool
@@ -75,8 +76,8 @@ def sanitize_branch_component(value: str) -> str:
     return value or "branch"
 
 
-def derive_variant_key(ref_name: str) -> str:
-    if ref_name == "master":
+def derive_variant_key(ref_name: str, baseline_ref_name: str) -> str:
+    if ref_name == baseline_ref_name:
         return "baseline"
     stripped = re.sub(r"^(feature|fix)/", "", ref_name, count=1)
     return sanitize_branch_component(stripped)
@@ -135,6 +136,7 @@ def write_text(path: Path, value: str) -> None:
 def load_run_summary(path: Path) -> RunSummary:
     value = read_json(path)
     value.setdefault("benchmark_variant", infer_benchmark_variant(value))
+    value.setdefault("baseline_ref_name", "master")
     return RunSummary(**value)
 
 
@@ -150,10 +152,16 @@ def infer_benchmark_variant(value: dict[str, Any]) -> str:
     names = [name for name in result_files if isinstance(name, str)]
     if any(name.startswith("bench_result-v6-dist-metrics-") for name in names):
         return "dist"
+    if any(name.startswith("bench_result-v5-dist-metrics-") for name in names):
+        return "dist"
     if any(name.startswith("bench_result-v6-leaf-strategies-") for name in names):
         return "leaf"
     if any(name.startswith("bench_result-v6-stem-strategies-") for name in names):
         return "stems"
+    if any(name.startswith("bench_result-v6-query-family-") for name in names):
+        return "extended"
+    if any(name.startswith("bench_result-v5-query-family-") for name in names):
+        return "extended"
     return "basic"
 
 
@@ -294,7 +302,7 @@ def render_run_page(
 <h1>Benchmark run: {summary.ref_name}</h1>
 <p class="meta"><code>{summary.sha}</code> · {summary.created_at}</p>
 <p>Benchmark suite: <code>{summary.benchmark_variant}</code></p>
-<p>{'Baseline publication' if summary.is_baseline else 'Branch comparison run'}</p>
+<p>{f'Baseline publication for {summary.baseline_ref_name}' if summary.is_baseline else 'Branch comparison run'}</p>
 {baseline_text}
 <p>{run_link}</p>
 <section>
@@ -535,6 +543,7 @@ def publish_run(
     ref_name: str,
     sha: str,
     benchmark_variant: str,
+    baseline_ref_name: str,
     results_dir: Path,
     pages_root: Path,
     site_url_base: str | None,
@@ -542,7 +551,7 @@ def publish_run(
     created_at: datetime | None = None,
 ) -> RunSummary:
     created_at = created_at or now_utc()
-    variant_key = derive_variant_key(ref_name)
+    variant_key = derive_variant_key(ref_name, baseline_ref_name)
     branch_path_key = derive_branch_path_key(ref_name)
     if not SAFE_KEY.fullmatch(variant_key):
         raise RuntimeError(f"derived variant key is invalid: {variant_key}")
@@ -557,6 +566,7 @@ def publish_run(
         ref_name=ref_name,
         sha=sha,
         benchmark_variant=benchmark_variant,
+        baseline_ref_name=baseline_ref_name,
         variant_key=variant_key,
         branch_path_key=branch_path_key,
         is_baseline=is_baseline,
@@ -645,7 +655,7 @@ def render_pr_comment(summary: RunSummary, site_url_base: str | None) -> str:
             [
                 "No comparison charts were generated for this run.",
                 "",
-                "This usually means there is no published `master` baseline yet.",
+                f"This usually means there is no published `{summary.baseline_ref_name}` baseline yet.",
                 "",
             ]
         )
@@ -740,6 +750,7 @@ def args_parser() -> argparse.ArgumentParser:
 
     derive = subparsers.add_parser("derive-key", help="derive the benchmark variant key")
     derive.add_argument("--ref-name", required=True)
+    derive.add_argument("--baseline-ref-name", default="master")
 
     derive_path = subparsers.add_parser("derive-path-key", help="derive the published branch path key")
     derive_path.add_argument("--ref-name", required=True)
@@ -748,6 +759,7 @@ def args_parser() -> argparse.ArgumentParser:
     publish.add_argument("--ref-name", required=True)
     publish.add_argument("--sha", required=True)
     publish.add_argument("--benchmark-variant", required=True)
+    publish.add_argument("--baseline-ref-name", default="master")
     publish.add_argument("--results-dir", type=Path, required=True)
     publish.add_argument("--pages-root", type=Path, required=True)
     publish.add_argument("--site-url-base")
@@ -777,7 +789,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = args_parser()
     args = parser.parse_args(argv)
     if args.command == "derive-key":
-        print(derive_variant_key(args.ref_name))
+        print(derive_variant_key(args.ref_name, args.baseline_ref_name))
         return 0
     if args.command == "derive-path-key":
         print(derive_branch_path_key(args.ref_name))
@@ -790,6 +802,7 @@ def main(argv: list[str] | None = None) -> int:
             ref_name=args.ref_name,
             sha=args.sha,
             benchmark_variant=args.benchmark_variant,
+            baseline_ref_name=args.baseline_ref_name,
             results_dir=args.results_dir,
             pages_root=args.pages_root,
             site_url_base=args.site_url_base,

--- a/scripts/benchmark_site_root.py
+++ b/scripts/benchmark_site_root.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Render the top-level benchmark site index and latest v5-v6 comparison page."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import re
+from pathlib import Path
+from typing import Any
+
+from benchmark_site import RunSummary, load_run_summary, render_html, site_join, write_text
+from chart_benchmark_results import (
+    NS_PER_US,
+    Point,
+    SeriesKey,
+    change_score,
+    import_matplotlib,
+    result_series,
+    slug,
+    subbenchmark_name,
+)
+
+
+RESULT_GLOB = "bench_result-*.json"
+LINE_ORDER = ("v6", "v5")
+
+
+def canonical_suite_name(suite: str) -> str:
+    return re.sub(r"^v[0-9]+-", "", suite)
+
+
+def latest_baseline_summary(line_root: Path) -> RunSummary | None:
+    path = line_root / "baseline" / "latest" / "run.json"
+    if not path.is_file():
+        return None
+    return load_run_summary(path)
+
+
+def load_result_sets(
+    results_dir: Path,
+) -> dict[str, tuple[str, dict[SeriesKey, list[Point]]]]:
+    sets: dict[str, tuple[str, dict[SeriesKey, list[Point]]]] = {}
+    for path in sorted(results_dir.glob(RESULT_GLOB)):
+        name = path.name
+        if not name.startswith("bench_result-") or not name.endswith("-baseline.json"):
+            continue
+        suite = name[len("bench_result-") : -len("-baseline.json")]
+        sets[canonical_suite_name(suite)] = (suite, result_series(path))
+    return sets
+
+
+def comparison_chart_path(
+    output_dir: Path,
+    suite: str,
+    key: SeriesKey,
+    left_label: str,
+    right_label: str,
+    seen: set[Path],
+) -> Path:
+    base = (
+        f"bench_result-{slug(suite)}-{subbenchmark_name(key)}-"
+        f"{slug(left_label)}-vs-{slug(right_label)}"
+    )
+    path = output_dir / f"{base}.png"
+    suffix = 1
+    while path in seen:
+        path = output_dir / f"{base}-{suffix}.png"
+        suffix += 1
+    seen.add(path)
+    return path
+
+
+def render_comparison_chart(
+    plt: Any,
+    title: str,
+    left_label: str,
+    left: list[Point],
+    right_label: str,
+    right: list[Point],
+    output_path: Path,
+) -> None:
+    if len(left) != len(right):
+        raise RuntimeError(f"point count mismatch for {title}")
+    for left_point, right_point in zip(left, right):
+        if left_point.tree_log2 != right_point.tree_log2:
+            raise RuntimeError(f"tree size mismatch for {title}")
+
+    figure, axis = plt.subplots(figsize=(10, 6))
+    for label, points, color in (
+        (left_label, left, "#3264a8"),
+        (right_label, right, "#d35400"),
+    ):
+        x = [point.tree_log2 for point in points]
+        y = [point.duration_ns / NS_PER_US for point in points]
+        lower = [point.lower_ns / NS_PER_US for point in points]
+        upper = [point.upper_ns / NS_PER_US for point in points]
+        axis.plot(x, y, marker="o", linewidth=2, label=label, color=color)
+        axis.fill_between(x, lower, upper, color=color, alpha=0.14)
+
+    x_ticks = sorted({point.tree_log2 for point in left} | {point.tree_log2 for point in right})
+    axis.set_xticks(x_ticks)
+    axis.set_xticklabels([f"{value:g}" for value in x_ticks])
+    axis.set_yscale("log")
+    axis.set_xlabel("log2(tree size)")
+    axis.set_ylabel("Mean duration per query (us, log scale)")
+    axis.set_title(title)
+    axis.grid(True, which="both", alpha=0.25)
+    axis.legend()
+
+    y_min, y_max = axis.get_ylim()
+    upward_factor = 10**0.009
+    downward_factor = 10**-0.0125
+    lower_safe = y_min * (10**0.01)
+    upper_safe = y_max * (10**-0.01)
+    for left_point, right_point in zip(left, right):
+        delta_fraction = (right_point.duration_ns - left_point.duration_ns) / left_point.duration_ns
+        delta_percent = round(delta_fraction * 100)
+        label = f"{delta_percent:+.0f}%"
+        left_y_us = left_point.duration_ns / NS_PER_US
+        right_y_us = right_point.duration_ns / NS_PER_US
+        if delta_fraction < 0:
+            anchor_y = right_y_us
+            preferred_above = False
+        else:
+            anchor_y = left_y_us
+            preferred_above = True
+
+        preferred_y = anchor_y * (upward_factor if preferred_above else downward_factor)
+        if lower_safe <= preferred_y <= upper_safe:
+            place_above = preferred_above
+            text_y = preferred_y
+        else:
+            place_above = not preferred_above
+            text_y = anchor_y * (upward_factor if place_above else downward_factor)
+
+        axis.text(
+            right_point.tree_log2,
+            text_y,
+            label,
+            color="#1f8f3a" if delta_fraction < 0 else "#c0392b",
+            fontsize=9,
+            ha="center",
+            va="bottom" if place_above else "top",
+            bbox={
+                "facecolor": "white",
+                "edgecolor": "none",
+                "alpha": 0.85,
+                "pad": 0.25,
+            },
+        )
+
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=140)
+    plt.close(figure)
+
+
+def render_latest_comparison(pages_root: Path, site_url_base: str | None) -> str | None:
+    v5_root = pages_root / "v5"
+    v6_root = pages_root / "v6"
+    v5_summary = latest_baseline_summary(v5_root)
+    v6_summary = latest_baseline_summary(v6_root)
+    if v5_summary is None or v6_summary is None:
+        return None
+
+    v5_results = load_result_sets(v5_root / "baseline" / "latest" / "results")
+    v6_results = load_result_sets(v6_root / "baseline" / "latest" / "results")
+    shared_suites = sorted(v5_results.keys() & v6_results.keys())
+    compare_root = pages_root / "compare" / "v5-v6-latest"
+    charts_dir = compare_root / "charts"
+    charts_dir.mkdir(parents=True, exist_ok=True)
+    for path in charts_dir.glob("*.png"):
+        path.unlink()
+
+    _, plt = import_matplotlib()
+    chart_rows: list[tuple[str, str, float]] = []
+    seen: set[Path] = set()
+    for canonical_suite in shared_suites:
+        _, v5_series = v5_results[canonical_suite]
+        _, v6_series = v6_results[canonical_suite]
+        common_keys = sorted(
+            v5_series.keys() & v6_series.keys(),
+            key=lambda key: (key.group_id, key.function_id),
+        )
+        for key in common_keys:
+            title = f"{canonical_suite}: {key.group_id} / {key.function_id}"
+            chart_path = comparison_chart_path(
+                charts_dir,
+                canonical_suite,
+                key,
+                "v5",
+                "v6",
+                seen,
+            )
+            render_comparison_chart(
+                plt,
+                title,
+                "v5",
+                v5_series[key],
+                "v6",
+                v6_series[key],
+                chart_path,
+            )
+            chart_rows.append((title, chart_path.name, change_score(v5_series[key], v6_series[key])))
+
+    chart_rows.sort(key=lambda row: row[2], reverse=True)
+    sections = []
+    for title, file_name, _ in chart_rows:
+        sections.append(
+            f"<section><h2>{html.escape(title)}</h2>"
+            f"<img src=\"charts/{file_name}\" alt=\"{html.escape(title, quote=True)}\"></section>"
+        )
+
+    v5_url = site_join(site_url_base, "v5/baseline/latest/index.html")
+    v6_url = site_join(site_url_base, "v6/baseline/latest/index.html")
+    body = f"""
+<p><a href="../../index.html">Home</a></p>
+<h1>Latest v5 vs latest v6 baseline comparison</h1>
+<p class="meta">v5 baseline: <code>{v5_summary.run_id}</code> · <code>{v5_summary.sha[:12]}</code></p>
+<p class="meta">v6 baseline: <code>{v6_summary.run_id}</code> · <code>{v6_summary.sha[:12]}</code></p>
+<p>{f'<a href="{v5_url}">View latest v5 baseline</a>' if v5_url else ''}</p>
+<p>{f'<a href="{v6_url}">View latest v6 baseline</a>' if v6_url else ''}</p>
+<p>{len(chart_rows)} shared charts generated from the latest published baselines.</p>
+{''.join(sections) if sections else '<section><p class="meta">No shared benchmark suites are published yet.</p></section>'}
+"""
+    write_text(compare_root / "index.html", render_html("Latest v5 vs latest v6 benchmark comparison", body))
+    return "compare/v5-v6-latest/index.html"
+
+
+def render_root_index(pages_root: Path, site_url_base: str | None) -> None:
+    line_rows = []
+    for line in LINE_ORDER:
+        line_root = pages_root / line
+        summary = latest_baseline_summary(line_root)
+        if summary is None:
+            continue
+        line_rows.append(
+            "<tr>"
+            f"<td><a href=\"{line}/index.html\">{line}</a></td>"
+            f"<td><code>{summary.baseline_ref_name}</code></td>"
+            f"<td><a href=\"{line}/baseline/latest/index.html\">{summary.run_id}</a></td>"
+            f"<td><code>{summary.sha[:12]}</code></td>"
+            f"<td>{summary.created_at}</td>"
+            "</tr>"
+        )
+
+    compare_rel = render_latest_comparison(pages_root, site_url_base)
+    compare_link = (
+        f'<p><a href="{compare_rel}">Compare latest v5 and v6 baselines</a></p>'
+        if compare_rel
+        else "<p class=\"meta\">The latest v5-v6 comparison page will appear after both lines publish a baseline.</p>"
+    )
+    body = f"""
+<h1>Kiddo benchmark reports</h1>
+<p>This index links the line-specific benchmark sites and the latest v5-v6 parity comparison.</p>
+<section>
+  <h2>Benchmark lines</h2>
+  <table>
+    <thead><tr><th>Line</th><th>Baseline branch</th><th>Latest baseline run</th><th>SHA</th><th>Created</th></tr></thead>
+    <tbody>{''.join(line_rows) if line_rows else '<tr><td colspan="5">No line baselines published yet.</td></tr>'}</tbody>
+  </table>
+</section>
+<section>
+  <h2>Cross-line comparison</h2>
+  {compare_link}
+</section>
+"""
+    write_text(pages_root / "index.html", render_html("Kiddo benchmark reports", body))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pages-root", type=Path, required=True)
+    parser.add_argument("--site-url-base")
+    args = parser.parse_args()
+    render_root_index(args.pages_root.resolve(), args.site_url_base)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add  to the basic v6 Eytzinger profile suite
- add an extended v6 query-family profile covering within/nearest-within/best-n-within queries
- publish v6 benchmark results under  and rebuild a shared root index plus latest v5-v6 comparison page
- route  comment dispatch to the correct base branch workflow and fix the profile query-count env var used by the v6 recipes

## Validation
- cargo fmt --all
- python3 -m py_compile scripts/benchmark_site.py scripts/benchmark_site_root.py scripts/chart_benchmark_results.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmark-report.yml")'
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmark-report-dispatch.yml")'
- cargo check --bench profile_v6_approx_nearest_one_eytzinger --bench profile_v6_query_family_eytzinger --features simd,test_utils,logging_off