### PR TITLE
ci: fix leaf benchmark result export

### DIFF
--- a/justfile
+++ b/justfile
@@ -247,7 +247,7 @@ bench-v6-leaf-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
     cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
         target/criterion \
         "$output_dir/bench_result-v6-leaf-strategies-${result_key}.json" \
-        profile_v6_leaf_strategies_criterion
+        profile_v6_leaf_strategies
 
 bench-v6-stem-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='1000' SCALAR_FEATURES='simd,test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- export the v6 leaf benchmark using its Criterion group ID, profile_v6_leaf_strategies
- stop filtering with the Cargo benchmark target name, profile_v6_leaf_strategies_criterion

The capped benchmark in Actions run 29900330148 completed its measurements, then failed because the exporter performs an exact group-prefix match and therefore found no results under the target-name filter.

## Validation

- verified the benchmark group ID against profile_v6_leaf_strategies_criterion.rs and the exporter prefix-matching implementation
- repository pre-commit hooks