### PR TITLE
ci: cap every benchmark-report tree at 2^25

### DIFF
--- a/benches/profile_v6_approx_nearest_one_eytzinger.rs
+++ b/benches/profile_v6_approx_nearest_one_eytzinger.rs
@@ -15,7 +15,7 @@ const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
-const TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -26,7 +26,6 @@ const TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 
 type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;

--- a/benches/profile_v6_dist_metrics.rs
+++ b/benches/profile_v6_dist_metrics.rs
@@ -16,7 +16,7 @@ const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
-const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
+const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 25];
 
 type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
 

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -16,7 +16,7 @@ const DEFAULT_QUERY_COUNT: usize = 1_000;
 const DEFAULT_MAX_LOG2_POINTS: usize = 26;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
-const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26];
+const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 25];
 
 type FlatTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
 type ArenaTree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, K, B>, K, B>;

--- a/benches/profile_v6_nearest_n_eytzinger.rs
+++ b/benches/profile_v6_nearest_n_eytzinger.rs
@@ -16,7 +16,7 @@ const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
-const TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -27,7 +27,6 @@ const TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 const MAX_QTYS: [usize; 3] = [5, 20, 50];
 

--- a/benches/profile_v6_nearest_one_eytzinger.rs
+++ b/benches/profile_v6_nearest_one_eytzinger.rs
@@ -15,7 +15,7 @@ const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
-const TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -26,7 +26,6 @@ const TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 
 type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;

--- a/benches/profile_v6_query_family_eytzinger.rs
+++ b/benches/profile_v6_query_family_eytzinger.rs
@@ -18,7 +18,7 @@ const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
 const MAX_DIST: f64 = 0.0025;
 const MAX_QTYS: [usize; 3] = [5, 20, 50];
-const TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -29,7 +29,6 @@ const TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 
 type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;

--- a/benches/profile_v6_stem_strategies.rs
+++ b/benches/profile_v6_stem_strategies.rs
@@ -21,7 +21,7 @@ const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0301;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0302;
-const TREE_SIZES: [usize; 11] = [
+const TREE_SIZES: [usize; 10] = [
     1 << 16,
     1 << 17,
     1 << 18,
@@ -32,7 +32,6 @@ const TREE_SIZES: [usize; 11] = [
     1 << 23,
     1 << 24,
     1 << 25,
-    1 << 26,
 ];
 
 type F64Tree<SS> = KdTree<f64, u32, SS, FlatVec<f64, u32, K, B>, K, B>;


### PR DESCRIPTION
## Summary

- remove 2^26 from the five dense benchmark size matrices
- use 2^25 instead of 2^26 in the two sparse benchmark size matrices
- keep every benchmark-report target at or below 2^25

This is deliberately a direct benchmark-constant change: no helper, workflow guard, or policy script.

## Validation

- cargo check --benches --features=simd,test_utils,logging_off
- repository pre-commit hooks, including formatting and Clippy
- repository-wide search confirms no 2^26 / 67,108,864 benchmark size remains