### PR TITLE
feat: add result capacity hint for radius queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,12 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "profile_v6_result_capacity"
+path = "benches/profile_v6_result_capacity.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
 name = "profile_v6_archived_huge_pages"
 path = "benches/profile_v6_archived_huge_pages.rs"
 harness = false

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Kiddo supports the following query types through its fluent builder API, startin
 - `.within(radius).unsorted()` finds all items within a specified radius of a query point without sorting the results.
   This is often faster than `.within(radius)` when result order does not matter, such as finding all customers within 5 miles of a store, or collecting point-cloud neighbourhoods for clustering or normal estimation.
 
-The builder API also supports boundary exclusivity, result projection, and periodic boundary conditions where applicable.
+The builder API also supports boundary exclusivity, result projection, and periodic boundary conditions where applicable. If you can estimate how many matches an eagerly materialized `.within(radius)` query will return, add `.with_result_capacity(estimated_count)` before `.execute()` to avoid result-vector growth reallocations. This is only an allocation hint and does not limit the number of results returned; omit it when no reasonable estimate is available.
 
 ## What's New In v6
 

--- a/benches/profile_v6_result_capacity.rs
+++ b/benches/profile_v6_result_capacity.rs
@@ -1,0 +1,201 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::Eytzinger;
+use kiddo::{QueryResultItem, SquaredEuclidean};
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_TREE_SIZE: usize = 1 << 20;
+const DEFAULT_QUERY_COUNT: usize = 256;
+const DEFAULT_SAMPLE_COUNT: usize = 5;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+
+// Physical radius, then a deliberately rounded result-count estimate.
+const CASES: [(f64, usize); 3] = [(0.03, 128), (0.06, 1_024), (0.1, 4_608)];
+
+type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Checksum {
+    len: usize,
+    item_sum: u64,
+    distance_bits_sum: u64,
+}
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn median(mut samples: Vec<f64>) -> f64 {
+    samples.sort_unstable_by(f64::total_cmp);
+    samples[samples.len() / 2]
+}
+
+#[inline(always)]
+fn execute_query(
+    tree: &Tree,
+    query: &[f64; K],
+    max_dist: f64,
+    sorted: bool,
+    capacity: Option<usize>,
+) -> Vec<QueryResultItem<(), u32, f64>> {
+    match (sorted, capacity) {
+        (true, Some(capacity)) => tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(max_dist)
+            .with_result_capacity(capacity)
+            .execute(),
+        (true, None) => tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(max_dist)
+            .execute(),
+        (false, Some(capacity)) => tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(max_dist)
+            .unsorted()
+            .with_result_capacity(capacity)
+            .execute(),
+        (false, None) => tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(max_dist)
+            .unsorted()
+            .execute(),
+    }
+}
+
+fn execute_queries(
+    tree: &Tree,
+    queries: &[[f64; K]],
+    max_dist: f64,
+    sorted: bool,
+    capacity: Option<usize>,
+) -> Checksum {
+    let mut checksum = Checksum {
+        len: 0,
+        item_sum: 0,
+        distance_bits_sum: 0,
+    };
+
+    for query in queries {
+        let results = execute_query(tree, query, max_dist, sorted, capacity);
+
+        checksum.len = checksum.len.wrapping_add(results.len());
+        for result in results {
+            checksum.item_sum = checksum.item_sum.wrapping_add(result.item as u64);
+            checksum.distance_bits_sum = checksum
+                .distance_bits_sum
+                .wrapping_add(result.distance.to_bits());
+        }
+    }
+
+    black_box(checksum)
+}
+
+fn measure(
+    tree: &Tree,
+    queries: &[[f64; K]],
+    max_dist: f64,
+    sorted: bool,
+    capacity: Option<usize>,
+) -> (f64, usize) {
+    // Result contents are validated outside the timed samples. Keep normal
+    // container destruction here, but do not include result iteration.
+    let start = Instant::now();
+    let mut total_len = 0usize;
+    for query in queries {
+        let results = execute_query(tree, query, max_dist, sorted, capacity);
+        total_len = total_len.wrapping_add(results.len());
+        let _ = black_box(results);
+    }
+    (
+        start.elapsed().as_nanos() as f64 / queries.len() as f64,
+        black_box(total_len),
+    )
+}
+
+fn main() {
+    let tree_size = read_usize_env("KIDDO_PROFILE_TREE_SIZE", DEFAULT_TREE_SIZE);
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let sample_count = read_usize_env("KIDDO_PROFILE_SAMPLES", DEFAULT_SAMPLE_COUNT);
+    assert!(tree_size > 0 && query_count > 0 && sample_count > 0);
+
+    let mut point_rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    let points: Vec<_> = (0..tree_size)
+        .map(|_| point_rng.random::<[f64; K]>())
+        .collect();
+    let tree = Tree::new_from_slice(&points).unwrap();
+
+    let mut query_rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    let queries: Vec<_> = (0..query_count)
+        .map(|_| query_rng.random::<[f64; K]>())
+        .collect();
+
+    println!(
+        "# result capacity profile: arch={} tree_size={} queries={} samples={}",
+        std::env::consts::ARCH,
+        tree_size,
+        query_count,
+        sample_count
+    );
+    println!("case_header,mode,radius,capacity,avg_results,default_ns,hinted_ns,speedup_pct");
+
+    for sorted in [true, false] {
+        for (radius, default_capacity) in CASES {
+            let capacity = default_capacity
+                .saturating_mul(tree_size)
+                .div_ceil(DEFAULT_TREE_SIZE)
+                .max(1);
+            let max_dist = radius * radius;
+            let expected = execute_queries(&tree, &queries, max_dist, sorted, None);
+            assert_eq!(
+                execute_queries(&tree, &queries, max_dist, sorted, Some(capacity)),
+                expected
+            );
+
+            let mut default_samples = Vec::with_capacity(sample_count);
+            let mut hinted_samples = Vec::with_capacity(sample_count);
+            for sample_idx in 0..sample_count {
+                let capacities = if sample_idx.is_multiple_of(2) {
+                    [None, Some(capacity)]
+                } else {
+                    [Some(capacity), None]
+                };
+                for current_capacity in capacities {
+                    let (elapsed, total_len) =
+                        measure(&tree, &queries, max_dist, sorted, current_capacity);
+                    assert_eq!(total_len, expected.len);
+                    if current_capacity.is_some() {
+                        hinted_samples.push(elapsed);
+                    } else {
+                        default_samples.push(elapsed);
+                    }
+                }
+            }
+
+            let default_ns = median(default_samples);
+            let hinted_ns = median(hinted_samples);
+            let speedup = (default_ns - hinted_ns) / default_ns * 100.0;
+            println!(
+                "case,{},{radius:.3},{capacity},{:.1},{default_ns:.2},{hinted_ns:.2},{speedup:.2}",
+                if sorted { "sorted" } else { "unsorted" },
+                expected.len as f64 / queries.len() as f64,
+            );
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -428,6 +428,11 @@ profile-v6-result-collection-thresholds FEATURES='test_utils,logging_off' TREE_S
     RUSTFLAGS='-C target-cpu=native' \
     cargo bench --bench profile_v6_result_collection_thresholds --features {{FEATURES}}
 
+# Compare default radius-query allocation growth with a caller-provided capacity hint.
+profile-v6-result-capacity FEATURES='test_utils,logging_off' TREE_SIZE='1048576' QUERIES='256' SAMPLES='5':
+    RUSTC_WRAPPER= KIDDO_PROFILE_TREE_SIZE='{{TREE_SIZE}}' KIDDO_PROFILE_QUERIES='{{QUERIES}}' KIDDO_PROFILE_SAMPLES='{{SAMPLES}}' RUSTFLAGS='-C target-cpu=native' \
+    cargo bench --bench profile_v6_result_capacity --features {{FEATURES}}
+
 build-v6-hugepage-archives FEATURES='rkyv_08,test_utils,logging_off' POINTS='33554432' QUERIES='100000' PREFIX='./target/kiddo-hugepage-v6':
     RUSTC_WRAPPER= \
     KIDDO_PROFILE_POINTS={{POINTS}} \

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -310,6 +310,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         T: PartialOrd,
@@ -326,6 +327,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         T: PartialOrd,
@@ -438,6 +440,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -455,6 +458,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -586,6 +590,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         T: PartialOrd,
@@ -598,7 +603,7 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.within_impl::<D, EXCLUSIVE>(query, radius)
+        self.within_impl::<D, EXCLUSIVE>(query, radius, result_capacity)
     }
 
     #[inline]
@@ -606,6 +611,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         T: PartialOrd,
@@ -618,7 +624,7 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.within_unsorted_impl::<D, EXCLUSIVE>(query, radius)
+        self.within_unsorted_impl::<D, EXCLUSIVE>(query, radius, result_capacity)
     }
 
     #[inline]
@@ -744,6 +750,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -757,7 +764,7 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+        self.within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, result_capacity, stack)
     }
 
     #[inline]
@@ -765,6 +772,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -778,7 +786,12 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.within_unsorted_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+        self.within_unsorted_impl_with_scratch::<D, EXCLUSIVE>(
+            query,
+            radius,
+            result_capacity,
+            stack,
+        )
     }
 
     #[inline]
@@ -912,6 +925,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         T: PartialOrd,
@@ -924,7 +938,7 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.within_impl::<D, EXCLUSIVE>(query, radius)
+        self.within_impl::<D, EXCLUSIVE>(query, radius, result_capacity)
     }
 
     #[inline]
@@ -932,6 +946,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         T: PartialOrd,
@@ -944,7 +959,7 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.within_unsorted_impl::<D, EXCLUSIVE>(query, radius)
+        self.within_unsorted_impl::<D, EXCLUSIVE>(query, radius, result_capacity)
     }
 
     #[inline]
@@ -1073,6 +1088,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -1086,7 +1102,7 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+        self.within_impl_with_scratch::<D, EXCLUSIVE>(query, radius, result_capacity, stack)
     }
 
     #[inline]
@@ -1094,6 +1110,7 @@ where
         &self,
         query: &[A; K],
         radius: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -1107,7 +1124,12 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.within_unsorted_impl_with_scratch::<D, EXCLUSIVE>(query, radius, stack)
+        self.within_unsorted_impl_with_scratch::<D, EXCLUSIVE>(
+            query,
+            radius,
+            result_capacity,
+            stack,
+        )
     }
 
     #[inline]
@@ -1338,6 +1360,14 @@ where
 /// [`unsorted`](Self::unsorted) is also available for the other multi-result
 /// query families when traversal order is acceptable.
 ///
+/// ## Result allocation
+///
+/// Eager [`within`](Self::within)`::<D>(radius)` queries materialize every
+/// matching result in a `Vec`. If the approximate number of matches is known,
+/// [`with_result_capacity`](Self::with_result_capacity) can reserve that space
+/// up front and avoid growth reallocations. The hint does not limit the number
+/// of results returned; omit it when a reasonable estimate is unavailable.
+///
 /// The concrete generic parameters on this type encode the current builder
 /// state and are considered an implementation detail of the fluent API.
 pub struct QueryBuilder<
@@ -1362,6 +1392,7 @@ pub struct QueryBuilder<
     query: &'a [A; K],
     box_size: Option<&'a [A; K]>,
     max_qty: Option<NonZeroUsize>,
+    result_capacity: Option<NonZeroUsize>,
     radius: <D as BuilderMetric<A, K>>::Output,
     _phantom: PhantomData<(T, SS, LS, Family, Space, Pj)>,
 }
@@ -1463,9 +1494,52 @@ where
             query: self.query,
             box_size,
             max_qty,
+            result_capacity: self.result_capacity,
             radius,
             _phantom: PhantomData,
         }
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        Space,
+        Pj,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > QueryBuilder<'a, Tree, A, T, SS, LS, D, WithinState, Space, Pj, SORTED, EXCLUSIVE, K, B>
+where
+    D: BuilderMetric<A, K>,
+{
+    /// Reserves space for the expected number of materialized radius-query results.
+    ///
+    /// A good estimate avoids growth reallocations without limiting the number
+    /// of results returned. Overestimating can reserve substantially more memory
+    /// than the query needs, so omit the hint when no reasonable estimate is
+    /// available.
+    ///
+    /// This option applies to both sorted and unsorted [`within`](Self::within)
+    /// queries, including periodic and archived-tree queries. Streaming
+    /// [`iter`](Self::iter) and [`visit`](Self::visit) queries do not materialize
+    /// a result `Vec` and therefore do not use a capacity hint.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `result_capacity` is zero.
+    #[inline]
+    pub fn with_result_capacity(mut self, result_capacity: usize) -> Self {
+        self.result_capacity = Some(
+            NonZeroUsize::new(result_capacity).expect("result capacity must be greater than zero"),
+        );
+        self
     }
 }
 
@@ -2143,6 +2217,7 @@ fn scan_projected_nearest_results<Tree, A, T, SS, LS, D, Pj, const K: usize, con
     radius: Option<D::Output>,
     max_qty: Option<usize>,
     sorted: bool,
+    result_capacity: Option<NonZeroUsize>,
     boundary: BoundaryMode,
 ) -> Vec<Pj::NearestOut>
 where
@@ -2156,7 +2231,8 @@ where
     Pj: ProjectionSpec<A, T, D::Output, K>,
 {
     let query_wide = query.map(D::widen_coord);
-    let mut results = Vec::new();
+    let mut results =
+        result_capacity.map_or_else(Vec::new, |capacity| Vec::with_capacity(capacity.get()));
 
     for (item, point) in KdTreeIter::<Tree, A, T, SS, LS, K, B>::new(tree) {
         let point_wide = point.map(D::widen_coord);
@@ -2248,6 +2324,7 @@ where
             query,
             box_size: None,
             max_qty: None,
+            result_capacity: None,
             radius: (),
             _phantom: PhantomData,
         }
@@ -2327,6 +2404,7 @@ where
             query,
             box_size: None,
             max_qty: None,
+            result_capacity: None,
             radius: (),
             _phantom: PhantomData,
         }
@@ -3797,12 +3875,17 @@ where
     fn execute_with_scratch(self, scratch: &mut QueryScratch<SS, D::Output>) -> Self::Output {
         with_cleared_scratch(scratch, |stack| {
             let results = if SORTED {
-                self.tree
-                    .qb_within_with_scratch::<D, EXCLUSIVE>(self.query, self.radius, stack)
+                self.tree.qb_within_with_scratch::<D, EXCLUSIVE>(
+                    self.query,
+                    self.radius,
+                    self.result_capacity,
+                    stack,
+                )
             } else {
                 self.tree.qb_within_unsorted_with_scratch::<D, EXCLUSIVE>(
                     self.query,
                     self.radius,
+                    self.result_capacity,
                     stack,
                 )
             };
@@ -4551,6 +4634,7 @@ where
                 None,
                 self.max_qty.map(NonZeroUsize::get),
                 true,
+                None,
                 if EXCLUSIVE {
                     BoundaryMode::Exclusive
                 } else {
@@ -4627,6 +4711,7 @@ where
                 None,
                 self.max_qty.map(NonZeroUsize::get),
                 false,
+                None,
                 if EXCLUSIVE {
                     BoundaryMode::Exclusive
                 } else {
@@ -4703,6 +4788,7 @@ where
                 Some(self.radius),
                 self.max_qty.map(NonZeroUsize::get),
                 true,
+                None,
                 if EXCLUSIVE {
                     BoundaryMode::Exclusive
                 } else {
@@ -4793,6 +4879,7 @@ where
                 Some(self.radius),
                 self.max_qty.map(NonZeroUsize::get),
                 false,
+                None,
                 if EXCLUSIVE {
                     BoundaryMode::Exclusive
                 } else {
@@ -4883,6 +4970,7 @@ where
                 Some(self.radius),
                 None,
                 true,
+                self.result_capacity,
                 if EXCLUSIVE {
                     BoundaryMode::Exclusive
                 } else {
@@ -4891,9 +4979,11 @@ where
             )
         } else {
             let results = if EXCLUSIVE {
-                self.tree.qb_within::<D, true>(self.query, self.radius)
+                self.tree
+                    .qb_within::<D, true>(self.query, self.radius, self.result_capacity)
             } else {
-                self.tree.qb_within::<D, false>(self.query, self.radius)
+                self.tree
+                    .qb_within::<D, false>(self.query, self.radius, self.result_capacity)
             };
             results
                 .into_iter()
@@ -4963,6 +5053,7 @@ where
                 Some(self.radius),
                 None,
                 false,
+                self.result_capacity,
                 if EXCLUSIVE {
                     BoundaryMode::Exclusive
                 } else {
@@ -4971,11 +5062,17 @@ where
             )
         } else {
             let results = if EXCLUSIVE {
-                self.tree
-                    .qb_within_unsorted::<D, true>(self.query, self.radius)
+                self.tree.qb_within_unsorted::<D, true>(
+                    self.query,
+                    self.radius,
+                    self.result_capacity,
+                )
             } else {
-                self.tree
-                    .qb_within_unsorted::<D, false>(self.query, self.radius)
+                self.tree.qb_within_unsorted::<D, false>(
+                    self.query,
+                    self.radius,
+                    self.result_capacity,
+                )
             };
             results
                 .into_iter()
@@ -5187,6 +5284,7 @@ where
             None,
             self.max_qty,
             true,
+            self.result_capacity,
         )
         .into_iter()
         .map(project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>)
@@ -5251,6 +5349,7 @@ macro_rules! impl_periodic_radius_vec_execute {
                     Some(self.radius),
                     self.max_qty,
                     SORTED,
+                    self.result_capacity,
                 )
                 .into_iter()
                 .map(project_nearest_without_point::<A, T, D::Output, P, I, Dp, K>)

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -145,7 +145,7 @@ where
 
         if max_qty == usize::MAX {
             self.nearest_n_within_inner::<D, Vec<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
-                query, max_dist, max_qty, sorted,
+                query, max_dist, max_qty, sorted, None,
             )
         } else {
             #[cfg(feature = "small_n_result_collectors")]
@@ -154,7 +154,7 @@ where
                     D,
                     SmallSortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
-                >(query, max_dist, max_qty, sorted);
+                >(query, max_dist, max_qty, sorted, None);
             }
 
             #[cfg(not(feature = "small_n_result_collectors"))]
@@ -169,11 +169,11 @@ where
                     D,
                     ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
-                >(query, max_dist, max_qty, sorted);
+                >(query, max_dist, max_qty, sorted, None);
             }
 
             self.nearest_n_within_inner::<D, BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
-                query, max_dist, max_qty, sorted,
+                query, max_dist, max_qty, sorted, None,
             )
         }
     }
@@ -203,7 +203,7 @@ where
                 D,
                 Vec<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted, stack)
+            >(query, max_dist, max_qty, sorted, None, stack)
         } else {
             #[cfg(feature = "small_n_result_collectors")]
             if max_qty <= SMALL_RESULT_COLLECTION_MAX_QTY {
@@ -211,7 +211,7 @@ where
                     D,
                     SmallSortedVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
-                >(query, max_dist, max_qty, sorted, stack);
+                >(query, max_dist, max_qty, sorted, None, stack);
             }
 
             #[cfg(not(feature = "small_n_result_collectors"))]
@@ -226,14 +226,14 @@ where
                     D,
                     ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     EXCLUSIVE,
-                >(query, max_dist, max_qty, sorted, stack);
+                >(query, max_dist, max_qty, sorted, None, stack);
             }
 
             self.nearest_n_within_inner_with_scratch::<
                 D,
                 BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted, stack)
+            >(query, max_dist, max_qty, sorted, None, stack)
         }
     }
 
@@ -267,22 +267,23 @@ where
                     D,
                     BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
                     false,
-                >(query, max_dist, max_qty, sorted),
+                >(query, max_dist, max_qty, sorted, None),
             crate::test_utils::NearestNBenchmarkCollector::ThresholdVecFused => self
                 .nearest_n_within_inner::<
                     D,
                     ThresholdVecResultCollection<QueryResultItem<(), T, D::Output>>,
                     false,
-                >(query, max_dist, max_qty, sorted),
+                >(query, max_dist, max_qty, sorted, None),
         }
     }
 
-    fn nearest_n_within_inner<D, R, const EXCLUSIVE: bool>(
+    pub(crate) fn nearest_n_within_inner<D, R, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
         max_dist: D::Output,
         max_qty: usize,
         sorted: bool,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         D: DistanceMetric<A>,
@@ -298,7 +299,7 @@ where
         let mut req_ctx = NearestNWithinReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
             query,
             max_dist,
-            results: R::with_max_qty(max_qty),
+            results: R::with_max_qty_and_capacity(max_qty, result_capacity),
             _phantom: std::marker::PhantomData,
         };
 
@@ -319,12 +320,13 @@ where
         }
     }
 
-    fn nearest_n_within_inner_with_scratch<D, R, const EXCLUSIVE: bool>(
+    pub(crate) fn nearest_n_within_inner_with_scratch<D, R, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
         max_dist: D::Output,
         max_qty: usize,
         sorted: bool,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -341,7 +343,7 @@ where
         let mut req_ctx = NearestNWithinReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
             query,
             max_dist,
-            results: R::with_max_qty(max_qty),
+            results: R::with_max_qty_and_capacity(max_qty, result_capacity),
             _phantom: std::marker::PhantomData,
         };
 

--- a/src/kd_tree/query/periodic.rs
+++ b/src/kd_tree/query/periodic.rs
@@ -636,6 +636,7 @@ fn periodic_nearest_results_inner<
     max_dist: D::Output,
     max_qty: usize,
     sorted: bool,
+    result_capacity: Option<NonZeroUsize>,
 ) -> Vec<QueryResultItem<(), T, D::Output>>
 where
     Tree: KdTreeAccessor<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
@@ -650,7 +651,7 @@ where
     let mut req_ctx = PeriodicNearestResultsReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
         query,
         max_dist,
-        results: R::with_max_qty(max_qty),
+        results: R::with_max_qty_and_capacity(max_qty, result_capacity),
         _phantom: PhantomData,
     };
 
@@ -695,6 +696,7 @@ pub(crate) fn periodic_nearest_results<
     radius: Option<D::Output>,
     max_qty: Option<NonZeroUsize>,
     sorted: bool,
+    result_capacity: Option<NonZeroUsize>,
 ) -> Vec<QueryResultItem<(), T, D::Output>>
 where
     Tree: KdTreeAccessor<A, T, SS, LS, K, B> + KdTreeQueryOps<A, T, SS, LS, K, B>,
@@ -729,7 +731,15 @@ where
             EXCLUSIVE,
             K,
             B,
-        >(tree, query, box_size, max_dist, max_qty, sorted);
+        >(
+            tree,
+            query,
+            box_size,
+            max_dist,
+            max_qty,
+            sorted,
+            result_capacity,
+        );
     }
 
     if sorted {
@@ -746,7 +756,7 @@ where
                 EXCLUSIVE,
                 K,
                 B,
-            >(tree, query, box_size, max_dist, max_qty, sorted);
+            >(tree, query, box_size, max_dist, max_qty, sorted, None);
         }
 
         #[cfg(not(feature = "small_n_result_collectors"))]
@@ -762,7 +772,7 @@ where
                 EXCLUSIVE,
                 K,
                 B,
-            >(tree, query, box_size, max_dist, max_qty, sorted);
+            >(tree, query, box_size, max_dist, max_qty, sorted, None);
         }
     }
 
@@ -777,5 +787,5 @@ where
         EXCLUSIVE,
         K,
         B,
-    >(tree, query, box_size, max_dist, max_qty, sorted)
+    >(tree, query, box_size, max_dist, max_qty, sorted, None)
 }

--- a/src/kd_tree/query/within.rs
+++ b/src/kd_tree/query/within.rs
@@ -19,6 +19,7 @@ where
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         D: DistanceMetric<A>,
@@ -30,13 +31,20 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.nearest_n_within_impl::<D, EXCLUSIVE>(query, max_dist, NonZeroUsize::MAX, true)
+        self.nearest_n_within_inner::<D, Vec<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
+            query,
+            max_dist,
+            usize::MAX,
+            true,
+            result_capacity,
+        )
     }
 
     pub(crate) fn within_impl_with_scratch<D, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -49,11 +57,16 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+        self.nearest_n_within_inner_with_scratch::<
+            D,
+            Vec<QueryResultItem<(), T, D::Output>>,
+            EXCLUSIVE,
+        >(
             query,
             max_dist,
-            NonZeroUsize::MAX,
+            usize::MAX,
             true,
+            result_capacity,
             stack,
         )
     }
@@ -74,6 +87,29 @@ mod tests {
 
     const RNG_SEED: u64 = 42;
     const TILE_BOUNDARY_CASES: [usize; 7] = [1, 2, 4, 8, 32, 33, 47];
+
+    #[test]
+    fn result_capacity_hint_is_preserved_for_materialized_results() {
+        let points: Vec<_> = (0..128).map(|idx| [idx as f64 / 128.0, 0.0]).collect();
+        let tree: KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 32>, 2, 32> =
+            KdTree::new_from_slice(&points).unwrap();
+        let query = [0.0, 0.0];
+
+        for results in [
+            tree.query(&query)
+                .within::<SquaredEuclidean<f64>>(1.0)
+                .with_result_capacity(256)
+                .execute(),
+            tree.query(&query)
+                .within::<SquaredEuclidean<f64>>(1.0)
+                .unsorted()
+                .with_result_capacity(256)
+                .execute(),
+        ] {
+            assert_eq!(results.len(), points.len());
+            assert!(results.capacity() >= 256);
+        }
+    }
 
     #[test]
     fn within_exclusive_boundaries_excludes_exact_threshold_matches() {

--- a/src/kd_tree/query/within_unsorted.rs
+++ b/src/kd_tree/query/within_unsorted.rs
@@ -134,6 +134,7 @@ where
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         D: DistanceMetric<A>,
@@ -145,7 +146,13 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.nearest_n_within_impl::<D, EXCLUSIVE>(query, max_dist, NonZeroUsize::MAX, false)
+        self.nearest_n_within_inner::<D, Vec<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
+            query,
+            max_dist,
+            usize::MAX,
+            false,
+            result_capacity,
+        )
     }
 
     #[inline]
@@ -153,6 +160,7 @@ where
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -165,11 +173,16 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+        self.nearest_n_within_inner_with_scratch::<
+            D,
+            Vec<QueryResultItem<(), T, D::Output>>,
+            EXCLUSIVE,
+        >(
             query,
             max_dist,
-            NonZeroUsize::MAX,
+            usize::MAX,
             false,
+            result_capacity,
             stack,
         )
     }

--- a/src/results/result_collection.rs
+++ b/src/results/result_collection.rs
@@ -1,4 +1,5 @@
 use std::collections::BinaryHeap;
+use std::num::NonZeroUsize;
 
 #[cfg(any(
     feature = "buffered_result_collection",
@@ -22,6 +23,11 @@ pub(crate) type ResultBuffer<E> = SmallVec<[E; BUFFERED_RESULT_COLLECTION_INLINE
 
 pub trait ResultCollection<O: Axis<Coord = O>, E>: Sized {
     fn with_max_qty(max_qty: usize) -> Self;
+    #[inline]
+    fn with_max_qty_and_capacity(max_qty: usize, result_capacity: Option<NonZeroUsize>) -> Self {
+        let _ = result_capacity;
+        Self::with_max_qty(max_qty)
+    }
     fn max_qty(&self) -> usize;
     fn len(&self) -> usize;
     fn add(&mut self, entry: E);
@@ -1262,11 +1268,15 @@ pub mod cargo_asm {
 
 impl<O: Axis<Coord = O>, E: Ord> ResultCollection<O, E> for Vec<E> {
     fn with_max_qty(max_qty: usize) -> Self {
+        <Self as ResultCollection<O, E>>::with_max_qty_and_capacity(max_qty, None)
+    }
+
+    fn with_max_qty_and_capacity(max_qty: usize, result_capacity: Option<NonZeroUsize>) -> Self {
         if max_qty == usize::MAX {
             // Unsorted query path: start with reasonable capacity to avoid
             // the first several realloc waves when many candidates fall within
             // the radius. 64 elements (1.55 KB at 24 B/elem) is negligible.
-            Vec::with_capacity(64)
+            Vec::with_capacity(result_capacity.map_or(64, NonZeroUsize::get))
         } else {
             Vec::with_capacity(max_qty)
         }

--- a/src/rkyv/query.rs
+++ b/src/rkyv/query.rs
@@ -233,14 +233,14 @@ where
         let max_qty = max_qty.get();
         if max_qty == usize::MAX {
             self.nearest_n_within_inner::<D, Vec<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
-                query, max_dist, max_qty, sorted,
+                query, max_dist, max_qty, sorted, None,
             )
         } else {
             self.nearest_n_within_inner::<
                 D,
                 BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted)
+            >(query, max_dist, max_qty, sorted, None)
         }
     }
 
@@ -250,6 +250,7 @@ where
         max_dist: D::Output,
         max_qty: usize,
         sorted: bool,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         D: DistanceMetric<A>,
@@ -265,7 +266,7 @@ where
         let mut req_ctx = ArchivedNearestNWithinReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
             query,
             max_dist,
-            results: R::with_max_qty(max_qty),
+            results: R::with_max_qty_and_capacity(max_qty, result_capacity),
             _phantom: std::marker::PhantomData,
         };
 
@@ -357,6 +358,7 @@ where
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         D: DistanceMetric<A>,
@@ -368,13 +370,20 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        self.nearest_n_within_impl::<D, EXCLUSIVE>(query, max_dist, NonZeroUsize::MAX, true)
+        self.nearest_n_within_inner::<D, Vec<QueryResultItem<(), T, D::Output>>, EXCLUSIVE>(
+            query,
+            max_dist,
+            usize::MAX,
+            true,
+            result_capacity,
+        )
     }
 
     pub(crate) fn within_impl_with_scratch<D, const EXCLUSIVE: bool>(
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -387,11 +396,16 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        self.nearest_n_within_impl_with_scratch::<D, EXCLUSIVE>(
+        self.nearest_n_within_inner_with_scratch::<
+            D,
+            Vec<QueryResultItem<(), T, D::Output>>,
+            EXCLUSIVE,
+        >(
             query,
             max_dist,
-            NonZeroUsize::MAX,
+            usize::MAX,
             true,
+            result_capacity,
             stack,
         )
     }
@@ -433,6 +447,7 @@ where
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
         D: DistanceMetric<A>,
@@ -444,7 +459,8 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS> + 'static,
     {
-        let mut results = Vec::new();
+        let mut results =
+            result_capacity.map_or_else(Vec::new, |capacity| Vec::with_capacity(capacity.get()));
         self.within_unsorted_visit_impl::<D, _, EXCLUSIVE>(query, max_dist, |result| {
             results.push(result)
         });
@@ -455,6 +471,7 @@ where
         &self,
         query: &[A; K],
         max_dist: D::Output,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -467,7 +484,8 @@ where
             + 'static,
         SS::Stack<D::Output>: StackTrait<D::Output, SS>,
     {
-        let mut results = Vec::new();
+        let mut results =
+            result_capacity.map_or_else(Vec::new, |capacity| Vec::with_capacity(capacity.get()));
         self.within_unsorted_visit_impl_with_scratch::<D, _, EXCLUSIVE>(
             query,
             max_dist,
@@ -501,13 +519,13 @@ where
                 D,
                 Vec<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted, stack)
+            >(query, max_dist, max_qty, sorted, None, stack)
         } else {
             self.nearest_n_within_inner_with_scratch::<
                 D,
                 BinaryHeapResultCollection<QueryResultItem<(), T, D::Output>>,
                 EXCLUSIVE,
-            >(query, max_dist, max_qty, sorted, stack)
+            >(query, max_dist, max_qty, sorted, None, stack)
         }
     }
 
@@ -517,6 +535,7 @@ where
         max_dist: D::Output,
         max_qty: usize,
         sorted: bool,
+        result_capacity: Option<NonZeroUsize>,
         stack: &mut SS::Stack<D::Output>,
     ) -> Vec<QueryResultItem<(), T, D::Output>>
     where
@@ -533,7 +552,7 @@ where
         let mut req_ctx = ArchivedNearestNWithinReqCtx::<A, T, D::Output, R, EXCLUSIVE, K> {
             query,
             max_dist,
-            results: R::with_max_qty(max_qty),
+            results: R::with_max_qty_and_capacity(max_qty, result_capacity),
             _phantom: std::marker::PhantomData,
         };
 


### PR DESCRIPTION
## Summary

- add `.with_result_capacity(usize)` to materialized `.within(radius)` query builders
- apply the hint to sorted and unsorted queries across owned, archived, periodic, scratch, and projected-result paths
- preserve existing allocation behavior when no hint is supplied
- document the API and add a focused local profiler

The hint reserves the initial result `Vec` capacity but does not limit the number of matches returned. It remains opt-in because an oversized estimate wastes memory and an undersized estimate can still require growth.

## Performance

A local run with a 2^18-point tree, 512 queries, and 9 samples showed roughly 4-5% improvement for denser queries with useful capacity estimates. Deliberately imperfect smaller estimates sometimes regressed by 2-3%, which supports keeping this as a caller-provided hint.

Run locally with:

```console
just profile-v6-result-capacity test_utils,logging_off 262144 512 9
```

## Validation

- `cargo test --lib --features=test_utils` (399 passed)
- `cargo test --doc --features=test_utils`
- `cargo clippy --features=serde,test_utils --no-deps`
- `cargo check --bench profile_v6_result_capacity --features=test_utils,logging_off`
- pre-commit and pre-push hooks