### PR TITLE
ci: cap leaf benchmark trees at 2^25

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -125,6 +125,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run benchmark suite
+        env:
+          # The self-hosted runner is currently OOM-killed by the 2^26 leaf trees.
+          KIDDO_PROFILE_MAX_LOG2_POINTS: "25"
         run: |
           run_variant() {
             case "$1" in

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -13,6 +13,7 @@ use std::hint::black_box;
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
+const DEFAULT_MAX_LOG2_POINTS: usize = 26;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
 const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
@@ -88,17 +89,21 @@ fn run_queries_vec_of_arrays(tree: &VecOfArraysTree, queries: &[[f64; K]]) -> (f
 
 fn leaf_strategies(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let max_log2_points = read_usize_env("KIDDO_PROFILE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
 
     eprintln!(
-        "benchmarking v6 leaf strategies: dims={} tree_sizes=2^16,2^18,...,2^26 queries={} point_seed={} query_seed={}",
-        K, query_count, POINT_SEED, QUERY_SEED
+        "benchmarking v6 leaf strategies: dims={} tree_sizes=2^16,2^18,... max_log2_points={} queries={} point_seed={} query_seed={}",
+        K, max_log2_points, query_count, POINT_SEED, QUERY_SEED
     );
 
     let queries = build_queries(query_count);
     let mut group = c.benchmark_group("profile_v6_leaf_strategies/f64");
     group.throughput(Throughput::Elements(query_count as u64));
 
-    for point_count in TREE_SIZES {
+    for point_count in TREE_SIZES
+        .into_iter()
+        .filter(|point_count| point_count.ilog2() as usize <= max_log2_points)
+    {
         let points = build_points(point_count);
 
         let flat_tree: FlatTree = KdTree::new_from_slice(&points).unwrap();


### PR DESCRIPTION
## Summary

- add KIDDO_PROFILE_MAX_LOG2_POINTS support to the v6 leaf-strategy Criterion benchmark
- set the benchmark-report workflow cap to 25 for the self-hosted runner
- preserve the existing 2^26 default for unrestricted local runs

This temporarily avoids the SIGKILL seen after the 2^26 arena benchmark in Actions run 29895547055, job 88846108436. The existing leaf-strategy size list uses even exponents, so its capped CI run ends at 2^24 rather than attempting 2^26. Experiment-specific full sweeps can use the same workflow value to retain 2^25 while excluding 2^26.

## Validation

- repository pre-commit hooks, including actionlint, formatting, and Clippy
- KIDDO_PROFILE_MAX_LOG2_POINTS=16 test-mode Criterion run completed successfully