### PR TITLE
ci: cap embedded descriptor benchmark sizes

### DIFF
--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -19,8 +19,8 @@ const DEFAULT_QUERY_COUNT: usize = 1_000;
 const DEFAULT_MAX_LOG2_POINTS: usize = 26;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
-const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
-const APPROX_TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 25];
+const APPROX_TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -31,7 +31,6 @@ const APPROX_TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 
 type FlatTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;


### PR DESCRIPTION
## Summary

- use 2^25 instead of 2^26 in the experiment sparse sweep
- remove 2^26 from the experiment dense sweep

This directly changes the experiment benchmark matrix and nothing else.

## Validation

- cargo check --bench profile_v6_leaf_strategies_criterion --features=simd,test_utils,logging_off
- repository pre-commit hooks