### PR TITLE
fix v5 unsorted nearest-n parity reporting

### DIFF
--- a/scripts/benchmark_site_root.py
+++ b/scripts/benchmark_site_root.py
@@ -30,6 +30,18 @@ def canonical_suite_name(suite: str) -> str:
     return re.sub(r"^v[0-9]+-", "", suite)
 
 
+def canonical_series_key(key: SeriesKey) -> SeriesKey:
+    return SeriesKey(re.sub(r"^profile_v[0-9]+_", "profile_", key.group_id), key.function_id)
+
+
+def shared_tree_points(left: list[Point], right: list[Point]) -> tuple[list[Point], list[Point]]:
+    shared_sizes = {point.tree_log2 for point in left} & {point.tree_log2 for point in right}
+    return (
+        [point for point in left if point.tree_log2 in shared_sizes],
+        [point for point in right if point.tree_log2 in shared_sizes],
+    )
+
+
 def latest_baseline_summary(line_root: Path) -> RunSummary | None:
     path = line_root / "baseline" / "latest" / "run.json"
     if not path.is_file():
@@ -46,7 +58,10 @@ def load_result_sets(
         if not name.startswith("bench_result-") or not name.endswith("-baseline.json"):
             continue
         suite = name[len("bench_result-") : -len("-baseline.json")]
-        sets[canonical_suite_name(suite)] = (suite, result_series(path))
+        series = {
+            canonical_series_key(key): points for key, points in result_series(path).items()
+        }
+        sets[canonical_suite_name(suite)] = (suite, series)
     return sets
 
 
@@ -183,6 +198,9 @@ def render_latest_comparison(pages_root: Path, site_url_base: str | None) -> str
             key=lambda key: (key.group_id, key.function_id),
         )
         for key in common_keys:
+            v5_points, v6_points = shared_tree_points(v5_series[key], v6_series[key])
+            if not v5_points:
+                continue
             title = f"{canonical_suite}: {key.group_id} / {key.function_id}"
             chart_path = comparison_chart_path(
                 charts_dir,
@@ -196,12 +214,12 @@ def render_latest_comparison(pages_root: Path, site_url_base: str | None) -> str
                 plt,
                 title,
                 "v5",
-                v5_series[key],
+                v5_points,
                 "v6",
-                v6_series[key],
+                v6_points,
                 chart_path,
             )
-            chart_rows.append((title, chart_path.name, change_score(v5_series[key], v6_series[key])))
+            chart_rows.append((title, chart_path.name, change_score(v5_points, v6_points)))
 
     chart_rows.sort(key=lambda row: row[2], reverse=True)
     sections = []

--- a/src/immutable/common/generate_immutable_nearest_n_within.rs
+++ b/src/immutable/common/generate_immutable_nearest_n_within.rs
@@ -23,8 +23,8 @@ macro_rules! generate_immutable_nearest_n_within {
                 // When false, only points strictly less than the maximum distance are included.
                 let max_items = max_items.into();
 
-                if sorted && max_items < usize::MAX {
-                    if max_items <= MAX_VEC_RESULT_SIZE {
+                if max_items < usize::MAX {
+                    if sorted && max_items <= MAX_VEC_RESULT_SIZE {
                         self.nearest_n_within_stub::<D, SortedVec<NearestNeighbour<A, T>>>(query, dist, max_items, sorted, inclusive)
                     } else {
                         self.nearest_n_within_stub::<D, BinaryHeap<NearestNeighbour<A, T>>>(query, dist, max_items, sorted, inclusive)

--- a/src/immutable/float/query/nearest_n_within.rs
+++ b/src/immutable/float/query/nearest_n_within.rs
@@ -119,6 +119,21 @@ mod tests {
     type AX = f32;
 
     #[test]
+    fn unsorted_respects_max_qty() {
+        let points = [[0.0f32, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]];
+        let tree: ImmutableKdTree<f32, u32, 2, 4> = ImmutableKdTree::new_from_slice(&points);
+        let max_qty = NonZero::new(2).unwrap();
+
+        let mut results =
+            tree.nearest_n_within::<SquaredEuclidean>(&[0.1, 0.0], 100.0, max_qty, false);
+        results.sort_unstable();
+
+        assert_eq!(results.len(), max_qty.get());
+        assert_eq!(results[0].item, 0);
+        assert_eq!(results[1].item, 1);
+    }
+
+    #[test]
     fn can_query_items_within_radius() {
         let content_to_add: [[AX; 4]; 16] = [
             [0.9f32, 0.0f32, 0.9f32, 0.0f32],


### PR DESCRIPTION
## Summary

- make immutable nearest_n_within(..., sorted = false) honor max_items
- use the bounded BinaryHeap result collector for unsorted finite-k queries
- add a regression test proving unsorted results are capped and contain the nearest items
- backport the v5-v6 chart key and shared-tree-size matching fix, so the resulting v5 baseline run republishes the comparison correctly

## Benchmark relevance

The current v5-v6 charts compare v6 bounded nearest_n_within(...).unsorted() against a v5 path that accidentally uses an unbounded Vec. With the published benchmark inputs, v5 returned 64,809 results for 1,000 k50 queries at 2^17 instead of the correct 48,994. At 2^18 it returned 129,795 instead of 49,973.

After this fix, the v5 output checksum matches v6. A local targeted run of the corrected v5 f64 unsorted-k50 path measured about 3.93, 5.61, and 10.76 us/query at 2^16, 2^17, and 2^18, versus the current correct v6 path at about 1.76, 3.04, and 4.09 us/query.

## Validation

- cargo test unsorted_respects_max_qty --lib --features=test_utils
- cargo test --lib --features=test_utils (2,143 passed)
- targeted corrected v5 benchmark at 2^16 through 2^18
- end-to-end top-level site render against current gh-pages data (32 charts)