### PR TITLE
perf: prototype embedded leaf descriptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,12 @@ harness = false
 required-features = ["simd", "test_utils"]
 
 [[bench]]
+name = "profile_v6_embedded_leaf_descriptor"
+path = "benches/profile_v6_embedded_leaf_descriptor.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "profile_v6_stem_exact_stats"
 path = "benches/profile_v6_stem_exact_stats.rs"
 harness = false

--- a/benches/profile_v6_embedded_leaf_descriptor.rs
+++ b/benches/profile_v6_embedded_leaf_descriptor.rs
@@ -1,0 +1,180 @@
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::embedded_leaf_descriptor_experiment::EmbeddedLeafDescriptorF64Tree;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::VecOfArenas;
+use kiddo::stem_strategy::{Donnelly, DonnellySimdDescent, DonnellyUnrolled, Eytzinger};
+use kiddo::{LeafStrategy, StemStrategy};
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const DEFAULT_MIN_LOG2_POINTS: u32 = 16;
+const DEFAULT_MAX_LOG2_POINTS: u32 = 26;
+const POINT_SEED: u64 = 0x5eed_0000_0000_ed01;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_ed02;
+
+type ArenaLeaves = VecOfArenas<f64, u32, K, B>;
+type BaselineTree<SS> = KdTree<f64, u32, SS, ArenaLeaves, K, B>;
+
+fn read_usize_env(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn read_u32_env(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn build_points(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn run_embedded(tree: &EmbeddedLeafDescriptorF64Tree<K, B>, queries: &[[f64; K]]) -> (f64, u64) {
+    let mut distance_checksum = 0.0;
+    let mut item_checksum = 0u64;
+    for query in queries {
+        let (distance, item) =
+            tree.approx_nearest_one_embedded::<SquaredEuclidean<f64>>(black_box(query));
+        distance_checksum += distance;
+        item_checksum = item_checksum.wrapping_add(u64::from(item));
+    }
+    (distance_checksum, item_checksum)
+}
+
+fn run_extent_control(
+    tree: &EmbeddedLeafDescriptorF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut distance_checksum = 0.0;
+    let mut item_checksum = 0u64;
+    for query in queries {
+        let (distance, item) =
+            tree.approx_nearest_one_via_extents::<SquaredEuclidean<f64>>(black_box(query));
+        distance_checksum += distance;
+        item_checksum = item_checksum.wrapping_add(u64::from(item));
+    }
+    (distance_checksum, item_checksum)
+}
+
+fn run_baseline<SS>(tree: &BaselineTree<SS>, queries: &[[f64; K]]) -> (f64, u64)
+where
+    SS: StemStrategy,
+    ArenaLeaves: LeafStrategy<f64, u32, SS, K, B>,
+{
+    let mut distance_checksum = 0.0;
+    let mut item_checksum = 0u64;
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .approx()
+            .execute();
+        distance_checksum += result.distance;
+        item_checksum = item_checksum.wrapping_add(u64::from(result.item));
+    }
+    (distance_checksum, item_checksum)
+}
+
+fn bench_baseline<SS>(
+    group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    label: &str,
+    point_count: usize,
+    points: &[[f64; K]],
+    queries: &[[f64; K]],
+) where
+    SS: StemStrategy,
+    ArenaLeaves: LeafStrategy<f64, u32, SS, K, B>,
+{
+    let tree: BaselineTree<SS> = KdTree::new_from_slice(points).unwrap();
+    group.bench_function(BenchmarkId::new(label, point_count), |bencher| {
+        bencher.iter(|| black_box(run_baseline(&tree, queries)))
+    });
+}
+
+fn embedded_leaf_descriptor(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_BENCH_QUERIES", DEFAULT_QUERY_COUNT);
+    let min_log2 = read_u32_env("KIDDO_BENCH_MIN_LOG2_POINTS", DEFAULT_MIN_LOG2_POINTS);
+    let max_log2 = read_u32_env("KIDDO_BENCH_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+    assert!(min_log2 <= max_log2);
+
+    let queries = build_queries(query_count);
+    let mut group = c.benchmark_group("profile_v6_embedded_leaf_descriptor/f64_k3_b32");
+    group.throughput(Throughput::Elements(query_count as u64));
+
+    for log2_points in min_log2..=max_log2 {
+        let point_count = 1usize << log2_points;
+        let points = build_points(point_count);
+        let tree = EmbeddedLeafDescriptorF64Tree::<K, B>::new_from_slice(&points).unwrap();
+
+        assert_eq!(
+            run_embedded(&tree, &queries),
+            run_extent_control(&tree, &queries)
+        );
+        eprintln!(
+            "embedded descriptor tree: 2^{log2_points} points, {} leaves, {} stem words",
+            tree.leaf_count(),
+            tree.stem_word_count()
+        );
+
+        group.bench_function(
+            BenchmarkId::new("embedded_descriptor", point_count),
+            |bencher| bencher.iter(|| black_box(run_embedded(&tree, &queries))),
+        );
+        group.bench_function(
+            BenchmarkId::new("embedded_extent_control", point_count),
+            |bencher| bencher.iter(|| black_box(run_extent_control(&tree, &queries))),
+        );
+        drop(tree);
+
+        bench_baseline::<DonnellyUnrolled<3>>(
+            &mut group,
+            "baseline_donnelly_unrolled",
+            point_count,
+            &points,
+            &queries,
+        );
+        bench_baseline::<Donnelly<3>>(
+            &mut group,
+            "baseline_donnelly",
+            point_count,
+            &points,
+            &queries,
+        );
+        bench_baseline::<DonnellySimdDescent<3>>(
+            &mut group,
+            "baseline_donnelly_simd_descent",
+            point_count,
+            &points,
+            &queries,
+        );
+        bench_baseline::<Eytzinger>(
+            &mut group,
+            "baseline_eytzinger",
+            point_count,
+            &points,
+            &queries,
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, embedded_leaf_descriptor);
+criterion_main!(benches);

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -19,8 +19,8 @@ const DEFAULT_QUERY_COUNT: usize = 1_000;
 const DEFAULT_MAX_LOG2_POINTS: usize = 26;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
-const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
-const APPROX_TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 25];
+const APPROX_TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -31,7 +31,6 @@ const APPROX_TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 
 type FlatTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -1,11 +1,14 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(coverage_nightly, coverage(off))]
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use kiddo::kd_tree::embedded_leaf_descriptor_experiment::EmbeddedLeafDescriptorF64Tree;
 use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::{FlatVec, VecOfArenas, VecOfArrays};
-use kiddo::stem_strategy::Eytzinger;
-use kiddo::SquaredEuclidean;
+use kiddo::stem_strategy::{DonnellySimdDescent, DonnellyUnrolled, Eytzinger};
+use kiddo::{LeafStrategy, SquaredEuclidean, StemStrategy};
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
@@ -17,10 +20,25 @@ const DEFAULT_MAX_LOG2_POINTS: usize = 26;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
 const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
+const APPROX_TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
 
 type FlatTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
 type ArenaTree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, K, B>, K, B>;
 type VecOfArraysTree = KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, K, B>, K, B>;
+type ArenaLeaves = VecOfArenas<f64, u32, K, B>;
+type ApproxBaselineTree<SS> = KdTree<f64, u32, SS, ArenaLeaves, K, B>;
 
 fn read_usize_env(var: &str, default: usize) -> usize {
     std::env::var(var)
@@ -87,6 +105,77 @@ fn run_queries_vec_of_arrays(tree: &VecOfArraysTree, queries: &[[f64; K]]) -> (f
     (checksum_dist, checksum_item)
 }
 
+fn run_approx_embedded(
+    tree: &EmbeddedLeafDescriptorF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let (distance, item) =
+            tree.approx_nearest_one_embedded::<SquaredEuclidean<f64>>(black_box(query));
+        checksum_dist += distance;
+        checksum_item = checksum_item.wrapping_add(u64::from(item));
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_approx_extent_control(
+    tree: &EmbeddedLeafDescriptorF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let (distance, item) =
+            tree.approx_nearest_one_via_extents::<SquaredEuclidean<f64>>(black_box(query));
+        checksum_dist += distance;
+        checksum_item = checksum_item.wrapping_add(u64::from(item));
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_approx_baseline<SS>(tree: &ApproxBaselineTree<SS>, queries: &[[f64; K]]) -> (f64, u64)
+where
+    SS: StemStrategy,
+    ArenaLeaves: LeafStrategy<f64, u32, SS, K, B>,
+{
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .approx()
+            .execute();
+        checksum_dist += result.distance;
+        checksum_item = checksum_item.wrapping_add(u64::from(result.item));
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn bench_approx_baseline<SS>(
+    group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    label: &str,
+    point_count: usize,
+    points: &[[f64; K]],
+    queries: &[[f64; K]],
+) where
+    SS: StemStrategy,
+    ArenaLeaves: LeafStrategy<f64, u32, SS, K, B>,
+{
+    let tree: ApproxBaselineTree<SS> = KdTree::new_from_slice(points).unwrap();
+    group.bench_function(BenchmarkId::new(label, point_count), |b| {
+        b.iter(|| black_box(run_approx_baseline(&tree, queries)))
+    });
+}
+
 fn leaf_strategies(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
     let max_log2_points = read_usize_env("KIDDO_PROFILE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
@@ -123,6 +212,57 @@ fn leaf_strategies(c: &mut Criterion) {
     }
 
     group.finish();
+
+    eprintln!(
+        "benchmarking v6 approx_nearest_one f64 embedded leaf descriptors: dims={} tree_sizes=2^16..=2^26 queries={}",
+        K, query_count
+    );
+
+    let mut approx_group = c.benchmark_group("profile_v6_leaf_strategies/approx_nearest_one_f64");
+    approx_group.throughput(Throughput::Elements(query_count as u64));
+
+    for point_count in APPROX_TREE_SIZES {
+        let points = build_points(point_count);
+        let embedded_tree = EmbeddedLeafDescriptorF64Tree::<K, B>::new_from_slice(&points).unwrap();
+
+        assert_eq!(
+            run_approx_embedded(&embedded_tree, &queries),
+            run_approx_extent_control(&embedded_tree, &queries)
+        );
+
+        approx_group.bench_function(BenchmarkId::new("embedded_descriptor", point_count), |b| {
+            b.iter(|| black_box(run_approx_embedded(&embedded_tree, &queries)))
+        });
+        approx_group.bench_function(
+            BenchmarkId::new("embedded_extent_control", point_count),
+            |b| b.iter(|| black_box(run_approx_extent_control(&embedded_tree, &queries))),
+        );
+        drop(embedded_tree);
+
+        bench_approx_baseline::<DonnellyUnrolled<3>>(
+            &mut approx_group,
+            "baseline_donnelly_unrolled",
+            point_count,
+            &points,
+            &queries,
+        );
+        bench_approx_baseline::<DonnellySimdDescent<3>>(
+            &mut approx_group,
+            "baseline_donnelly_simd_descent",
+            point_count,
+            &points,
+            &queries,
+        );
+        bench_approx_baseline::<Eytzinger>(
+            &mut approx_group,
+            "baseline_eytzinger",
+            point_count,
+            &points,
+            &queries,
+        );
+    }
+
+    approx_group.finish();
 }
 
 criterion_group!(benches, leaf_strategies);

--- a/scripts/chart_benchmark_results.py
+++ b/scripts/chart_benchmark_results.py
@@ -37,6 +37,17 @@ MATRIX_COLORS = (
     "#7f5f00",
     "#00838f",
 )
+LEAF_STRATEGY_SUITE = "v6-leaf-strategies"
+EMBEDDED_LEAF_DESCRIPTOR_GROUP_ID = (
+    "profile_v6_leaf_strategies/approx_nearest_one_f64"
+)
+EMBEDDED_LEAF_DESCRIPTOR_SERIES = (
+    ("embedded_descriptor", "embedded descriptor"),
+    ("embedded_extent_control", "same-layout extent control"),
+    ("baseline_donnelly_unrolled", "Donnelly unrolled"),
+    ("baseline_donnelly_simd_descent", "Donnelly SIMD descent"),
+    ("baseline_eytzinger", "Eytzinger"),
+)
 
 
 @dataclass(frozen=True)
@@ -326,6 +337,53 @@ def render_matrix_chart(
     plt.close(figure)
 
 
+def render_intra_run_matrix_chart(
+    plt: Any,
+    title: str,
+    series: list[tuple[str, list[Point]]],
+    output_path: Path,
+) -> None:
+    figure, axis = plt.subplots(figsize=(11, 7))
+    x_ticks: set[float] = set()
+    reference_name, reference_points = series[0]
+
+    for index, (series_name, points) in enumerate(series):
+        validate_series_pair(
+            reference_points,
+            points,
+            f"{title}: {reference_name} / {series_name}",
+        )
+        color = MATRIX_COLORS[index % len(MATRIX_COLORS)]
+        x = [point.tree_log2 for point in points]
+        y = [point.duration_ns / NS_PER_US for point in points]
+        lower = [point.lower_ns / NS_PER_US for point in points]
+        upper = [point.upper_ns / NS_PER_US for point in points]
+        x_ticks.update(x)
+        axis.plot(
+            x,
+            y,
+            marker="o",
+            linewidth=2.6 if index < 2 else 2,
+            linestyle="--" if index == 1 else "-",
+            label=series_name,
+            color=color,
+        )
+        axis.fill_between(x, lower, upper, color=color, alpha=0.08)
+
+    sorted_ticks = sorted(x_ticks)
+    axis.set_xticks(sorted_ticks)
+    axis.set_xticklabels([f"{value:g}" for value in sorted_ticks])
+    axis.set_yscale("log")
+    axis.set_xlabel("log2(tree size)")
+    axis.set_ylabel("Mean duration per query (us, log scale)")
+    axis.set_title(title)
+    axis.grid(True, which="both", alpha=0.25)
+    axis.legend(fontsize=9, ncol=2)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=140)
+    plt.close(figure)
+
+
 def matrix_change_score(series: list[tuple[str, list[Point], list[Point]]]) -> float:
     return sum(change_score(baseline, variant) for _, baseline, variant in series)
 
@@ -515,6 +573,52 @@ def generate_dist_metric_matrix_charts(
     return charts, metadata
 
 
+def generate_embedded_leaf_descriptor_matrix_chart(
+    plt: Any,
+    variant_key: str,
+    output_dir: Path,
+    variant_series: dict[SeriesKey, list[Point]],
+    paths_seen: set[Path],
+) -> tuple[list[tuple[str, Path]], list[dict[str, str | float]]]:
+    expected = [
+        (
+            SeriesKey(EMBEDDED_LEAF_DESCRIPTOR_GROUP_ID, function_id),
+            label,
+        )
+        for function_id, label in EMBEDDED_LEAF_DESCRIPTOR_SERIES
+    ]
+    if not all(key in variant_series for key, _ in expected):
+        return [], []
+
+    series = [(label, variant_series[key]) for key, label in expected]
+    chart_key = SeriesKey(
+        EMBEDDED_LEAF_DESCRIPTOR_GROUP_ID,
+        "embedded_leaf_descriptor_matrix",
+    )
+    chart_path = unique_chart_path(
+        output_dir,
+        LEAF_STRATEGY_SUITE,
+        chart_key,
+        variant_key,
+        paths_seen,
+    )
+    title = f"Embedded leaf descriptors: approx_nearest_one f64 ({variant_key})"
+    render_intra_run_matrix_chart(plt, title, series, chart_path)
+
+    embedded = variant_series[expected[0][0]]
+    extent_control = variant_series[expected[1][0]]
+    return [(title, chart_path)], [
+        {
+            "title": title,
+            "file_name": chart_path.name,
+            "suite": LEAF_STRATEGY_SUITE,
+            "group_id": EMBEDDED_LEAF_DESCRIPTOR_GROUP_ID,
+            "function_id": "embedded_leaf_descriptor_matrix",
+            "change_score": change_score(extent_control, embedded),
+        }
+    ]
+
+
 def generate_charts(
     variant_key: str,
     results_dir: Path,
@@ -582,6 +686,19 @@ def generate_charts(
                     "change_score": change_score(baseline_series[key], variant_series[key]),
                 }
             )
+
+        if suite == LEAF_STRATEGY_SUITE:
+            matrix_charts, matrix_metadata = (
+                generate_embedded_leaf_descriptor_matrix_chart(
+                    plt,
+                    variant_key,
+                    output_dir,
+                    variant_series,
+                    paths_seen,
+                )
+            )
+            charts.extend(matrix_charts)
+            metadata.extend(matrix_metadata)
 
     matrix_charts, matrix_metadata = generate_dist_metric_matrix_charts(
         plt,

--- a/src/kd_tree/construction.rs
+++ b/src/kd_tree/construction.rs
@@ -427,10 +427,13 @@ where
         }
 
         let mut stems_depth: usize = leaf_node_count.next_power_of_two().ilog2() as usize;
+        let unpadded_stems_depth = stems_depth;
 
-        // Pad stem tree height to the next block boundary for block-based strategies
-        let padding_level_count = if !stems_depth.is_multiple_of(SS::block_size()) {
-            let padding_level_count = SS::block_size() - (stems_depth % SS::block_size());
+        // Pad the occupied tree height to the next block boundary. Experimental
+        // layouts may reserve terminal levels in the final block for leaf metadata.
+        let occupied_depth = stems_depth + SS::TERMINAL_METADATA_LEVELS;
+        let padding_level_count = if !occupied_depth.is_multiple_of(SS::block_size()) {
+            let padding_level_count = SS::block_size() - (occupied_depth % SS::block_size());
             stems_depth += padding_level_count;
             padding_level_count
         } else {
@@ -452,7 +455,13 @@ where
         };
 
         // Traverse to the right-most represented leaf to determine the max used stem index
-        let rightmost_leaf_idx = soft_leaf_budget - 1;
+        let rightmost_leaf_idx = if LS::BUCKET_LIMIT_TYPE == BucketLimitType::Soft
+            && SS::TERMINAL_METADATA_LEVELS != 0
+        {
+            (1usize << unpadded_stems_depth) - 1
+        } else {
+            soft_leaf_budget - 1
+        };
         let rightmost_leaf_bit_range = if LS::BUCKET_LIMIT_TYPE == BucketLimitType::Soft {
             0..stems_depth
         } else {

--- a/src/kd_tree/embedded_leaf_descriptor_experiment.rs
+++ b/src/kd_tree/embedded_leaf_descriptor_experiment.rs
@@ -1,0 +1,254 @@
+//! Benchmark-only embedded leaf descriptor experiment.
+
+use std::ptr::NonNull;
+
+use aligned_vec::{AVec, CACHELINE_ALIGN};
+
+use crate::dist::DistanceMetric;
+use crate::kd_tree::{ConstructionError, KdTree};
+use crate::leaf_strategy::VecOfArenas;
+use crate::stem_strategy::DonnellyUnrolledLeafEmbedded3;
+use crate::{LeafStrategy, StemStrategy};
+
+const DESCRIPTOR_OFFSET_BITS: u32 = 48;
+const DESCRIPTOR_OFFSET_MASK: u64 = (1u64 << DESCRIPTOR_OFFSET_BITS) - 1;
+const FINAL_PIVOT_LEVELS: i32 = 2;
+
+type ConstructionTree<const K: usize, const B: usize> =
+    KdTree<f64, u32, DonnellyUnrolledLeafEmbedded3, VecOfArenas<f64, u32, K, B>, K, B>;
+
+/// Construction failure for the benchmark-only 48-bit-offset/16-bit-length layout.
+#[doc(hidden)]
+#[derive(Debug)]
+pub enum EmbeddedLeafDescriptorError {
+    /// The ordinary kd-tree construction failed.
+    Construction(ConstructionError),
+    /// A byte offset did not fit in the descriptor's low 48 bits.
+    ByteOffsetOverflow { leaf_idx: usize, byte_offset: usize },
+    /// A leaf length did not fit in the descriptor's high 16 bits.
+    LeafLengthOverflow { leaf_idx: usize, leaf_len: usize },
+}
+
+impl From<ConstructionError> for EmbeddedLeafDescriptorError {
+    fn from(value: ConstructionError) -> Self {
+        Self::Construction(value)
+    }
+}
+
+/// An aligned integer-word Donnelly tree used only by the descriptor benchmark.
+///
+/// Pivot words contain `f64::to_bits()` values. The last level of every final
+/// block contains a packed 48-bit arena byte offset and 16-bit leaf length.
+#[doc(hidden)]
+pub struct EmbeddedLeafDescriptorF64Tree<const K: usize, const B: usize> {
+    stem_words: AVec<u64>,
+    leaves: VecOfArenas<f64, u32, K, B>,
+    max_stem_level: i32,
+    leaf_count: usize,
+}
+
+impl<const K: usize, const B: usize> EmbeddedLeafDescriptorF64Tree<K, B> {
+    /// Builds the benchmark tree while retaining the ordinary leaf extent table.
+    pub fn new_from_slice(source: &[[f64; K]]) -> Result<Self, EmbeddedLeafDescriptorError> {
+        let tree: ConstructionTree<K, B> = KdTree::new_from_slice(source)?;
+        let KdTree {
+            stems,
+            leaves,
+            max_stem_level,
+            ..
+        } = tree;
+
+        let leaf_count = <VecOfArenas<f64, u32, K, B> as LeafStrategy<
+            f64,
+            u32,
+            DonnellyUnrolledLeafEmbedded3,
+            K,
+            B,
+        >>::leaf_count(&leaves);
+
+        let mut stem_words = AVec::new(CACHELINE_ALIGN);
+        stem_words.resize(stems.len(), 0);
+        for (word, pivot) in stem_words.iter_mut().zip(stems.iter()) {
+            *word = pivot.to_bits();
+        }
+
+        let pivot_depth = (max_stem_level + 1) as usize;
+        debug_assert_eq!((pivot_depth + 1) % 3, 0);
+
+        for leaf_idx in 0..leaf_count {
+            let (byte_offset, leaf_len) = leaves.leaf_extent_for_embedded_descriptor(leaf_idx);
+            let descriptor = pack_descriptor(leaf_idx, byte_offset, leaf_len)?;
+            let terminal_stem_idx = terminal_stem_idx::<K>(leaf_idx, pivot_depth);
+            debug_assert!(terminal_stem_idx < stem_words.len());
+            unsafe {
+                *stem_words.get_unchecked_mut(terminal_stem_idx) = descriptor;
+            }
+        }
+
+        Ok(Self {
+            stem_words,
+            leaves,
+            max_stem_level,
+            leaf_count,
+        })
+    }
+
+    /// Approximate nearest-one using the existing extent indirection.
+    #[inline(always)]
+    pub fn approx_nearest_one_via_extents<D>(&self, query: &[f64; K]) -> (f64, u32)
+    where
+        D: DistanceMetric<f64, Output = f64>,
+    {
+        let (leaf_idx, _) = self.descend(query);
+        let arena = <VecOfArenas<f64, u32, K, B> as LeafStrategy<
+            f64,
+            u32,
+            DonnellyUnrolledLeafEmbedded3,
+            K,
+            B,
+        >>::leaf_arena(&self.leaves, leaf_idx);
+        process_arena::<D, K>(&arena, query)
+    }
+
+    /// Approximate nearest-one using the descriptor selected from the final block.
+    #[inline(always)]
+    pub fn approx_nearest_one_embedded<D>(&self, query: &[f64; K]) -> (f64, u32)
+    where
+        D: DistanceMetric<f64, Output = f64>,
+    {
+        let (_, descriptor_idx) = self.descend(query);
+        let descriptor = unsafe { *self.stem_words.get_unchecked(descriptor_idx) };
+        let (byte_offset, leaf_len) = unpack_descriptor(descriptor);
+        let arena = self
+            .leaves
+            .leaf_arena_from_embedded_descriptor(byte_offset, leaf_len);
+        process_arena::<D, K>(&arena, query)
+    }
+
+    /// Number of logical leaves, exposed for benchmark validation.
+    #[inline]
+    pub fn leaf_count(&self) -> usize {
+        self.leaf_count
+    }
+
+    /// Number of packed stem/descriptor words, exposed for benchmark diagnostics.
+    #[inline]
+    pub fn stem_word_count(&self) -> usize {
+        self.stem_words.len()
+    }
+
+    #[inline(always)]
+    fn descend(&self, query: &[f64; K]) -> (usize, usize) {
+        let stems_ptr = NonNull::new(self.stem_words.as_ptr() as *mut u8).unwrap();
+        let mut strat = DonnellyUnrolledLeafEmbedded3::new(stems_ptr);
+        let pivot_depth = self.max_stem_level + 1;
+
+        debug_assert_eq!((pivot_depth + 1) % 3, 0);
+
+        while strat.level() + FINAL_PIVOT_LEVELS < pivot_depth {
+            self.traverse_head(&mut strat, query);
+            self.traverse_head(&mut strat, query);
+            self.traverse_tail(&mut strat, query);
+        }
+
+        self.traverse_head(&mut strat, query);
+        self.traverse_head(&mut strat, query);
+
+        let leaf_idx = strat.leaf_idx();
+        debug_assert!(leaf_idx < self.leaf_count);
+        (leaf_idx, strat.stem_idx())
+    }
+
+    #[inline(always)]
+    fn traverse_head(&self, strat: &mut DonnellyUnrolledLeafEmbedded3, query: &[f64; K]) {
+        let pivot = f64::from_bits(unsafe { *self.stem_words.get_unchecked(strat.stem_idx()) });
+        let query_value = unsafe { *query.get_unchecked(strat.dim::<K>()) };
+        strat.traverse_head::<f64, K>(query_value >= pivot);
+    }
+
+    #[inline(always)]
+    fn traverse_tail(&self, strat: &mut DonnellyUnrolledLeafEmbedded3, query: &[f64; K]) {
+        let pivot = f64::from_bits(unsafe { *self.stem_words.get_unchecked(strat.stem_idx()) });
+        let query_value = unsafe { *query.get_unchecked(strat.dim::<K>()) };
+        strat.traverse_tail::<f64, K>(query_value >= pivot);
+    }
+}
+
+#[inline(always)]
+fn process_arena<D, const K: usize>(
+    arena: &crate::leaf_view::LeafArena<'_, f64, u32, K>,
+    query: &[f64; K],
+) -> (f64, u32)
+where
+    D: DistanceMetric<f64, Output = f64>,
+{
+    let mut best_dist = f64::INFINITY;
+    let mut best_item = 0;
+    crate::leaf_view_chunked::nearest_one::nearest_one_with_query_wide_arena::<f64, u32, D, K>(
+        arena,
+        query,
+        &mut best_dist,
+        &mut best_item,
+    );
+    (best_dist, best_item)
+}
+
+fn pack_descriptor(
+    leaf_idx: usize,
+    byte_offset: usize,
+    leaf_len: usize,
+) -> Result<u64, EmbeddedLeafDescriptorError> {
+    if byte_offset as u128 > DESCRIPTOR_OFFSET_MASK as u128 {
+        return Err(EmbeddedLeafDescriptorError::ByteOffsetOverflow {
+            leaf_idx,
+            byte_offset,
+        });
+    }
+    let leaf_len = u16::try_from(leaf_len)
+        .map_err(|_| EmbeddedLeafDescriptorError::LeafLengthOverflow { leaf_idx, leaf_len })?;
+    Ok((u64::from(leaf_len) << DESCRIPTOR_OFFSET_BITS) | byte_offset as u64)
+}
+
+#[inline(always)]
+fn unpack_descriptor(descriptor: u64) -> (usize, usize) {
+    (
+        (descriptor & DESCRIPTOR_OFFSET_MASK) as usize,
+        (descriptor >> DESCRIPTOR_OFFSET_BITS) as usize,
+    )
+}
+
+fn terminal_stem_idx<const K: usize>(leaf_idx: usize, pivot_depth: usize) -> usize {
+    let mut strat = DonnellyUnrolledLeafEmbedded3::new_no_ptr();
+    for bit_idx in (0..pivot_depth).rev() {
+        let is_right = leaf_idx & (1usize << bit_idx) != 0;
+        strat.traverse::<f64, K>(is_right);
+    }
+    strat.stem_idx()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EmbeddedLeafDescriptorF64Tree;
+    use crate::dist::SquaredEuclidean;
+    use rand::{RngExt, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn embedded_and_extent_paths_match() {
+        const K: usize = 3;
+        const B: usize = 32;
+        let mut rng = ChaCha8Rng::seed_from_u64(0x5eed_edd0);
+        let points: Vec<[f64; K]> = (0..4096).map(|_| rng.random()).collect();
+        let queries: Vec<[f64; K]> = (0..256).map(|_| rng.random()).collect();
+        let tree = EmbeddedLeafDescriptorF64Tree::<K, B>::new_from_slice(&points).unwrap();
+
+        assert_eq!(tree.leaf_count(), 128);
+        assert!(tree.stem_word_count() > tree.leaf_count());
+        for query in &queries {
+            assert_eq!(
+                tree.approx_nearest_one_via_extents::<SquaredEuclidean<f64>>(query),
+                tree.approx_nearest_one_embedded::<SquaredEuclidean<f64>>(query)
+            );
+        }
+    }
+}

--- a/src/kd_tree/mod.rs
+++ b/src/kd_tree/mod.rs
@@ -16,6 +16,9 @@
 //!   soon as they are found.
 //!
 mod construction;
+#[cfg(feature = "test_utils")]
+#[doc(hidden)]
+pub mod embedded_leaf_descriptor_experiment;
 mod iter;
 pub(crate) mod orchestrator;
 mod query;

--- a/src/leaf_strategy/vec_of_arenas.rs
+++ b/src/leaf_strategy/vec_of_arenas.rs
@@ -68,6 +68,34 @@ pub struct VecOfArenas<A, T, const K: usize, const B: usize> {
     _phantom: std::marker::PhantomData<(A, T)>,
 }
 
+#[cfg(feature = "test_utils")]
+impl<A: Copy, T: Copy, const K: usize, const B: usize> VecOfArenas<A, T, K, B> {
+    #[inline(always)]
+    pub(crate) fn leaf_extent_for_embedded_descriptor(&self, leaf_idx: usize) -> (usize, usize) {
+        debug_assert!(leaf_idx < self.leaf_extents.len());
+        unsafe { *self.leaf_extents.get_unchecked(leaf_idx) }
+    }
+
+    #[inline(always)]
+    pub(crate) fn leaf_arena_from_embedded_descriptor(
+        &self,
+        byte_offset: usize,
+        leaf_len: usize,
+    ) -> LeafArena<'_, A, T, K> {
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                byte_offset + LeafArena::<A, T, K>::encoded_len_bytes(leaf_len)
+                    <= self.leaf_bytes.len()
+            );
+        }
+        LeafArena::new(
+            unsafe { self.leaf_bytes.as_ptr().add(byte_offset) },
+            leaf_len,
+        )
+    }
+}
+
 #[cfg(feature = "rkyv_08")]
 impl<A, T, const K: usize, const B: usize> ArchivedVecOfArenas<A, T, K, B>
 where

--- a/src/stem_strategy/donnelly/mod.rs
+++ b/src/stem_strategy/donnelly/mod.rs
@@ -32,6 +32,8 @@ mod scalar;
 mod simd_descent;
 mod unrolled;
 mod unrolled_block_dim;
+#[cfg(feature = "test_utils")]
+mod unrolled_leaf_embedded;
 
 #[doc(hidden)]
 pub mod core;
@@ -50,3 +52,6 @@ pub use simd_full::DonnellySimdFull;
 pub use unrolled::DonnellyUnrolled;
 #[doc(inline)]
 pub use unrolled_block_dim::DonnellyUnrolledBlockDim;
+#[cfg(feature = "test_utils")]
+#[doc(hidden)]
+pub use unrolled_leaf_embedded::DonnellyUnrolledLeafEmbedded3;

--- a/src/stem_strategy/donnelly/unrolled_leaf_embedded.rs
+++ b/src/stem_strategy/donnelly/unrolled_leaf_embedded.rs
@@ -1,0 +1,125 @@
+//! Benchmark-only Donnelly layout reserving the final block level for leaf descriptors.
+
+use std::ptr::NonNull;
+
+use crate::stem_strategy::donnelly::core::DonnellyCore;
+use crate::{Axis, StemStrategy};
+
+/// Block-height-three Donnelly traversal whose final block level is leaf metadata.
+///
+/// This exists only to test the embedded-leaf-descriptor layout. Its ordinary
+/// `get_leaf_idx` implementation stops before the metadata level and continues to
+/// resolve leaves through the leaf strategy's extent table.
+#[doc(hidden)]
+#[derive(Copy, Clone, Debug)]
+pub struct DonnellyUnrolledLeafEmbedded3 {
+    core: DonnellyCore<3>,
+}
+
+impl StemStrategy for DonnellyUnrolledLeafEmbedded3 {
+    const ROOT_IDX: usize = 0;
+    const BLOCK_SIZE: usize = 3;
+    const TERMINAL_METADATA_LEVELS: usize = 1;
+
+    type DeferredState = Self;
+    type StackContext<A> = crate::kd_tree::query_stack::QueryStackContext<A, Self::DeferredState>;
+    type Stack<A> = crate::kd_tree::query_stack::QueryStack<A, Self>;
+
+    #[inline(always)]
+    fn new(stems_ptr: NonNull<u8>) -> Self {
+        Self {
+            core: DonnellyCore::new(stems_ptr),
+        }
+    }
+
+    #[inline(always)]
+    fn stem_idx(&self) -> usize {
+        self.core.stem_idx()
+    }
+
+    #[inline(always)]
+    fn deferred_state(&self) -> Self::DeferredState {
+        *self
+    }
+
+    #[inline(always)]
+    fn rehydrate_deferred_state(&mut self, state: Self::DeferredState) {
+        *self = state;
+    }
+
+    #[inline(always)]
+    fn leaf_idx(&self) -> usize {
+        self.core.leaf_idx()
+    }
+
+    #[inline(always)]
+    fn dim<const K: usize>(&self) -> usize {
+        self.core.dim::<K>()
+    }
+
+    #[inline(always)]
+    fn level(&self) -> i32 {
+        self.core.level()
+    }
+
+    #[inline(always)]
+    fn traverse<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+        self.core.traverse::<A, K>(is_right);
+    }
+
+    #[inline(always)]
+    fn traverse_head<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+        self.core.traverse_head::<A, K>(is_right);
+    }
+
+    #[inline(always)]
+    fn traverse_tail<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+        self.core.traverse_tail_with_block_size::<A, K>(is_right, 3);
+    }
+
+    #[inline(always)]
+    fn branch<A: Axis<Coord = A>, const K: usize>(&mut self) -> Self {
+        Self {
+            core: self.core.branch::<A, K>(),
+        }
+    }
+
+    #[inline(always)]
+    fn child_indices<A: Axis<Coord = A>>(&self) -> (usize, usize) {
+        self.core.child_indices::<A>()
+    }
+
+    fn get_leaf_idx<A: Axis<Coord = A>, const K: usize>(
+        stems: &[A],
+        query: &[A; K],
+        max_stem_level: i32,
+    ) -> usize {
+        let stems_ptr = NonNull::new(stems.as_ptr() as *mut u8).unwrap();
+        let mut strat = Self::new(stems_ptr);
+        let pivot_depth = max_stem_level + 1;
+
+        debug_assert_eq!((pivot_depth + 1) % 3, 0);
+
+        while strat.level() + 2 < pivot_depth {
+            let pivot = unsafe { *stems.get_unchecked(strat.stem_idx()) };
+            let is_right = unsafe { *query.get_unchecked(strat.dim::<K>()) } >= pivot;
+            strat.traverse_head::<A, K>(is_right);
+
+            let pivot = unsafe { *stems.get_unchecked(strat.stem_idx()) };
+            let is_right = unsafe { *query.get_unchecked(strat.dim::<K>()) } >= pivot;
+            strat.traverse_head::<A, K>(is_right);
+
+            let pivot = unsafe { *stems.get_unchecked(strat.stem_idx()) };
+            let is_right = unsafe { *query.get_unchecked(strat.dim::<K>()) } >= pivot;
+            strat.traverse_tail::<A, K>(is_right);
+        }
+
+        while strat.level() < pivot_depth {
+            let pivot = unsafe { *stems.get_unchecked(strat.stem_idx()) };
+            let is_right = unsafe { *query.get_unchecked(strat.dim::<K>()) } >= pivot;
+            strat.traverse_head::<A, K>(is_right);
+        }
+
+        strat.leaf_idx()
+    }
+}

--- a/src/stem_strategy/mod.rs
+++ b/src/stem_strategy/mod.rs
@@ -9,6 +9,9 @@ pub use donnelly::simd_full::{CompareBlock3, CompareBlock4, SimdPrune, SimdSelec
 
 #[doc(hidden)]
 pub use donnelly::Donnelly;
+#[cfg(feature = "test_utils")]
+#[doc(hidden)]
+pub use donnelly::DonnellyUnrolledLeafEmbedded3;
 #[doc(hidden)]
 pub use donnelly::{
     DonnellyNoPf, DonnellySimdDescent, DonnellySimdFull, DonnellyUnrolled, DonnellyUnrolledBlockDim,

--- a/src/traits/stem_strategy.rs
+++ b/src/traits/stem_strategy.rs
@@ -18,6 +18,14 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
     /// The default is 1, which means that the strategy is not block-based.
     const BLOCK_SIZE: usize = 1;
 
+    /// Number of non-pivot terminal levels reserved at the bottom of the final block.
+    ///
+    /// Experimental stem layouts can use this to make construction align the pivot
+    /// depth so terminal metadata occupies the last level of a block. Ordinary stem
+    /// strategies leave this at zero.
+    #[doc(hidden)]
+    const TERMINAL_METADATA_LEVELS: usize = 0;
+
     /// Compact state persisted on scalar backtracking stacks.
     ///
     /// Scalar strategies can use this to store only the state needed to resume a deferred branch.


### PR DESCRIPTION
## Summary

Prototype a benchmark-only Donnelly/VecOfArenas layout that stores each leaf's arena descriptor in the terminal level of the final stem block, putting leaf resolution metadata alongside the last pivots.

- add a default-zero terminal-metadata-level hook to stem construction
- add a test-utils-only block-height-3 Donnelly strategy reserving one terminal level
- store pivots and descriptors in aligned integer words, reinterpreting pivots as f64
- pack a 48-bit VecOfArenas byte offset and 16-bit leaf length into each u64 descriptor
- add specialized approximate-nearest-one entry points for embedded and extent-table resolution
- add a full 2^16 through 2^26 f64/K3/B32 Criterion sweep with same-layout and established stem baselines
- publish an experiment-specific five-series matrix in the benchmark GitHub Pages report

All experimental public surface remains hidden behind `test_utils`.

## Preliminary local result

A quick local sweep suggests that removing the leaf extent indirection is measurable:

| Points | Embedded | Same-layout extent control | Embedded improvement |
| --- | ---: | ---: | ---: |
| 2^16 | 129.83 ns/query | 137.92 ns/query | 5.9% |
| 2^20 | 167.25 ns/query | 175.38 ns/query | 4.6% |
| 2^24 | 182.91 ns/query | 206.96 ns/query | 11.6% |
| 2^26 | 223.76 ns/query | 242.42 ns/query | 7.7% |

At 2^26 the prototype roughly ties ordinary DonnellyUnrolled but remains slower than DonnellySimdDescent, so the experiment tests the indirection hypothesis without yet establishing this padded layout as the best overall strategy.

The self-hosted runner's full sweep is intended to provide the reliable comparison.

## Validation

- `cargo test --lib --features=test_utils` (399 passed)
- `cargo clippy --features=serde,test_utils --no-deps`
- `cargo fmt --all --check`
- nightly SIMD benchmark check and optimized native benchmark build
- synthetic GitHub Pages publication test covering PNG creation, run-summary registration, and HTML embedding

## Benchmark report note

The usual `/benchmark leaf` comment dispatch sources publishing scripts from `master`. Until this PR's matrix renderer exists on `master`, run `benchmark-report.yml` manually with this branch selected to render the intra-run experiment matrix on GitHub Pages.
