### PR TITLE
ci: add tree construction benchmarks

### DIFF
--- a/.github/workflows/benchmark-report-dispatch.yml
+++ b/.github/workflows/benchmark-report-dispatch.yml
@@ -55,6 +55,7 @@ jobs:
                   ["/benchmark dist", "dist"],
                   ["/benchmark leaf", "leaf"],
                   ["/benchmark stems", "stems"],
+                  ["/benchmark construction", "construction"],
                 ]),
               ],
               [
@@ -101,11 +102,13 @@ jobs:
                 ? "dist-focussed"
                 : benchmarkVariant === "extended"
                   ? "query-family"
-                : benchmarkVariant === "leaf"
-                  ? "leaf-strategy"
-                  : benchmarkVariant === "stems"
-                    ? "stem-strategy"
-                  : "basic";
+                  : benchmarkVariant === "leaf"
+                    ? "leaf-strategy"
+                    : benchmarkVariant === "stems"
+                      ? "stem-strategy"
+                      : benchmarkVariant === "construction"
+                        ? "tree-construction"
+                        : "basic";
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -45,6 +45,7 @@ on:
           - dist
           - leaf
           - stems
+          - construction
 
 concurrency:
   group: benchmark-report-${{ inputs.head_ref || github.ref_name }}-${{ inputs.benchmark_variant || 'basic' }}
@@ -168,6 +169,12 @@ jobs:
                   simd,test_utils,logging_off \
                   simd,test_utils,logging_off
                 ;;
+              construction)
+                just bench-v6-construction \
+                  "${{ steps.meta.outputs.variant_key }}" \
+                  ./target/benchmark-results \
+                  simd,test_utils,logging_off
+                ;;
               *)
                 echo "Unknown benchmark variant: $1" >&2
                 exit 2
@@ -181,6 +188,7 @@ jobs:
             run_variant dist
             run_variant leaf
             run_variant stems
+            run_variant construction
           else
             run_variant "${{ steps.meta.outputs.benchmark_variant }}"
           fi

--- a/AVAILABLE_CI_BENCHMARK_OPTIONS.md
+++ b/AVAILABLE_CI_BENCHMARK_OPTIONS.md
@@ -11,6 +11,13 @@ The workflow reads the YAML block below.
 
 ```yaml
 rules:
+  - command: /benchmark construction
+    reason: Changes to the tree builder or construction pipeline can affect tree creation performance.
+    match_any:
+      - src/kd_tree/builder.rs
+      - src/kd_tree/construction.rs
+      - src/kd_tree/construction/**
+
   - command: /benchmark dist
     reason: Changes under `src/dist/` can affect distance metric performance.
     match_any:
@@ -47,6 +54,7 @@ rules:
 ## Notes
 
 - `/benchmark dist` is reserved for distance-metric-focused changes and should stay above broader rules.
+- `/benchmark construction` is reserved for tree-builder and construction-pipeline changes and should stay above broader rules.
 - `/benchmark stems` is reserved for stem-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark leaf` is reserved for leaf-strategy-specific changes and should stay above the broader `/benchmark` rule.
 - `/benchmark extended` is reserved for query-pipeline changes and should stay above the broader `/benchmark` rule.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,12 @@ harness = false
 required-features = ["simd", "test_utils"]
 
 [[bench]]
+name = "profile_v6_construction"
+path = "benches/profile_v6_construction.rs"
+harness = false
+required-features = ["simd", "test_utils"]
+
+[[bench]]
 name = "profile_v6_stem_exact_stats"
 path = "benches/profile_v6_stem_exact_stats.rs"
 harness = false

--- a/benches/profile_v6_construction.rs
+++ b/benches/profile_v6_construction.rs
@@ -1,0 +1,120 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BatchSize, BenchmarkGroup, BenchmarkId, Criterion,
+    SamplingMode, Throughput,
+};
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::VecOfArenas;
+use kiddo::{DonnellySimdDescent, Eytzinger};
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+use std::time::Duration;
+
+const K: usize = 3;
+const B: usize = 32;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0401;
+const TREE_SIZES: [usize; 11] = [
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20,
+    1 << 21,
+    1 << 22,
+    1 << 23,
+    1 << 24,
+    1 << 25,
+    1 << 26,
+];
+
+type F32EytzingerTree = KdTree<f32, u32, Eytzinger, VecOfArenas<f32, u32, K, B>, K, B>;
+type F64EytzingerTree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, K, B>, K, B>;
+type F64DonnellySimdDescentTree =
+    KdTree<f64, u32, DonnellySimdDescent<3>, VecOfArenas<f64, u32, K, B>, K, B>;
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f32; K]>()).collect()
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random::<[f64; K]>()).collect()
+}
+
+fn configure_group<'a>(c: &'a mut Criterion, group_id: &str) -> BenchmarkGroup<'a, WallTime> {
+    let mut group = c.benchmark_group(group_id);
+    group.throughput(Throughput::Elements(1));
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+    group
+}
+
+fn bench_construction<A, Tree>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    strategy: &str,
+    point_count: usize,
+    points: &[[A; K]],
+    build: impl Fn(&[[A; K]]) -> Tree,
+) {
+    group.bench_function(BenchmarkId::new(strategy, point_count), |b| {
+        b.iter_batched(
+            || (),
+            |()| black_box(build(black_box(points))),
+            BatchSize::LargeInput,
+        )
+    });
+}
+
+fn construction(c: &mut Criterion) {
+    eprintln!(
+        "benchmarking v6 construction: dims={} leaf=VecOfArenas tree_sizes=2^16..=2^26 \
+         rayon_threads={} point_seed={}",
+        K,
+        std::env::var("RAYON_NUM_THREADS")
+            .as_deref()
+            .unwrap_or("unset"),
+        POINT_SEED,
+    );
+
+    {
+        let mut group = configure_group(c, "profile_v6_construction/f32");
+        for point_count in TREE_SIZES {
+            let points = build_points_f32(point_count);
+            bench_construction(&mut group, "eytzinger", point_count, &points, |points| {
+                F32EytzingerTree::new_from_slice(points).expect("f32 Eytzinger construction failed")
+            });
+        }
+        group.finish();
+    }
+
+    {
+        let mut group = configure_group(c, "profile_v6_construction/f64");
+        for point_count in TREE_SIZES {
+            let points = build_points_f64(point_count);
+            bench_construction(&mut group, "eytzinger", point_count, &points, |points| {
+                F64EytzingerTree::new_from_slice(points).expect("f64 Eytzinger construction failed")
+            });
+            bench_construction(
+                &mut group,
+                "donnelly_simd_descent",
+                point_count,
+                &points,
+                |points| {
+                    F64DonnellySimdDescentTree::new_from_slice(points)
+                        .expect("f64 DonnellySimdDescent<3> construction failed")
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, construction);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -298,6 +298,37 @@ bench-v6-stem-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES=
             ;;
     esac
 
+bench-v6-construction RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    host=$(rustc -vV | sed -n 's/^host: //p')
+    if [[ "$host" != x86_64-* ]]; then
+        echo "bench-v6-construction requires an x86_64 AVX-512 host; found $host" >&2
+        exit 2
+    fi
+    if ! rustc --print cfg -C target-cpu=native | grep -qx 'target_feature="avx512f"'; then
+        echo "bench-v6-construction requires AVX-512F support" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        RAYON_NUM_THREADS=6 \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --target "$host" \
+            --bench profile_v6_construction \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-v6-construction-avx512-${result_key}.json" \
+        profile_v6_construction
+
 chart-benchmark-results VARIANT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
     {{quote(PYTHON)}} scripts/chart_benchmark_results.py {{quote(VARIANT_KEY)}} --results-dir {{quote(RESULTS_DIR)}} --output-dir {{quote(OUTPUT_DIR)}}
 

--- a/scripts/benchmark_site.py
+++ b/scripts/benchmark_site.py
@@ -25,6 +25,7 @@ from chart_benchmark_results import (
     Point,
     SeriesKey,
     SAFE_KEY,
+    duration_axis_label,
     generate_charts,
     import_matplotlib,
     load_json,
@@ -156,6 +157,8 @@ def infer_benchmark_variant(value: dict[str, Any]) -> str:
         return "dist"
     if any(name.startswith("bench_result-v5-dist-metrics-") for name in names):
         return "dist"
+    if any(name.startswith("bench_result-v6-construction-") for name in names):
+        return "construction"
     if any(name.startswith("bench_result-v6-leaf-strategies-") for name in names):
         return "leaf"
     if any(name.startswith("bench_result-v6-stem-strategies-") for name in names):
@@ -646,7 +649,7 @@ def render_baseline_trends(pages_root: Path) -> list[str]:
                 axis.plot(x_vals, y_vals, marker="o", linewidth=2, label=f"log2 n={tree_size:g}")
         axis.set_yscale("log")
         axis.set_xlabel("Baseline run")
-        axis.set_ylabel("Mean duration per query (us, log scale)")
+        axis.set_ylabel(duration_axis_label(group_id))
         axis.set_title(f"{suite}: {group_id} / {function_id}")
         axis.grid(True, which="both", alpha=0.25)
         axis.legend()

--- a/scripts/chart_benchmark_results.py
+++ b/scripts/chart_benchmark_results.py
@@ -37,6 +37,7 @@ MATRIX_COLORS = (
     "#7f5f00",
     "#00838f",
 )
+CONSTRUCTION_GROUP_PREFIX = "profile_v6_construction/"
 
 
 @dataclass(frozen=True)
@@ -102,6 +103,11 @@ def finite_positive(value: Any, description: str, path: Path) -> float:
     return number
 
 
+def duration_axis_label(group_id: str) -> str:
+    operation = "build" if group_id.startswith(CONSTRUCTION_GROUP_PREFIX) else "query"
+    return f"Mean duration per {operation} (us, log scale)"
+
+
 def result_series(path: Path) -> dict[SeriesKey, list[Point]]:
     series: dict[SeriesKey, list[Point]] = {}
     for result in load_json(path)["results"]:
@@ -119,8 +125,10 @@ def result_series(path: Path) -> dict[SeriesKey, list[Point]]:
             raise RuntimeError(f"invalid benchmark identity in {path}: {metadata!r}")
 
         throughput = metadata.get("throughput")
-        query_count = throughput.get("Elements") if isinstance(throughput, dict) else None
-        query_count = finite_positive(query_count, "query count/Elements throughput", path)
+        operation_count = throughput.get("Elements") if isinstance(throughput, dict) else None
+        operation_count = finite_positive(
+            operation_count, "operation count/Elements throughput", path
+        )
 
         mean = estimates.get("mean")
         interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
@@ -134,9 +142,9 @@ def result_series(path: Path) -> dict[SeriesKey, list[Point]]:
         series.setdefault(key, []).append(
             Point(
                 tree_log2=math.log2(tree_size),
-                duration_ns=duration / query_count,
-                lower_ns=lower / query_count,
-                upper_ns=upper / query_count,
+                duration_ns=duration / operation_count,
+                lower_ns=lower / operation_count,
+                upper_ns=upper / operation_count,
             )
         )
 
@@ -210,7 +218,7 @@ def render_chart(
     axis.set_xticklabels([f"{value:g}" for value in x_ticks])
     axis.set_yscale("log")
     axis.set_xlabel("log2(tree size)")
-    axis.set_ylabel("Mean duration per query (us, log scale)")
+    axis.set_ylabel(duration_axis_label(key.group_id))
     axis.set_title(f"{suite}: {key.group_id} / {key.function_id}")
     axis.grid(True, which="both", alpha=0.25)
     axis.legend()


### PR DESCRIPTION
## Summary

- add Criterion tree-construction benchmarks for f32/f64 Eytzinger and f64 DonnellySimdDescent<3> with VecOfArenas across 2^16 through 2^26 points
- add an AVX-512-only, target-cpu=native CI recipe with Rayon pinned to six threads
- add `/benchmark construction` dispatch and automatic construction-change suggestions
- report construction timing per build in PR and baseline charts

