### PR TITLE
perf: prototype SIMD hybrid embedded leaf descriptors

### DIFF
--- a/benches/profile_v6_embedded_leaf_descriptor.rs
+++ b/benches/profile_v6_embedded_leaf_descriptor.rs
@@ -2,7 +2,9 @@ use criterion::{
     criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
 };
 use kiddo::dist::SquaredEuclidean;
-use kiddo::kd_tree::embedded_leaf_descriptor_experiment::EmbeddedLeafDescriptorF64Tree;
+use kiddo::kd_tree::embedded_leaf_descriptor_experiment::{
+    EmbeddedLeafDescriptorF64Tree, EmbeddedLeafDescriptorSimdF64Tree,
+};
 use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::VecOfArenas;
 use kiddo::stem_strategy::{Donnelly, DonnellySimdDescent, DonnellyUnrolled, Eytzinger};
@@ -67,6 +69,51 @@ fn run_extent_control(
     for query in queries {
         let (distance, item) =
             tree.approx_nearest_one_via_extents::<SquaredEuclidean<f64>>(black_box(query));
+        distance_checksum += distance;
+        item_checksum = item_checksum.wrapping_add(u64::from(item));
+    }
+    (distance_checksum, item_checksum)
+}
+
+fn run_hybrid_shallow_simd(
+    tree: &EmbeddedLeafDescriptorSimdF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut distance_checksum = 0.0;
+    let mut item_checksum = 0u64;
+    for query in queries {
+        let (distance, item) = tree
+            .approx_nearest_one_embedded_shallow_simd::<SquaredEuclidean<f64>>(black_box(query));
+        distance_checksum += distance;
+        item_checksum = item_checksum.wrapping_add(u64::from(item));
+    }
+    (distance_checksum, item_checksum)
+}
+
+fn run_hybrid_terminal_scalar(
+    tree: &EmbeddedLeafDescriptorSimdF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut distance_checksum = 0.0;
+    let mut item_checksum = 0u64;
+    for query in queries {
+        let (distance, item) = tree
+            .approx_nearest_one_embedded_terminal_scalar::<SquaredEuclidean<f64>>(black_box(query));
+        distance_checksum += distance;
+        item_checksum = item_checksum.wrapping_add(u64::from(item));
+    }
+    (distance_checksum, item_checksum)
+}
+
+fn run_hybrid_extent_control(
+    tree: &EmbeddedLeafDescriptorSimdF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut distance_checksum = 0.0;
+    let mut item_checksum = 0u64;
+    for query in queries {
+        let (distance, item) = tree
+            .approx_nearest_one_via_extents_shallow_simd::<SquaredEuclidean<f64>>(black_box(query));
         distance_checksum += distance;
         item_checksum = item_checksum.wrapping_add(u64::from(item));
     }
@@ -142,6 +189,39 @@ fn embedded_leaf_descriptor(c: &mut Criterion) {
             |bencher| bencher.iter(|| black_box(run_extent_control(&tree, &queries))),
         );
         drop(tree);
+
+        let hybrid_tree =
+            EmbeddedLeafDescriptorSimdF64Tree::<K, B>::new_from_slice(&points).unwrap();
+        let hybrid_expected = run_hybrid_shallow_simd(&hybrid_tree, &queries);
+        assert_eq!(
+            hybrid_expected,
+            run_hybrid_terminal_scalar(&hybrid_tree, &queries)
+        );
+        assert_eq!(
+            hybrid_expected,
+            run_hybrid_extent_control(&hybrid_tree, &queries)
+        );
+        eprintln!(
+            "hybrid descriptor tree: 2^{log2_points} points, {} leaves, {} stem words",
+            hybrid_tree.leaf_count(),
+            hybrid_tree.stem_word_count()
+        );
+
+        group.bench_function(
+            BenchmarkId::new("hybrid_simd_embedded", point_count),
+            |bencher| bencher.iter(|| black_box(run_hybrid_shallow_simd(&hybrid_tree, &queries))),
+        );
+        group.bench_function(
+            BenchmarkId::new("hybrid_scalar_terminal_embedded", point_count),
+            |bencher| {
+                bencher.iter(|| black_box(run_hybrid_terminal_scalar(&hybrid_tree, &queries)))
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("hybrid_simd_extent_control", point_count),
+            |bencher| bencher.iter(|| black_box(run_hybrid_extent_control(&hybrid_tree, &queries))),
+        );
+        drop(hybrid_tree);
 
         bench_baseline::<DonnellyUnrolled<3>>(
             &mut group,

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -4,7 +4,9 @@
 use criterion::{
     criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
 };
-use kiddo::kd_tree::embedded_leaf_descriptor_experiment::EmbeddedLeafDescriptorF64Tree;
+use kiddo::kd_tree::embedded_leaf_descriptor_experiment::{
+    EmbeddedLeafDescriptorF64Tree, EmbeddedLeafDescriptorSimdF64Tree,
+};
 use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::{FlatVec, VecOfArenas, VecOfArrays};
 use kiddo::stem_strategy::{DonnellySimdDescent, DonnellyUnrolled, Eytzinger};
@@ -138,6 +140,57 @@ fn run_approx_extent_control(
     (checksum_dist, checksum_item)
 }
 
+fn run_approx_hybrid_shallow_simd(
+    tree: &EmbeddedLeafDescriptorSimdF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let (distance, item) = tree
+            .approx_nearest_one_embedded_shallow_simd::<SquaredEuclidean<f64>>(black_box(query));
+        checksum_dist += distance;
+        checksum_item = checksum_item.wrapping_add(u64::from(item));
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_approx_hybrid_terminal_scalar(
+    tree: &EmbeddedLeafDescriptorSimdF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let (distance, item) = tree
+            .approx_nearest_one_embedded_terminal_scalar::<SquaredEuclidean<f64>>(black_box(query));
+        checksum_dist += distance;
+        checksum_item = checksum_item.wrapping_add(u64::from(item));
+    }
+
+    (checksum_dist, checksum_item)
+}
+
+fn run_approx_hybrid_extent_control(
+    tree: &EmbeddedLeafDescriptorSimdF64Tree<K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut checksum_dist = 0.0f64;
+    let mut checksum_item = 0u64;
+
+    for query in queries {
+        let (distance, item) = tree
+            .approx_nearest_one_via_extents_shallow_simd::<SquaredEuclidean<f64>>(black_box(query));
+        checksum_dist += distance;
+        checksum_item = checksum_item.wrapping_add(u64::from(item));
+    }
+
+    (checksum_dist, checksum_item)
+}
+
 fn run_approx_baseline<SS>(tree: &ApproxBaselineTree<SS>, queries: &[[f64; K]]) -> (f64, u64)
 where
     SS: StemStrategy,
@@ -237,6 +290,31 @@ fn leaf_strategies(c: &mut Criterion) {
             |b| b.iter(|| black_box(run_approx_extent_control(&embedded_tree, &queries))),
         );
         drop(embedded_tree);
+
+        let hybrid_tree =
+            EmbeddedLeafDescriptorSimdF64Tree::<K, B>::new_from_slice(&points).unwrap();
+        let hybrid_expected = run_approx_hybrid_shallow_simd(&hybrid_tree, &queries);
+        assert_eq!(
+            hybrid_expected,
+            run_approx_hybrid_terminal_scalar(&hybrid_tree, &queries)
+        );
+        assert_eq!(
+            hybrid_expected,
+            run_approx_hybrid_extent_control(&hybrid_tree, &queries)
+        );
+
+        approx_group.bench_function(BenchmarkId::new("hybrid_simd_embedded", point_count), |b| {
+            b.iter(|| black_box(run_approx_hybrid_shallow_simd(&hybrid_tree, &queries)))
+        });
+        approx_group.bench_function(
+            BenchmarkId::new("hybrid_scalar_terminal_embedded", point_count),
+            |b| b.iter(|| black_box(run_approx_hybrid_terminal_scalar(&hybrid_tree, &queries))),
+        );
+        approx_group.bench_function(
+            BenchmarkId::new("hybrid_simd_extent_control", point_count),
+            |b| b.iter(|| black_box(run_approx_hybrid_extent_control(&hybrid_tree, &queries))),
+        );
+        drop(hybrid_tree);
 
         bench_approx_baseline::<DonnellyUnrolled<3>>(
             &mut approx_group,

--- a/scripts/chart_benchmark_results.py
+++ b/scripts/chart_benchmark_results.py
@@ -36,6 +36,8 @@ MATRIX_COLORS = (
     "#8e44ad",
     "#7f5f00",
     "#00838f",
+    "#c2185b",
+    "#455a64",
 )
 LEAF_STRATEGY_SUITE = "v6-leaf-strategies"
 EMBEDDED_LEAF_DESCRIPTOR_GROUP_ID = (
@@ -44,6 +46,9 @@ EMBEDDED_LEAF_DESCRIPTOR_GROUP_ID = (
 EMBEDDED_LEAF_DESCRIPTOR_SERIES = (
     ("embedded_descriptor", "embedded descriptor"),
     ("embedded_extent_control", "same-layout extent control"),
+    ("hybrid_simd_embedded", "hybrid shallow SIMD"),
+    ("hybrid_scalar_terminal_embedded", "hybrid scalar terminal"),
+    ("hybrid_simd_extent_control", "hybrid extent control"),
     ("baseline_donnelly_unrolled", "Donnelly unrolled"),
     ("baseline_donnelly_simd_descent", "Donnelly SIMD descent"),
     ("baseline_eytzinger", "Eytzinger"),

--- a/src/kd_tree/embedded_leaf_descriptor_experiment.rs
+++ b/src/kd_tree/embedded_leaf_descriptor_experiment.rs
@@ -7,7 +7,8 @@ use aligned_vec::{AVec, CACHELINE_ALIGN};
 use crate::dist::DistanceMetric;
 use crate::kd_tree::{ConstructionError, KdTree};
 use crate::leaf_strategy::VecOfArenas;
-use crate::stem_strategy::DonnellyUnrolledLeafEmbedded3;
+use crate::stem_strategy::donnelly::simd_full::compare_block3;
+use crate::stem_strategy::{DonnellySimdDescentLeafEmbedded3, DonnellyUnrolledLeafEmbedded3};
 use crate::{LeafStrategy, StemStrategy};
 
 const DESCRIPTOR_OFFSET_BITS: u32 = 48;
@@ -16,6 +17,8 @@ const FINAL_PIVOT_LEVELS: i32 = 2;
 
 type ConstructionTree<const K: usize, const B: usize> =
     KdTree<f64, u32, DonnellyUnrolledLeafEmbedded3, VecOfArenas<f64, u32, K, B>, K, B>;
+type SimdConstructionTree<const K: usize, const B: usize> =
+    KdTree<f64, u32, DonnellySimdDescentLeafEmbedded3, VecOfArenas<f64, u32, K, B>, K, B>;
 
 /// Construction failure for the benchmark-only 48-bit-offset/16-bit-length layout.
 #[doc(hidden)]
@@ -41,6 +44,15 @@ impl From<ConstructionError> for EmbeddedLeafDescriptorError {
 /// block contains a packed 48-bit arena byte offset and 16-bit leaf length.
 #[doc(hidden)]
 pub struct EmbeddedLeafDescriptorF64Tree<const K: usize, const B: usize> {
+    stem_words: AVec<u64>,
+    leaves: VecOfArenas<f64, u32, K, B>,
+    max_stem_level: i32,
+    leaf_count: usize,
+}
+
+/// Descriptor tree using full SIMD-descent blocks and a shallow terminal block.
+#[doc(hidden)]
+pub struct EmbeddedLeafDescriptorSimdF64Tree<const K: usize, const B: usize> {
     stem_words: AVec<u64>,
     leaves: VecOfArenas<f64, u32, K, B>,
     max_stem_level: i32,
@@ -174,6 +186,212 @@ impl<const K: usize, const B: usize> EmbeddedLeafDescriptorF64Tree<K, B> {
     }
 }
 
+impl<const K: usize, const B: usize> EmbeddedLeafDescriptorSimdF64Tree<K, B> {
+    /// Builds the hybrid tree with block-dimension pivot construction.
+    pub fn new_from_slice(source: &[[f64; K]]) -> Result<Self, EmbeddedLeafDescriptorError> {
+        let tree: SimdConstructionTree<K, B> = KdTree::new_from_slice(source)?;
+        let KdTree {
+            stems,
+            leaves,
+            max_stem_level,
+            ..
+        } = tree;
+
+        let leaf_count = <VecOfArenas<f64, u32, K, B> as LeafStrategy<
+            f64,
+            u32,
+            DonnellySimdDescentLeafEmbedded3,
+            K,
+            B,
+        >>::leaf_count(&leaves);
+
+        let mut stem_words = AVec::new(CACHELINE_ALIGN);
+        stem_words.resize(stems.len(), 0);
+        for (word, pivot) in stem_words.iter_mut().zip(stems.iter()) {
+            *word = pivot.to_bits();
+        }
+
+        let pivot_depth = (max_stem_level + 1) as usize;
+        debug_assert_eq!((pivot_depth + 1) % 3, 0);
+
+        for leaf_idx in 0..leaf_count {
+            let (byte_offset, leaf_len) = leaves.leaf_extent_for_embedded_descriptor(leaf_idx);
+            let descriptor = pack_descriptor(leaf_idx, byte_offset, leaf_len)?;
+            let terminal_stem_idx = terminal_simd_stem_idx::<K>(leaf_idx, pivot_depth);
+            debug_assert!(terminal_stem_idx < stem_words.len());
+            unsafe {
+                *stem_words.get_unchecked_mut(terminal_stem_idx) = descriptor;
+            }
+        }
+
+        Ok(Self {
+            stem_words,
+            leaves,
+            max_stem_level,
+            leaf_count,
+        })
+    }
+
+    /// Hybrid descent with a shallow SIMD selector and embedded descriptor.
+    #[inline(always)]
+    pub fn approx_nearest_one_embedded_shallow_simd<D>(&self, query: &[f64; K]) -> (f64, u32)
+    where
+        D: DistanceMetric<f64, Output = f64>,
+    {
+        let (strat, terminal_base_idx, query_value) = self.descend_complete_blocks(query);
+        let terminal_rank =
+            compare_terminal_block2_f64(&self.stem_words, terminal_base_idx, query_value);
+        debug_assert!(strat.leaf_idx_with_terminal_rank(terminal_rank) < self.leaf_count);
+        let descriptor = unsafe {
+            *self
+                .stem_words
+                .get_unchecked(terminal_base_idx + 3 + usize::from(terminal_rank))
+        };
+        let (byte_offset, leaf_len) = unpack_descriptor(descriptor);
+        let arena = self
+            .leaves
+            .leaf_arena_from_embedded_descriptor(byte_offset, leaf_len);
+        process_arena::<D, K>(&arena, query)
+    }
+
+    /// Hybrid descent using two serial comparisons in the terminal block.
+    #[inline(always)]
+    pub fn approx_nearest_one_embedded_terminal_scalar<D>(&self, query: &[f64; K]) -> (f64, u32)
+    where
+        D: DistanceMetric<f64, Output = f64>,
+    {
+        let (strat, terminal_base_idx, query_value) = self.descend_complete_blocks(query);
+        let terminal_rank =
+            compare_terminal_block2_scalar(&self.stem_words, terminal_base_idx, query_value);
+        debug_assert!(strat.leaf_idx_with_terminal_rank(terminal_rank) < self.leaf_count);
+        let descriptor = unsafe {
+            *self
+                .stem_words
+                .get_unchecked(terminal_base_idx + 3 + usize::from(terminal_rank))
+        };
+        let (byte_offset, leaf_len) = unpack_descriptor(descriptor);
+        let arena = self
+            .leaves
+            .leaf_arena_from_embedded_descriptor(byte_offset, leaf_len);
+        process_arena::<D, K>(&arena, query)
+    }
+
+    /// Same hybrid traversal followed by the existing extent-table lookup.
+    #[inline(always)]
+    pub fn approx_nearest_one_via_extents_shallow_simd<D>(&self, query: &[f64; K]) -> (f64, u32)
+    where
+        D: DistanceMetric<f64, Output = f64>,
+    {
+        let (strat, terminal_base_idx, query_value) = self.descend_complete_blocks(query);
+        let terminal_rank =
+            compare_terminal_block2_f64(&self.stem_words, terminal_base_idx, query_value);
+        let leaf_idx = strat.leaf_idx_with_terminal_rank(terminal_rank);
+        debug_assert!(leaf_idx < self.leaf_count);
+        let arena = <VecOfArenas<f64, u32, K, B> as LeafStrategy<
+            f64,
+            u32,
+            DonnellySimdDescentLeafEmbedded3,
+            K,
+            B,
+        >>::leaf_arena(&self.leaves, leaf_idx);
+        process_arena::<D, K>(&arena, query)
+    }
+
+    /// Number of logical leaves, exposed for benchmark diagnostics.
+    #[inline]
+    pub fn leaf_count(&self) -> usize {
+        self.leaf_count
+    }
+
+    /// Number of packed stem/descriptor words, exposed for benchmark diagnostics.
+    #[inline]
+    pub fn stem_word_count(&self) -> usize {
+        self.stem_words.len()
+    }
+
+    #[inline(always)]
+    fn descend_complete_blocks(
+        &self,
+        query: &[f64; K],
+    ) -> (DonnellySimdDescentLeafEmbedded3, usize, f64) {
+        let stems_ptr = NonNull::new(self.stem_words.as_ptr() as *mut u8).unwrap();
+        let stems = unsafe {
+            std::slice::from_raw_parts(
+                self.stem_words.as_ptr().cast::<f64>(),
+                self.stem_words.len(),
+            )
+        };
+        let mut strat = DonnellySimdDescentLeafEmbedded3::new(stems_ptr);
+        let pivot_depth = self.max_stem_level + 1;
+        let terminal_block_level = pivot_depth - 2;
+
+        debug_assert_eq!((pivot_depth + 1) % 3, 0);
+        debug_assert_eq!(terminal_block_level % 3, 0);
+
+        while strat.level() < terminal_block_level {
+            let query_value = unsafe { *query.get_unchecked(strat.dim::<K>()) };
+            let child_idx = compare_block3(stems, query_value, strat.stem_idx());
+            strat.traverse_block::<K>(child_idx);
+        }
+
+        debug_assert_eq!(strat.level(), terminal_block_level);
+        let terminal_base_idx = strat.stem_idx();
+        let query_value = unsafe { *query.get_unchecked(strat.dim::<K>()) };
+        (strat, terminal_base_idx, query_value)
+    }
+}
+
+#[inline(always)]
+fn compare_terminal_block2_scalar(stem_words: &[u64], base_idx: usize, query_value: f64) -> u8 {
+    let root = f64::from_bits(unsafe { *stem_words.get_unchecked(base_idx) });
+    let root_right = query_value >= root;
+    let child_idx = base_idx + 1 + usize::from(root_right);
+    let child = f64::from_bits(unsafe { *stem_words.get_unchecked(child_idx) });
+    (u8::from(root_right) << 1) | u8::from(query_value >= child)
+}
+
+#[inline(always)]
+fn compare_terminal_block2_f64(stem_words: &[u64], base_idx: usize, query_value: f64) -> u8 {
+    #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+    {
+        unsafe {
+            use std::arch::x86_64::*;
+
+            let ptr = stem_words.as_ptr().add(base_idx).cast::<f64>();
+            let pivots = _mm256_loadu_pd(ptr);
+            let query = _mm256_set1_pd(query_value);
+            let compared = _mm256_cmp_pd(query, pivots, _CMP_GE_OQ);
+            return ((_mm256_movemask_pd(compared) as u32) & 0b0111).count_ones() as u8;
+        }
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "aarch64"))]
+    {
+        unsafe {
+            use std::arch::aarch64::*;
+
+            let ptr = stem_words.as_ptr().add(base_idx).cast::<f64>();
+            let query = vdupq_n_f64(query_value);
+            let first_two = vshrq_n_u64(vcgeq_f64(query, vld1q_f64(ptr)), 63);
+            let third_and_descriptor = vshrq_n_u64(vcgeq_f64(query, vld1q_f64(ptr.add(2))), 63);
+            return (vaddvq_u64(first_two) + vgetq_lane_u64::<0>(third_and_descriptor)) as u8;
+        }
+    }
+
+    #[cfg(not(any(
+        all(feature = "simd", target_arch = "x86_64"),
+        all(feature = "simd", target_arch = "aarch64")
+    )))]
+    {
+        let mut rank = 0u8;
+        for offset in 0..3 {
+            let pivot = f64::from_bits(unsafe { *stem_words.get_unchecked(base_idx + offset) });
+            rank += u8::from(query_value >= pivot);
+        }
+        rank
+    }
+}
+
 #[inline(always)]
 fn process_arena<D, const K: usize>(
     arena: &crate::leaf_view::LeafArena<'_, f64, u32, K>,
@@ -226,9 +444,18 @@ fn terminal_stem_idx<const K: usize>(leaf_idx: usize, pivot_depth: usize) -> usi
     strat.stem_idx()
 }
 
+fn terminal_simd_stem_idx<const K: usize>(leaf_idx: usize, pivot_depth: usize) -> usize {
+    let mut strat = DonnellySimdDescentLeafEmbedded3::new_no_ptr();
+    for bit_idx in (0..pivot_depth).rev() {
+        let is_right = leaf_idx & (1usize << bit_idx) != 0;
+        strat.traverse::<f64, K>(is_right);
+    }
+    strat.stem_idx()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::EmbeddedLeafDescriptorF64Tree;
+    use super::{EmbeddedLeafDescriptorF64Tree, EmbeddedLeafDescriptorSimdF64Tree};
     use crate::dist::SquaredEuclidean;
     use rand::{RngExt, SeedableRng};
     use rand_chacha::ChaCha8Rng;
@@ -248,6 +475,31 @@ mod tests {
             assert_eq!(
                 tree.approx_nearest_one_via_extents::<SquaredEuclidean<f64>>(query),
                 tree.approx_nearest_one_embedded::<SquaredEuclidean<f64>>(query)
+            );
+        }
+    }
+
+    #[test]
+    fn hybrid_embedded_scalar_and_extent_paths_match() {
+        const K: usize = 3;
+        const B: usize = 32;
+        let mut rng = ChaCha8Rng::seed_from_u64(0x5eed_51d0);
+        let points: Vec<[f64; K]> = (0..4096).map(|_| rng.random()).collect();
+        let queries: Vec<[f64; K]> = (0..256).map(|_| rng.random()).collect();
+        let tree = EmbeddedLeafDescriptorSimdF64Tree::<K, B>::new_from_slice(&points).unwrap();
+
+        assert_eq!(tree.leaf_count(), 128);
+        assert!(tree.stem_word_count() > tree.leaf_count());
+        for query in &queries {
+            let shallow =
+                tree.approx_nearest_one_embedded_shallow_simd::<SquaredEuclidean<f64>>(query);
+            assert_eq!(
+                shallow,
+                tree.approx_nearest_one_embedded_terminal_scalar::<SquaredEuclidean<f64>>(query)
+            );
+            assert_eq!(
+                shallow,
+                tree.approx_nearest_one_via_extents_shallow_simd::<SquaredEuclidean<f64>>(query)
             );
         }
     }

--- a/src/stem_strategy/donnelly/mod.rs
+++ b/src/stem_strategy/donnelly/mod.rs
@@ -30,6 +30,8 @@
 mod no_pf;
 mod scalar;
 mod simd_descent;
+#[cfg(feature = "test_utils")]
+mod simd_descent_leaf_embedded;
 mod unrolled;
 mod unrolled_block_dim;
 #[cfg(feature = "test_utils")]
@@ -46,6 +48,9 @@ pub use no_pf::DonnellyNoPf;
 pub use scalar::Donnelly;
 #[doc(inline)]
 pub use simd_descent::DonnellySimdDescent;
+#[cfg(feature = "test_utils")]
+#[doc(hidden)]
+pub use simd_descent_leaf_embedded::DonnellySimdDescentLeafEmbedded3;
 #[doc(inline)]
 pub use simd_full::DonnellySimdFull;
 #[doc(inline)]

--- a/src/stem_strategy/donnelly/simd_descent_leaf_embedded.rs
+++ b/src/stem_strategy/donnelly/simd_descent_leaf_embedded.rs
@@ -1,0 +1,126 @@
+//! Benchmark-only SIMD-descent layout reserving the final block level for descriptors.
+
+use std::ptr::NonNull;
+
+use crate::stem_strategy::donnelly::core::DonnellyCore;
+use crate::{Axis, StemStrategy};
+
+/// Block-height-three, block-dimension traversal with terminal leaf metadata.
+///
+/// Complete pivot blocks are traversed block-at-once by the benchmark query
+/// entry point. The final block contains two pivot levels and four leaf
+/// descriptors in place of its third pivot level.
+#[doc(hidden)]
+#[derive(Copy, Clone, Debug)]
+pub struct DonnellySimdDescentLeafEmbedded3 {
+    core: DonnellyCore<3>,
+}
+
+impl DonnellySimdDescentLeafEmbedded3 {
+    #[inline(always)]
+    pub(crate) fn traverse_block<const K: usize>(&mut self, child_idx: u8) {
+        self.core.traverse_block::<K>(child_idx, 3);
+    }
+
+    #[inline(always)]
+    pub(crate) fn leaf_idx_with_terminal_rank(&self, terminal_rank: u8) -> usize {
+        debug_assert!(terminal_rank < 4);
+        self.core.leaf_idx().wrapping_shl(2) | usize::from(terminal_rank)
+    }
+}
+
+impl StemStrategy for DonnellySimdDescentLeafEmbedded3 {
+    const ROOT_IDX: usize = 0;
+    const BLOCK_SIZE: usize = 3;
+    const TERMINAL_METADATA_LEVELS: usize = 1;
+
+    type DeferredState = Self;
+    type StackContext<A> = crate::kd_tree::query_stack::QueryStackContext<A, Self::DeferredState>;
+    type Stack<A> = crate::kd_tree::query_stack::QueryStack<A, Self>;
+
+    #[inline(always)]
+    fn new(stems_ptr: NonNull<u8>) -> Self {
+        Self {
+            core: DonnellyCore::new(stems_ptr),
+        }
+    }
+
+    #[inline(always)]
+    fn stem_idx(&self) -> usize {
+        self.core.stem_idx()
+    }
+
+    #[inline(always)]
+    fn deferred_state(&self) -> Self::DeferredState {
+        *self
+    }
+
+    #[inline(always)]
+    fn rehydrate_deferred_state(&mut self, state: Self::DeferredState) {
+        *self = state;
+    }
+
+    #[inline(always)]
+    fn leaf_idx(&self) -> usize {
+        self.core.leaf_idx()
+    }
+
+    #[inline(always)]
+    fn dim<const K: usize>(&self) -> usize {
+        self.core.level() as usize / 3 % K
+    }
+
+    #[inline(always)]
+    fn construction_dim<const K: usize>(&self) -> usize {
+        self.core.level() as usize / 3 % K
+    }
+
+    #[inline(always)]
+    fn level(&self) -> i32 {
+        self.core.level()
+    }
+
+    #[inline(always)]
+    fn traverse<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+        self.core.traverse::<A, K>(is_right);
+    }
+
+    #[inline(always)]
+    fn traverse_head<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+        self.core.traverse_head::<A, K>(is_right);
+    }
+
+    #[inline(always)]
+    fn traverse_tail<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+        self.core.traverse_tail_with_block_size::<A, K>(is_right, 3);
+    }
+
+    #[inline(always)]
+    fn branch<A: Axis<Coord = A>, const K: usize>(&mut self) -> Self {
+        Self {
+            core: self.core.branch::<A, K>(),
+        }
+    }
+
+    #[inline(always)]
+    fn child_indices<A: Axis<Coord = A>>(&self) -> (usize, usize) {
+        self.core.child_indices::<A>()
+    }
+
+    fn get_leaf_idx<A: Axis<Coord = A>, const K: usize>(
+        stems: &[A],
+        query: &[A; K],
+        max_stem_level: i32,
+    ) -> usize {
+        let stems_ptr = NonNull::new(stems.as_ptr() as *mut u8).unwrap();
+        let mut strat = Self::new(stems_ptr);
+
+        while strat.level() <= max_stem_level {
+            let pivot = unsafe { *stems.get_unchecked(strat.stem_idx()) };
+            let query_value = unsafe { *query.get_unchecked(strat.dim::<K>()) };
+            strat.traverse::<A, K>(query_value >= pivot);
+        }
+
+        strat.leaf_idx()
+    }
+}

--- a/src/stem_strategy/mod.rs
+++ b/src/stem_strategy/mod.rs
@@ -11,6 +11,9 @@ pub use donnelly::simd_full::{CompareBlock3, CompareBlock4, SimdPrune, SimdSelec
 pub use donnelly::Donnelly;
 #[cfg(feature = "test_utils")]
 #[doc(hidden)]
+pub use donnelly::DonnellySimdDescentLeafEmbedded3;
+#[cfg(feature = "test_utils")]
+#[doc(hidden)]
 pub use donnelly::DonnellyUnrolledLeafEmbedded3;
 #[doc(hidden)]
 pub use donnelly::{


### PR DESCRIPTION
## Summary

- add a benchmark-only Donnelly SIMD-descent strategy with complete block-at-once traversal
- reserve the third level of the terminal block for four packed leaf descriptors
- compare shallow-SIMD and scalar terminal selectors against a same-tree extent lookup
- add the hybrid series to the experiment benchmark, v6 CI benchmark, and Pages matrix
- directly cap the experiment benchmark matrices at 2^25

## Local results

On Apple/NEON with f64, K=3, B=32 approximate nearest-one, the scalar terminal selector was about 3% faster than shallow SIMD. At the naturally aligned 2^25 size it measured 185.5 ns/query, versus 190.7 ns for shallow SIMD, 204.5 ns for the same-tree extent control, and 210.0 ns for ordinary DonnellySimdDescent.

The clean descriptor-only comparison is hybrid_simd_embedded versus hybrid_simd_extent_control because those paths use identical traversal and terminal selection. The ordinary DonnellySimdDescent comparison uses a different padding/pivot phase and is therefore an overall throughput comparison rather than identical leaf selection.

## Validation

- cargo test --lib --features=test_utils
- cargo +nightly test --lib --features=simd,test_utils
- cargo clippy --features=serde,test_utils --no-deps
- nightly SIMD checks for both modified benchmarks
- full local benchmark sweep from 2^16 through 2^26 before applying the CI cap
- current experiment CI matrices stop at 2^25

Stacked on the embedded leaf descriptor experiment PR.