### PR TITLE
chore: add external comparison and projection benchmark tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,16 +139,23 @@ elapsed = "0.1.2"
 flate2 = { version = "1", features = [
   "zlib-ng-compat",
 ], default-features = false }
+fnntw = { version = "0.4.1", default-features = false, features = [
+  "no-position",
+] }
 itertools = "0.15"
+kd-tree = "0.6.2"
 # required to be able to run tests without specifying --features=test_utils
 # see https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
 kiddo = { path = ".", features = ["test_utils"] }
 las = { version = "0.10", features = ["laz-parallel"] }
 memmap = "0.7"
+nabo = { version = "0.6.0", default-features = false }
+neighbourhood = "0.2.0"
 postcard = { version = "1", features = ["alloc"] }
 proc-macro2 = { version = "1", features = ["default", "proc-macro"] }
 radians = "0.3"
 rand = "0.10"
+rand_09 = { package = "rand", version = "0.9", features = ["small_rng"] }
 rand_distr = "0.6"
 rayon = "1"
 reqwest = { version = "0.13", default-features = false, features = [
@@ -264,7 +271,6 @@ required-features = ["test_utils"]
 name = "profile_v6_nearest_n_eytzinger"
 path = "benches/profile_v6_nearest_n_eytzinger.rs"
 harness = false
-required-features = ["test_utils"]
 
 [[bench]]
 name = "profile_v6_query_family_eytzinger"
@@ -295,6 +301,24 @@ name = "profile_v6_construction"
 path = "benches/profile_v6_construction.rs"
 harness = false
 required-features = ["simd", "test_utils"]
+
+[[bench]]
+name = "profile_external_kd_trees"
+path = "benches/profile_external_kd_trees.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
+name = "profile_v6_within_radius_projection"
+path = "benches/profile_v6_within_radius_projection.rs"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
+name = "profile_neighbourhood_published"
+path = "benches/profile_neighbourhood_published.rs"
+harness = false
+required-features = ["test_utils"]
 
 [[bench]]
 name = "profile_v6_stem_exact_stats"

--- a/benches/profile_external_kd_trees.rs
+++ b/benches/profile_external_kd_trees.rs
@@ -1,0 +1,835 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! Query-only comparison against current Rust k-d tree crates.
+//!
+//! All implementations receive the same seeded, uniformly distributed 3D
+//! `f32` and `f64` points and queries. Tree construction happens outside
+//! Criterion's timed regions. Each external library's native exact query API is
+//! used, including its normal result allocation and sorting behaviour. Kiddo is
+//! benchmarked separately by its focused suites.
+//!
+//! FNNTW does not expose a radius query. Nabo can cap a k-NN query by radius,
+//! but cannot return an unbounded set of all points within that radius, so
+//! neither library is included in the `within_radius` cases.
+
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use fnntw::Tree as FnntwTree;
+use kd_tree::KdTree as ExternalKdTree;
+use nabo::simple_point::SimplePoint;
+use nabo::{KDTree as NaboTree, NotNan, Point as NaboPoint};
+use neighbourhood::KdTree as NeighbourhoodTree;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const DEFAULT_MIN_LOG2_POINTS: u32 = 16;
+const DEFAULT_MAX_LOG2_POINTS: u32 = 25;
+const DEFAULT_RADIUS: f64 = 0.05;
+// Match the focused Kiddo suites so their separately collected results are comparable.
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+const MAX_QTYS: [usize; 3] = [5, 20, 50];
+const FNNTW_LEAF_SIZE: usize = 32;
+
+type PointF32 = [f32; K];
+type PointF64 = [f64; K];
+type NaboPointF32 = SimplePoint<K>;
+
+#[derive(Clone, Copy, Debug)]
+struct NaboPointF64([NotNan<f64>; K]);
+
+impl Default for NaboPointF64 {
+    fn default() -> Self {
+        Self([NotNan::new(0.0).unwrap(); K])
+    }
+}
+
+impl NaboPoint<f64> for NaboPointF64 {
+    const DIM: u32 = K as u32;
+
+    fn set(&mut self, index: u32, value: NotNan<f64>) {
+        self.0[index as usize] = value;
+    }
+
+    fn get(&self, index: u32) -> NotNan<f64> {
+        self.0[index as usize]
+    }
+}
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_u32_env(var: &str, default: u32) -> u32 {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_f64_env(var: &str, default: f64) -> f64 {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("{var} must be a finite positive number"))
+        })
+        .unwrap_or(default)
+}
+
+fn build_points_f32(point_count: usize) -> Vec<PointF32> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<PointF32> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn build_points_f64(point_count: usize) -> Vec<PointF64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<PointF64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn id(library: &str, query: &str, point_count: usize) -> BenchmarkId {
+    BenchmarkId::new(format!("{library}_{query}"), point_count)
+}
+
+fn assert_distances_match(label: &str, mut actual: Vec<f32>, expected: &[f32]) {
+    actual.sort_unstable_by(f32::total_cmp);
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label} returned the wrong number of neighbours"
+    );
+    for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+        let tolerance = 1.0e-5 * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "{label} distance mismatch at result {index}: actual={actual} expected={expected}"
+        );
+    }
+}
+
+fn validate_implementations_f32(points: &[PointF32], query: &PointF32, radius: f32) {
+    let max_qty = *MAX_QTYS.last().unwrap();
+    let max_dist = radius * radius;
+    let mut expected: Vec<_> = points
+        .iter()
+        .map(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(point, query)| (point - query) * (point - query))
+                .sum::<f32>()
+        })
+        .collect();
+    expected.sort_unstable_by(f32::total_cmp);
+    expected.truncate(max_qty);
+    let expected_within = points
+        .iter()
+        .filter(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(point, query)| (point - query) * (point - query))
+                .sum::<f32>()
+                <= max_dist
+        })
+        .count();
+
+    let fnntw = FnntwTree::new(points, FNNTW_LEAF_SIZE).unwrap();
+    let (fnntw_nearest, _) = fnntw.query_nearest_k(query, max_qty).unwrap();
+    assert_distances_match("FNNTW", fnntw_nearest, &expected);
+
+    let nabo_points = to_nabo_points_f32(points);
+    let nabo_query = NaboPointF32::from_raw(query).unwrap();
+    let nabo = NaboTree::new(&nabo_points);
+    let nabo_nearest = nabo
+        .knn(max_qty as u32, &nabo_query)
+        .into_iter()
+        .map(|result| result.dist2.into_inner())
+        .collect();
+    assert_distances_match("nabo", nabo_nearest, &expected);
+
+    let kd_tree: ExternalKdTree<PointF32> = ExternalKdTree::build_by_ordered_float(points.to_vec());
+    let kd_tree_nearest = kd_tree
+        .nearests(query, max_qty)
+        .into_iter()
+        .map(|result| result.squared_distance)
+        .collect();
+    assert_distances_match("kd-tree", kd_tree_nearest, &expected);
+    assert_eq!(
+        kd_tree.within_radius(query, radius).len(),
+        expected_within,
+        "kd-tree returned the wrong within-radius count"
+    );
+
+    let neighbourhood = NeighbourhoodTree::new(points.to_vec());
+    let neighbourhood_nearest = neighbourhood
+        .knn_by_index(query, max_qty)
+        .into_iter()
+        .map(|result| result.0 * result.0)
+        .collect();
+    assert_distances_match("neighbourhood", neighbourhood_nearest, &expected);
+    assert_eq!(
+        neighbourhood.neighbourhood_by_index(query, radius).len(),
+        expected_within,
+        "neighbourhood returned the wrong within-radius count"
+    );
+}
+
+fn assert_distances_match_f64(label: &str, mut actual: Vec<f64>, expected: &[f64]) {
+    actual.sort_unstable_by(f64::total_cmp);
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label} returned the wrong number of neighbours"
+    );
+    for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+        let tolerance = 1.0e-12 * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "{label} distance mismatch at result {index}: actual={actual} expected={expected}"
+        );
+    }
+}
+
+fn to_nabo_points_f64(points: &[PointF64]) -> Vec<NaboPointF64> {
+    points
+        .iter()
+        .map(|point| NaboPointF64::from_raw(point).unwrap())
+        .collect()
+}
+
+fn validate_implementations_f64(points: &[PointF64], query: &PointF64, radius: f64) {
+    let max_qty = *MAX_QTYS.last().unwrap();
+    let max_dist = radius * radius;
+    let mut expected: Vec<_> = points
+        .iter()
+        .map(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(point, query)| (point - query) * (point - query))
+                .sum::<f64>()
+        })
+        .collect();
+    expected.sort_unstable_by(f64::total_cmp);
+    expected.truncate(max_qty);
+    let expected_within = points
+        .iter()
+        .filter(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(point, query)| (point - query) * (point - query))
+                .sum::<f64>()
+                <= max_dist
+        })
+        .count();
+
+    let fnntw = FnntwTree::new(points, FNNTW_LEAF_SIZE).unwrap();
+    let (fnntw_nearest, _) = fnntw.query_nearest_k(query, max_qty).unwrap();
+    assert_distances_match_f64("FNNTW", fnntw_nearest, &expected);
+
+    let nabo_points = to_nabo_points_f64(points);
+    let nabo_query = NaboPointF64::from_raw(query).unwrap();
+    let nabo = NaboTree::new(&nabo_points);
+    let nabo_nearest = nabo
+        .knn(max_qty as u32, &nabo_query)
+        .into_iter()
+        .map(|result| result.dist2.into_inner())
+        .collect();
+    assert_distances_match_f64("nabo", nabo_nearest, &expected);
+
+    let kd_tree: ExternalKdTree<PointF64> = ExternalKdTree::build_by_ordered_float(points.to_vec());
+    let kd_tree_nearest = kd_tree
+        .nearests(query, max_qty)
+        .into_iter()
+        .map(|result| result.squared_distance)
+        .collect();
+    assert_distances_match_f64("kd-tree", kd_tree_nearest, &expected);
+    assert_eq!(
+        kd_tree.within_radius(query, radius).len(),
+        expected_within,
+        "kd-tree returned the wrong within-radius count"
+    );
+
+    let neighbourhood = NeighbourhoodTree::new(points.to_vec());
+    let neighbourhood_nearest = neighbourhood
+        .knn_by_index(query, max_qty)
+        .into_iter()
+        .map(|result| result.0 * result.0)
+        .collect();
+    assert_distances_match_f64("neighbourhood", neighbourhood_nearest, &expected);
+    assert_eq!(
+        neighbourhood.neighbourhood_by_index(query, radius).len(),
+        expected_within,
+        "neighbourhood returned the wrong within-radius count"
+    );
+}
+
+fn bench_fnntw(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let tree = FnntwTree::new(points, FNNTW_LEAF_SIZE).unwrap();
+
+    group.bench_function(id("fnntw", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut item = 0u64;
+            for query in queries {
+                let result = tree.query_nearest(black_box(query)).unwrap();
+                distance += result.0;
+                item = item.wrapping_add(result.1);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id("fnntw", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f32;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let (distances, items) =
+                            tree.query_nearest_k(black_box(query), max_qty).unwrap();
+                        len = len.wrapping_add(distances.len());
+                        distance += distances.into_iter().sum::<f32>();
+                        item = items
+                            .into_iter()
+                            .fold(item, |checksum, value| checksum.wrapping_add(value));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn to_nabo_points_f32(points: &[PointF32]) -> Vec<NaboPointF32> {
+    points
+        .iter()
+        .map(|point| NaboPointF32::from_raw(point).unwrap())
+        .collect()
+}
+
+fn bench_nabo(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let points = to_nabo_points_f32(points);
+    let queries = to_nabo_points_f32(queries);
+    let tree = NaboTree::new(&points);
+
+    group.bench_function(id("nabo", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut item = 0u64;
+            for query in &queries {
+                let result = tree.knn(1, black_box(query));
+                distance += result[0].dist2.into_inner();
+                item = item.wrapping_add(result[0].index as u64);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id("nabo", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f32;
+                    let mut item = 0u64;
+                    for query in &queries {
+                        let results = tree.knn(max_qty as u32, black_box(query));
+                        len = len.wrapping_add(results.len());
+                        for result in results {
+                            distance += result.dist2.into_inner();
+                            item = item.wrapping_add(result.index as u64);
+                        }
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn bench_kd_tree(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+    radius: f32,
+    within_radius_id: &str,
+) {
+    let tree: ExternalKdTree<PointF32> = ExternalKdTree::build_by_ordered_float(points.to_vec());
+
+    group.bench_function(id("kd_tree", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut point_sum = 0.0f32;
+            for query in queries {
+                let result = tree.nearest(black_box(query)).unwrap();
+                distance += result.squared_distance;
+                point_sum += result.item.iter().sum::<f32>();
+            }
+            black_box((distance, point_sum))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id("kd_tree", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f32;
+                    let mut point_sum = 0.0f32;
+                    for query in queries {
+                        let results = tree.nearests(black_box(query), max_qty);
+                        len = len.wrapping_add(results.len());
+                        for result in results {
+                            distance += result.squared_distance;
+                            point_sum += result.item.iter().sum::<f32>();
+                        }
+                    }
+                    black_box((len, distance, point_sum))
+                });
+            },
+        );
+    }
+
+    group.bench_function(id("kd_tree", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0usize;
+            let mut point_sum = 0.0f32;
+            for query in queries {
+                let results = tree.within_radius(black_box(query), radius);
+                len = len.wrapping_add(results.len());
+                for point in results {
+                    point_sum += point.iter().sum::<f32>();
+                }
+            }
+            black_box((len, point_sum))
+        });
+    });
+}
+
+fn bench_neighbourhood(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+    radius: f32,
+    within_radius_id: &str,
+) {
+    let tree = NeighbourhoodTree::new(points.to_vec());
+
+    group.bench_function(id("neighbourhood", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut item = 0usize;
+            for query in queries {
+                let result = tree.knn_by_index(black_box(query), 1);
+                distance += result[0].0;
+                item = item.wrapping_add(result[0].1);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id(
+                "neighbourhood",
+                &format!("nearest_n_k{max_qty}"),
+                point_count,
+            ),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f32;
+                    let mut item = 0usize;
+                    for query in queries {
+                        let results = tree.knn_by_index(black_box(query), max_qty);
+                        len = len.wrapping_add(results.len());
+                        for result in results {
+                            distance += result.0;
+                            item = item.wrapping_add(result.1);
+                        }
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+
+    group.bench_function(id("neighbourhood", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0usize;
+            let mut item = 0usize;
+            for query in queries {
+                let results = tree.neighbourhood_by_index(black_box(query), radius);
+                len = len.wrapping_add(results.len());
+                item = results
+                    .into_iter()
+                    .fold(item, |checksum, value| checksum.wrapping_add(value));
+            }
+            black_box((len, item))
+        });
+    });
+}
+
+fn bench_fnntw_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let tree = FnntwTree::new(points, FNNTW_LEAF_SIZE).unwrap();
+
+    group.bench_function(id("fnntw", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0u64;
+            for query in queries {
+                let result = tree.query_nearest(black_box(query)).unwrap();
+                distance += result.0;
+                item = item.wrapping_add(result.1);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id("fnntw", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f64;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let (distances, items) =
+                            tree.query_nearest_k(black_box(query), max_qty).unwrap();
+                        len = len.wrapping_add(distances.len());
+                        distance += distances.into_iter().sum::<f64>();
+                        item = items
+                            .into_iter()
+                            .fold(item, |checksum, value| checksum.wrapping_add(value));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn bench_nabo_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let points = to_nabo_points_f64(points);
+    let queries = to_nabo_points_f64(queries);
+    let tree = NaboTree::new(&points);
+
+    group.bench_function(id("nabo", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0u64;
+            for query in &queries {
+                let result = tree.knn(1, black_box(query));
+                distance += result[0].dist2.into_inner();
+                item = item.wrapping_add(result[0].index as u64);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id("nabo", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f64;
+                    let mut item = 0u64;
+                    for query in &queries {
+                        let results = tree.knn(max_qty as u32, black_box(query));
+                        len = len.wrapping_add(results.len());
+                        for result in results {
+                            distance += result.dist2.into_inner();
+                            item = item.wrapping_add(result.index as u64);
+                        }
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn bench_kd_tree_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+    radius: f64,
+    within_radius_id: &str,
+) {
+    let tree: ExternalKdTree<PointF64> = ExternalKdTree::build_by_ordered_float(points.to_vec());
+
+    group.bench_function(id("kd_tree", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut point_sum = 0.0f64;
+            for query in queries {
+                let result = tree.nearest(black_box(query)).unwrap();
+                distance += result.squared_distance;
+                point_sum += result.item.iter().sum::<f64>();
+            }
+            black_box((distance, point_sum))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id("kd_tree", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f64;
+                    let mut point_sum = 0.0f64;
+                    for query in queries {
+                        let results = tree.nearests(black_box(query), max_qty);
+                        len = len.wrapping_add(results.len());
+                        for result in results {
+                            distance += result.squared_distance;
+                            point_sum += result.item.iter().sum::<f64>();
+                        }
+                    }
+                    black_box((len, distance, point_sum))
+                });
+            },
+        );
+    }
+
+    group.bench_function(id("kd_tree", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0usize;
+            let mut point_sum = 0.0f64;
+            for query in queries {
+                let results = tree.within_radius(black_box(query), radius);
+                len = len.wrapping_add(results.len());
+                for point in results {
+                    point_sum += point.iter().sum::<f64>();
+                }
+            }
+            black_box((len, point_sum))
+        });
+    });
+}
+
+fn bench_neighbourhood_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+    radius: f64,
+    within_radius_id: &str,
+) {
+    let tree = NeighbourhoodTree::new(points.to_vec());
+
+    group.bench_function(id("neighbourhood", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0usize;
+            for query in queries {
+                let result = tree.knn_by_index(black_box(query), 1);
+                distance += result[0].0;
+                item = item.wrapping_add(result[0].1);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        group.bench_function(
+            id(
+                "neighbourhood",
+                &format!("nearest_n_k{max_qty}"),
+                point_count,
+            ),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0usize;
+                    let mut distance = 0.0f64;
+                    let mut item = 0usize;
+                    for query in queries {
+                        let results = tree.knn_by_index(black_box(query), max_qty);
+                        len = len.wrapping_add(results.len());
+                        for result in results {
+                            distance += result.0;
+                            item = item.wrapping_add(result.1);
+                        }
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+
+    group.bench_function(id("neighbourhood", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0usize;
+            let mut item = 0usize;
+            for query in queries {
+                let results = tree.neighbourhood_by_index(black_box(query), radius);
+                len = len.wrapping_add(results.len());
+                item = results
+                    .into_iter()
+                    .fold(item, |checksum, value| checksum.wrapping_add(value));
+            }
+            black_box((len, item))
+        });
+    });
+}
+
+fn external_kd_trees(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let min_log2_points = read_u32_env("KIDDO_PROFILE_MIN_LOG2_POINTS", DEFAULT_MIN_LOG2_POINTS);
+    let max_log2_points = read_u32_env("KIDDO_PROFILE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+    let radius_f64 = read_f64_env("KIDDO_PROFILE_RADIUS", DEFAULT_RADIUS);
+    let radius_f32 = radius_f64 as f32;
+    let within_radius_id = format!("within_radius_r{radius_f64}");
+
+    assert!(query_count > 0, "KIDDO_PROFILE_QUERIES must be positive");
+    assert!(
+        min_log2_points <= max_log2_points,
+        "KIDDO_PROFILE_MIN_LOG2_POINTS must not exceed KIDDO_PROFILE_MAX_LOG2_POINTS"
+    );
+    assert!(
+        max_log2_points <= 31,
+        "KIDDO_PROFILE_MAX_LOG2_POINTS must fit u32 item indices"
+    );
+    assert!(
+        radius_f64.is_finite() && radius_f64 > 0.0 && radius_f32.is_finite() && radius_f32 > 0.0,
+        "KIDDO_PROFILE_RADIUS must be a finite positive number"
+    );
+
+    eprintln!(
+        "benchmarking external k-d trees: dims={K} scalars=f32,f64 tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} nearest_n={MAX_QTYS:?} radius={radius_f64} point_seed={POINT_SEED} query_seed={QUERY_SEED}"
+    );
+    eprintln!(
+        "within_radius coverage: kd-tree, neighbourhood (FNNTW has no radius query; nabo has only radius-capped k-NN)"
+    );
+
+    let queries = build_queries_f32(query_count);
+    let mut group = c.benchmark_group("profile_external_kd_trees/f32");
+    group.throughput(Throughput::Elements(query_count as u64));
+
+    for log2_points in min_log2_points..=max_log2_points {
+        let point_count = 1usize << log2_points;
+        let points = build_points_f32(point_count);
+        if log2_points == min_log2_points {
+            validate_implementations_f32(&points, &queries[0], radius_f32);
+        }
+
+        bench_fnntw(&mut group, point_count, &points, &queries);
+        bench_nabo(&mut group, point_count, &points, &queries);
+        bench_kd_tree(
+            &mut group,
+            point_count,
+            &points,
+            &queries,
+            radius_f32,
+            &within_radius_id,
+        );
+        bench_neighbourhood(
+            &mut group,
+            point_count,
+            &points,
+            &queries,
+            radius_f32,
+            &within_radius_id,
+        );
+    }
+
+    group.finish();
+
+    let queries = build_queries_f64(query_count);
+    let mut group = c.benchmark_group("profile_external_kd_trees/f64");
+    group.throughput(Throughput::Elements(query_count as u64));
+
+    for log2_points in min_log2_points..=max_log2_points {
+        let point_count = 1usize << log2_points;
+        let points = build_points_f64(point_count);
+        if log2_points == min_log2_points {
+            validate_implementations_f64(&points, &queries[0], radius_f64);
+        }
+
+        bench_fnntw_f64(&mut group, point_count, &points, &queries);
+        bench_nabo_f64(&mut group, point_count, &points, &queries);
+        bench_kd_tree_f64(
+            &mut group,
+            point_count,
+            &points,
+            &queries,
+            radius_f64,
+            &within_radius_id,
+        );
+        bench_neighbourhood_f64(
+            &mut group,
+            point_count,
+            &points,
+            &queries,
+            radius_f64,
+            &within_radius_id,
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, external_kd_trees);
+criterion_main!(benches);

--- a/benches/profile_neighbourhood_published.rs
+++ b/benches/profile_neighbourhood_published.rs
@@ -1,0 +1,192 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! Reproduction of neighbourhood's published 3D within-range benchmark.
+
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::Eytzinger;
+use neighbourhood::KdTree as NeighbourhoodTree;
+use rand_09::distr::{Distribution, Uniform};
+use rand_09::rngs::SmallRng;
+use rand_09::SeedableRng;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_POINT_COUNT: usize = 100_000_000;
+const DEFAULT_QUERY_COUNT: usize = 20_000;
+const DEFAULT_RUNS: usize = 1;
+const DEFAULT_EPSILONS: [f64; 4] = [0.02, 0.05, 0.1, 0.2];
+const POINT_SEED: u64 = 0;
+const QUERY_SEED: u64 = u64::MAX;
+
+type KiddoTree = KdTree<f64, u64, Eytzinger, FlatVec<f64, u64, K, B>, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_epsilons() -> Vec<f64> {
+    std::env::var("KIDDO_NEIGHBOURHOOD_EPSILONS")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|epsilon| {
+                    epsilon.trim().parse::<f64>().unwrap_or_else(|_| {
+                        panic!(
+                            "KIDDO_NEIGHBOURHOOD_EPSILONS must be comma-separated positive numbers"
+                        )
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_else(|| DEFAULT_EPSILONS.to_vec())
+}
+
+fn make_points(num_points: usize, seed: u64) -> Vec<[f64; K]> {
+    let mut points = Vec::with_capacity(num_points);
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let distribution = Uniform::new_inclusive(-10.0, 10.0).unwrap();
+    for _ in 0..num_points {
+        let mut point = [0.0; K];
+        for coordinate in &mut point {
+            *coordinate = distribution.sample(&mut rng);
+        }
+        points.push(point);
+    }
+    points
+}
+
+fn time_queries<R>(
+    queries: &[[f64; K]],
+    runs: usize,
+    mut query: impl FnMut(&[f64; K]) -> Vec<R>,
+) -> (Duration, usize) {
+    let mut best = Duration::MAX;
+    let mut expected_matches = None;
+
+    for _ in 0..runs {
+        let started = Instant::now();
+        let mut matches = 0usize;
+        for point in queries {
+            let results = query(black_box(point));
+            matches = matches.wrapping_add(results.len());
+            black_box(results);
+        }
+        let elapsed = started.elapsed();
+        if let Some(expected) = expected_matches {
+            assert_eq!(matches, expected, "query result count changed between runs");
+        } else {
+            expected_matches = Some(matches);
+        }
+        best = best.min(elapsed);
+    }
+
+    (best, expected_matches.unwrap())
+}
+
+fn print_result(
+    library: &str,
+    point_count: usize,
+    query_count: usize,
+    epsilon: f64,
+    elapsed: Duration,
+    matches: usize,
+    build_elapsed: Duration,
+) {
+    let ns_per_query = elapsed.as_secs_f64() * 1.0e9 / query_count as f64;
+    println!(
+        "{library}\t{point_count}\t{query_count}\t{epsilon}\t{ns_per_query:.3}\t{matches}\t{:.6}",
+        build_elapsed.as_secs_f64()
+    );
+}
+
+fn main() {
+    let point_count = read_usize_env("KIDDO_NEIGHBOURHOOD_POINTS", DEFAULT_POINT_COUNT);
+    let query_count = read_usize_env("KIDDO_NEIGHBOURHOOD_QUERIES", DEFAULT_QUERY_COUNT);
+    let runs = read_usize_env("KIDDO_NEIGHBOURHOOD_RUNS", DEFAULT_RUNS);
+    let epsilons = read_epsilons();
+
+    assert!(
+        point_count > 0,
+        "KIDDO_NEIGHBOURHOOD_POINTS must be positive"
+    );
+    assert!(
+        query_count > 0,
+        "KIDDO_NEIGHBOURHOOD_QUERIES must be positive"
+    );
+    assert!(runs > 0, "KIDDO_NEIGHBOURHOOD_RUNS must be positive");
+    assert!(
+        epsilons
+            .iter()
+            .all(|epsilon| epsilon.is_finite() && *epsilon > 0.0),
+        "KIDDO_NEIGHBOURHOOD_EPSILONS must contain finite positive numbers"
+    );
+
+    eprintln!(
+        "reproducing neighbourhood 0.2.0 benchmark: dims={K} points={point_count} queries={query_count} epsilons={epsilons:?} runs={runs} cube=[-10,10] point_seed={POINT_SEED} query_seed={QUERY_SEED}"
+    );
+    println!("library\tpoints\tqueries\tepsilon\tns_per_query\ttotal_matches\tbuild_seconds");
+
+    let queries = make_points(query_count, QUERY_SEED);
+
+    let points = make_points(point_count, POINT_SEED);
+    let tree_points = points.clone();
+    let started = Instant::now();
+    let tree = NeighbourhoodTree::new(tree_points);
+    let build_elapsed = started.elapsed();
+    for &epsilon in &epsilons {
+        let (elapsed, matches) =
+            time_queries(&queries, runs, |query| tree.neighbourhood(query, epsilon));
+        print_result(
+            "neighbourhood_0.2.0",
+            point_count,
+            query_count,
+            epsilon,
+            elapsed,
+            matches,
+            build_elapsed,
+        );
+    }
+    drop(tree);
+    drop(points);
+
+    let points = make_points(point_count, POINT_SEED);
+    let tree_points = points.clone();
+    let started = Instant::now();
+    let tree: KiddoTree = KdTree::new_from_slice(&tree_points).unwrap();
+    let build_elapsed = started.elapsed();
+    for &epsilon in &epsilons {
+        let radius_squared = epsilon * epsilon;
+        let (elapsed, matches) = time_queries(&queries, runs, |query| {
+            tree.query(query)
+                .within::<SquaredEuclidean<f64>>(radius_squared)
+                .unsorted()
+                .without_distances()
+                .execute()
+        });
+        print_result(
+            "kiddo_v6_item_only",
+            point_count,
+            query_count,
+            epsilon,
+            elapsed,
+            matches,
+            build_elapsed,
+        );
+    }
+    drop(tree);
+    drop(tree_points);
+    drop(points);
+}

--- a/benches/profile_tree_sizes.rs
+++ b/benches/profile_tree_sizes.rs
@@ -1,0 +1,36 @@
+pub fn from_env(default_sizes: &[usize]) -> Vec<usize> {
+    assert!(
+        !default_sizes.is_empty(),
+        "default tree sizes must not be empty"
+    );
+
+    let default_min = default_sizes.iter().copied().min().unwrap().ilog2();
+    let default_max = default_sizes.iter().copied().max().unwrap().ilog2();
+    let min = read_log2("KIDDO_PROFILE_MIN_LOG2_POINTS").unwrap_or(default_min);
+    let max = read_log2("KIDDO_PROFILE_MAX_LOG2_POINTS").unwrap_or(default_max);
+
+    assert!(
+        min <= max,
+        "KIDDO_PROFILE_MIN_LOG2_POINTS must not exceed KIDDO_PROFILE_MAX_LOG2_POINTS"
+    );
+    assert!(
+        max <= 31,
+        "KIDDO_PROFILE_MAX_LOG2_POINTS must fit u32 item indices"
+    );
+
+    if std::env::var_os("KIDDO_PROFILE_MIN_LOG2_POINTS").is_none()
+        && std::env::var_os("KIDDO_PROFILE_MAX_LOG2_POINTS").is_none()
+    {
+        return default_sizes.to_vec();
+    }
+
+    (min..=max).map(|log2| 1usize << log2).collect()
+}
+
+fn read_log2(var: &str) -> Option<u32> {
+    std::env::var(var).ok().map(|value| {
+        value
+            .parse::<u32>()
+            .unwrap_or_else(|_| panic!("{var} must be a non-negative integer"))
+    })
+}

--- a/benches/profile_v6_approx_nearest_one_eytzinger.rs
+++ b/benches/profile_v6_approx_nearest_one_eytzinger.rs
@@ -10,6 +10,8 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
@@ -94,16 +96,17 @@ fn run_queries_f32(tree: &F32Tree, queries: &[[f32; K]]) -> (f32, u64) {
 
 fn approx_nearest_one(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 approx_nearest_one: dims={} tree_sizes=2^16..2^26 queries={} point_seed={} query_seed={}",
-        K, query_count, POINT_SEED, QUERY_SEED
+        "benchmarking v6 approx_nearest_one: dims={} tree_sizes=2^{}..2^{} queries={} point_seed={} query_seed={}",
+        K, tree_sizes[0].ilog2(), tree_sizes.last().unwrap().ilog2(), query_count, POINT_SEED, QUERY_SEED
     );
 
     let f64_queries = build_queries_f64(query_count);
     let mut f64_group = c.benchmark_group("profile_v6_approx_nearest_one_eytzinger/f64");
     f64_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes.iter().copied() {
         let points = build_points_f64(point_count);
         let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
         f64_group.bench_function(BenchmarkId::new("approx_nearest_one", point_count), |b| {
@@ -115,7 +118,7 @@ fn approx_nearest_one(c: &mut Criterion) {
     let f32_queries = build_queries_f32(query_count);
     let mut f32_group = c.benchmark_group("profile_v6_approx_nearest_one_eytzinger/f32");
     f32_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes {
         let points = build_points_f32(point_count);
         let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
         f32_group.bench_function(BenchmarkId::new("approx_nearest_one", point_count), |b| {

--- a/benches/profile_v6_dist_metrics.rs
+++ b/benches/profile_v6_dist_metrics.rs
@@ -11,6 +11,8 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
@@ -55,17 +57,18 @@ where
 
 fn dist_metrics(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 distance metrics: dims={} tree_sizes=2^16,2^18,...,2^26 queries={} point_seed={} query_seed={}",
-        K, query_count, POINT_SEED, QUERY_SEED
+        "benchmarking v6 distance metrics: dims={} tree_sizes=2^{}..2^{} queries={} point_seed={} query_seed={}",
+        K, tree_sizes[0].ilog2(), tree_sizes.last().unwrap().ilog2(), query_count, POINT_SEED, QUERY_SEED
     );
 
     let queries = build_queries(query_count);
     let mut group = c.benchmark_group("profile_v6_dist_metrics/f64");
     group.throughput(Throughput::Elements(query_count as u64));
 
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes {
         let points = build_points(point_count);
         let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
 

--- a/benches/profile_v6_leaf_strategies_criterion.rs
+++ b/benches/profile_v6_leaf_strategies_criterion.rs
@@ -10,10 +10,11 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
-const DEFAULT_MAX_LOG2_POINTS: usize = 26;
 const POINT_SEED: u64 = 0x5eed_0000_0000_0201;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0202;
 const TREE_SIZES: [usize; 6] = [1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 25];
@@ -89,21 +90,18 @@ fn run_queries_vec_of_arrays(tree: &VecOfArraysTree, queries: &[[f64; K]]) -> (f
 
 fn leaf_strategies(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
-    let max_log2_points = read_usize_env("KIDDO_PROFILE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 leaf strategies: dims={} tree_sizes=2^16,2^18,... max_log2_points={} queries={} point_seed={} query_seed={}",
-        K, max_log2_points, query_count, POINT_SEED, QUERY_SEED
+        "benchmarking v6 leaf strategies: dims={} tree_sizes=2^{}..2^{} queries={} point_seed={} query_seed={}",
+        K, tree_sizes[0].ilog2(), tree_sizes.last().unwrap().ilog2(), query_count, POINT_SEED, QUERY_SEED
     );
 
     let queries = build_queries(query_count);
     let mut group = c.benchmark_group("profile_v6_leaf_strategies/f64");
     group.throughput(Throughput::Elements(query_count as u64));
 
-    for point_count in TREE_SIZES
-        .into_iter()
-        .filter(|point_count| point_count.ilog2() as usize <= max_log2_points)
-    {
+    for point_count in tree_sizes {
         let points = build_points(point_count);
 
         let flat_tree: FlatTree = KdTree::new_from_slice(&points).unwrap();

--- a/benches/profile_v6_nearest_n_eytzinger.rs
+++ b/benches/profile_v6_nearest_n_eytzinger.rs
@@ -11,6 +11,8 @@ use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 use std::num::NonZeroUsize;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
@@ -110,16 +112,17 @@ fn run_queries_f32(
 
 fn nearest_n(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 nearest_n: dims={} tree_sizes=2^16..2^26 queries={} ks={:?} point_seed={} query_seed={}",
-        K, query_count, MAX_QTYS, POINT_SEED, QUERY_SEED
+        "benchmarking v6 nearest_n: dims={} tree_sizes=2^{}..2^{} queries={} ks={:?} point_seed={} query_seed={}",
+        K, tree_sizes[0].ilog2(), tree_sizes.last().unwrap().ilog2(), query_count, MAX_QTYS, POINT_SEED, QUERY_SEED
     );
 
     let f64_queries = build_queries_f64(query_count);
     let mut f64_group = c.benchmark_group("profile_v6_nearest_n_eytzinger/f64");
     f64_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes.iter().copied() {
         let points = build_points_f64(point_count);
         let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
         for max_qty in MAX_QTYS {
@@ -135,7 +138,7 @@ fn nearest_n(c: &mut Criterion) {
     let f32_queries = build_queries_f32(query_count);
     let mut f32_group = c.benchmark_group("profile_v6_nearest_n_eytzinger/f32");
     f32_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes {
         let points = build_points_f32(point_count);
         let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
         for max_qty in MAX_QTYS {

--- a/benches/profile_v6_nearest_one_eytzinger.rs
+++ b/benches/profile_v6_nearest_one_eytzinger.rs
@@ -10,6 +10,8 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
@@ -92,16 +94,17 @@ fn run_queries_f32(tree: &F32Tree, queries: &[[f32; K]]) -> (f32, u64) {
 
 fn nearest_one(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 nearest_one: dims={} tree_sizes=2^16..2^26 queries={} point_seed={} query_seed={}",
-        K, query_count, POINT_SEED, QUERY_SEED
+        "benchmarking v6 nearest_one: dims={} tree_sizes=2^{}..2^{} queries={} point_seed={} query_seed={}",
+        K, tree_sizes[0].ilog2(), tree_sizes.last().unwrap().ilog2(), query_count, POINT_SEED, QUERY_SEED
     );
 
     let f64_queries = build_queries_f64(query_count);
     let mut f64_group = c.benchmark_group("profile_v6_nearest_one_eytzinger/f64");
     f64_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes.iter().copied() {
         let points = build_points_f64(point_count);
         let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
         f64_group.bench_function(BenchmarkId::new("nearest_one", point_count), |b| {
@@ -113,7 +116,7 @@ fn nearest_one(c: &mut Criterion) {
     let f32_queries = build_queries_f32(query_count);
     let mut f32_group = c.benchmark_group("profile_v6_nearest_one_eytzinger/f32");
     f32_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes {
         let points = build_points_f32(point_count);
         let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
         f32_group.bench_function(BenchmarkId::new("nearest_one", point_count), |b| {

--- a/benches/profile_v6_query_family_eytzinger.rs
+++ b/benches/profile_v6_query_family_eytzinger.rs
@@ -11,6 +11,8 @@ use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 use std::num::NonZeroUsize;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
@@ -295,16 +297,17 @@ fn run_best_n_within_f32(
 
 fn query_family(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 query family: dims={} tree_sizes=2^16..2^26 queries={} max_dist={} ks={:?} point_seed={} query_seed={}",
-        K, query_count, MAX_DIST, MAX_QTYS, POINT_SEED, QUERY_SEED
+        "benchmarking v6 query family: dims={} tree_sizes=2^{}..2^{} queries={} max_dist={} ks={:?} point_seed={} query_seed={}",
+        K, tree_sizes[0].ilog2(), tree_sizes.last().unwrap().ilog2(), query_count, MAX_DIST, MAX_QTYS, POINT_SEED, QUERY_SEED
     );
 
     let f64_queries = build_queries_f64(query_count);
     let mut f64_group = c.benchmark_group("profile_v6_query_family_eytzinger/f64");
     f64_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes.iter().copied() {
         let points = build_points_f64(point_count);
         let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
         f64_group.bench_function(BenchmarkId::new("within", point_count), |b| {
@@ -345,7 +348,7 @@ fn query_family(c: &mut Criterion) {
     let f32_queries = build_queries_f32(query_count);
     let mut f32_group = c.benchmark_group("profile_v6_query_family_eytzinger/f32");
     f32_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes {
         let points = build_points_f32(point_count);
         let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
         f32_group.bench_function(BenchmarkId::new("within", point_count), |b| {

--- a/benches/profile_v6_stem_strategies.rs
+++ b/benches/profile_v6_stem_strategies.rs
@@ -16,6 +16,8 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 
+mod profile_tree_sizes;
+
 const K: usize = 3;
 const B: usize = 32;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
@@ -340,16 +342,23 @@ fn bench_simd_f32(
 fn stem_strategies(c: &mut Criterion) {
     let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
     let mode = read_mode_env();
+    let tree_sizes = profile_tree_sizes::from_env(&TREE_SIZES);
 
     eprintln!(
-        "benchmarking v6 stem strategies: dims={} tree_sizes=2^16..2^25 queries={} mode={:?} point_seed={} query_seed={}",
-        K, query_count, mode, POINT_SEED, QUERY_SEED
+        "benchmarking v6 stem strategies: dims={} tree_sizes=2^{}..2^{} queries={} mode={:?} point_seed={} query_seed={}",
+        K,
+        tree_sizes[0].ilog2(),
+        tree_sizes.last().unwrap().ilog2(),
+        query_count,
+        mode,
+        POINT_SEED,
+        QUERY_SEED
     );
 
     let f64_queries = build_queries_f64(query_count);
     let mut f64_group = c.benchmark_group("profile_v6_stem_strategies/f64");
     f64_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes.iter().copied() {
         let points = build_points_f64(point_count);
         match mode {
             StemBenchMode::Scalar => {
@@ -365,7 +374,7 @@ fn stem_strategies(c: &mut Criterion) {
     let f32_queries = build_queries_f32(query_count);
     let mut f32_group = c.benchmark_group("profile_v6_stem_strategies/f32");
     f32_group.throughput(Throughput::Elements(query_count as u64));
-    for point_count in TREE_SIZES {
+    for point_count in tree_sizes {
         let points = build_points_f32(point_count);
         match mode {
             StemBenchMode::Scalar => {

--- a/benches/profile_v6_within_radius_projection.rs
+++ b/benches/profile_v6_within_radius_projection.rs
@@ -1,0 +1,418 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! Focused rerun of the 3D within-radius cases in the external comparison chart.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::Eytzinger;
+use neighbourhood::KdTree as NeighbourhoodTree;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const K: usize = 3;
+const B: usize = 32;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const DEFAULT_MIN_LOG2_POINTS: u32 = 16;
+const DEFAULT_MAX_LOG2_POINTS: u32 = 27;
+const DEFAULT_RADIUS: f64 = 0.05;
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+
+type F64Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, K, B>, K, B>;
+type F32Tree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, K, B>, K, B>;
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_u32_env(var: &str, default: u32) -> u32 {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .unwrap_or_else(|_| panic!("{var} must be a non-negative integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_f64_env(var: &str, default: f64) -> f64 {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("{var} must be a finite positive number"))
+        })
+        .unwrap_or(default)
+}
+
+fn build_points_f64(point_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<[f64; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn build_points_f32(point_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn run_kiddo_item_distance_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    radius_squared: f64,
+) -> (usize, u64, f64) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    let mut distance = 0.0f64;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(radius_squared)
+            .unsorted()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+            distance += result.distance;
+        }
+    }
+    (len, item, distance)
+}
+
+fn run_kiddo_item_only_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    radius_squared: f64,
+) -> (usize, u64) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(radius_squared)
+            .unsorted()
+            .without_distances()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+        }
+    }
+    (len, item)
+}
+
+fn run_kiddo_point_item_distance_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    radius_squared: f64,
+) -> (usize, u64, f64, f64) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    let mut distance = 0.0f64;
+    let mut point = 0.0f64;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(radius_squared)
+            .unsorted()
+            .with_points()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+            distance += result.distance;
+            point += result.point.into_iter().sum::<f64>();
+        }
+    }
+    (len, item, distance, point)
+}
+
+fn run_kiddo_point_item_f64(
+    tree: &F64Tree,
+    queries: &[[f64; K]],
+    radius_squared: f64,
+) -> (usize, u64, f64) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    let mut point = 0.0f64;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f64>>(radius_squared)
+            .unsorted()
+            .with_points()
+            .without_distances()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+            point += result.point.into_iter().sum::<f64>();
+        }
+    }
+    (len, item, point)
+}
+
+fn run_neighbourhood_f64(
+    tree: &NeighbourhoodTree<f64, K>,
+    queries: &[[f64; K]],
+    radius: f64,
+) -> (usize, usize) {
+    let mut len = 0usize;
+    let mut item = 0usize;
+    for query in queries {
+        let results = tree.neighbourhood_by_index(black_box(query), radius);
+        len = len.wrapping_add(results.len());
+        item = results
+            .into_iter()
+            .fold(item, |checksum, value| checksum.wrapping_add(value));
+    }
+    (len, item)
+}
+
+fn run_kiddo_item_distance_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    radius_squared: f32,
+) -> (usize, u64, f32) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    let mut distance = 0.0f32;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f32>>(radius_squared)
+            .unsorted()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+            distance += result.distance;
+        }
+    }
+    (len, item, distance)
+}
+
+fn run_kiddo_item_only_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    radius_squared: f32,
+) -> (usize, u64) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f32>>(radius_squared)
+            .unsorted()
+            .without_distances()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+        }
+    }
+    (len, item)
+}
+
+fn run_kiddo_point_item_distance_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    radius_squared: f32,
+) -> (usize, u64, f32, f32) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    let mut distance = 0.0f32;
+    let mut point = 0.0f32;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f32>>(radius_squared)
+            .unsorted()
+            .with_points()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+            distance += result.distance;
+            point += result.point.into_iter().sum::<f32>();
+        }
+    }
+    (len, item, distance, point)
+}
+
+fn run_kiddo_point_item_f32(
+    tree: &F32Tree,
+    queries: &[[f32; K]],
+    radius_squared: f32,
+) -> (usize, u64, f32) {
+    let mut len = 0usize;
+    let mut item = 0u64;
+    let mut point = 0.0f32;
+    for query in queries {
+        let results = tree
+            .query(black_box(query))
+            .within::<SquaredEuclidean<f32>>(radius_squared)
+            .unsorted()
+            .with_points()
+            .without_distances()
+            .execute();
+        len = len.wrapping_add(results.len());
+        for result in results {
+            item = item.wrapping_add(result.item as u64);
+            point += result.point.into_iter().sum::<f32>();
+        }
+    }
+    (len, item, point)
+}
+
+fn run_neighbourhood_f32(
+    tree: &NeighbourhoodTree<f32, K>,
+    queries: &[[f32; K]],
+    radius: f32,
+) -> (usize, usize) {
+    let mut len = 0usize;
+    let mut item = 0usize;
+    for query in queries {
+        let results = tree.neighbourhood_by_index(black_box(query), radius);
+        len = len.wrapping_add(results.len());
+        item = results
+            .into_iter()
+            .fold(item, |checksum, value| checksum.wrapping_add(value));
+    }
+    (len, item)
+}
+
+fn within_radius_projection(c: &mut Criterion) {
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let min_log2 = read_u32_env("KIDDO_PROFILE_MIN_LOG2_POINTS", DEFAULT_MIN_LOG2_POINTS);
+    let max_log2 = read_u32_env("KIDDO_PROFILE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+    let radius_f64 = read_f64_env("KIDDO_PROFILE_RADIUS", DEFAULT_RADIUS);
+    let radius_f32 = radius_f64 as f32;
+
+    assert!(query_count > 0, "KIDDO_PROFILE_QUERIES must be positive");
+    assert!(
+        min_log2 <= max_log2,
+        "KIDDO_PROFILE_MIN_LOG2_POINTS must not exceed KIDDO_PROFILE_MAX_LOG2_POINTS"
+    );
+    assert!(
+        max_log2 <= 31,
+        "KIDDO_PROFILE_MAX_LOG2_POINTS must fit u32 item indices"
+    );
+    assert!(
+        radius_f64.is_finite() && radius_f64 > 0.0 && radius_f32.is_finite() && radius_f32 > 0.0,
+        "KIDDO_PROFILE_RADIUS must be a finite positive number"
+    );
+
+    eprintln!(
+        "benchmarking focused 3D within-radius projections: scalars=f32,f64 tree_sizes=2^{min_log2}..2^{max_log2} queries={query_count} radius={radius_f64} point_seed={POINT_SEED} query_seed={QUERY_SEED}"
+    );
+
+    let queries = build_queries_f32(query_count);
+    let mut group = c.benchmark_group("profile_v6_within_radius_projection/f32");
+    group.throughput(Throughput::Elements(query_count as u64));
+    for log2_points in min_log2..=max_log2 {
+        let point_count = 1usize << log2_points;
+        let points = build_points_f32(point_count);
+        let tree: F32Tree = KdTree::new_from_slice(&points).unwrap();
+        let radius_squared = radius_f32 * radius_f32;
+
+        group.bench_function(BenchmarkId::new("kiddo_item_distance", point_count), |b| {
+            b.iter(|| black_box(run_kiddo_item_distance_f32(&tree, &queries, radius_squared)));
+        });
+        group.bench_function(BenchmarkId::new("kiddo_item_only", point_count), |b| {
+            b.iter(|| black_box(run_kiddo_item_only_f32(&tree, &queries, radius_squared)));
+        });
+        group.bench_function(
+            BenchmarkId::new("kiddo_point_item_distance", point_count),
+            |b| {
+                b.iter(|| {
+                    black_box(run_kiddo_point_item_distance_f32(
+                        &tree,
+                        &queries,
+                        radius_squared,
+                    ))
+                });
+            },
+        );
+        group.bench_function(BenchmarkId::new("kiddo_point_item", point_count), |b| {
+            b.iter(|| black_box(run_kiddo_point_item_f32(&tree, &queries, radius_squared)));
+        });
+        drop(tree);
+
+        let tree = NeighbourhoodTree::new(points);
+        group.bench_function(
+            BenchmarkId::new("neighbourhood_item_only", point_count),
+            |b| {
+                b.iter(|| black_box(run_neighbourhood_f32(&tree, &queries, radius_f32)));
+            },
+        );
+    }
+    group.finish();
+
+    let queries = build_queries_f64(query_count);
+    let mut group = c.benchmark_group("profile_v6_within_radius_projection/f64");
+    group.throughput(Throughput::Elements(query_count as u64));
+    for log2_points in min_log2..=max_log2 {
+        let point_count = 1usize << log2_points;
+        let points = build_points_f64(point_count);
+        let tree: F64Tree = KdTree::new_from_slice(&points).unwrap();
+        let radius_squared = radius_f64 * radius_f64;
+
+        group.bench_function(BenchmarkId::new("kiddo_item_distance", point_count), |b| {
+            b.iter(|| black_box(run_kiddo_item_distance_f64(&tree, &queries, radius_squared)));
+        });
+        group.bench_function(BenchmarkId::new("kiddo_item_only", point_count), |b| {
+            b.iter(|| black_box(run_kiddo_item_only_f64(&tree, &queries, radius_squared)));
+        });
+        group.bench_function(
+            BenchmarkId::new("kiddo_point_item_distance", point_count),
+            |b| {
+                b.iter(|| {
+                    black_box(run_kiddo_point_item_distance_f64(
+                        &tree,
+                        &queries,
+                        radius_squared,
+                    ))
+                });
+            },
+        );
+        group.bench_function(BenchmarkId::new("kiddo_point_item", point_count), |b| {
+            b.iter(|| black_box(run_kiddo_point_item_f64(&tree, &queries, radius_squared)));
+        });
+        drop(tree);
+
+        let tree = NeighbourhoodTree::new(points);
+        group.bench_function(
+            BenchmarkId::new("neighbourhood_item_only", point_count),
+            |b| {
+                b.iter(|| black_box(run_neighbourhood_f64(&tree, &queries, radius_f64)));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, within_radius_projection);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ default:
   just --list
 
 benchmark_result_key := `date -u +%Y%m%dT%H%M%SZ`
+profile_min_log2_points := env_var_or_default("KIDDO_PROFILE_MIN_LOG2_POINTS", "16")
+profile_max_log2_points := env_var_or_default("KIDDO_PROFILE_MAX_LOG2_POINTS", "25")
+profile_queries := env_var_or_default("KIDDO_PROFILE_QUERIES", "1000")
 
 fmt:
     cargo fmt --all
@@ -125,7 +128,7 @@ benchmark-derive-key REF_NAME PYTHON='python3':
 benchmark-derive-path-key REF_NAME PYTHON='python3':
     {{quote(PYTHON)}} scripts/benchmark_site.py derive-path-key --ref-name {{quote(REF_NAME)}}
 
-bench-v6-eytzinger-focus RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES='1000':
+bench-v6-eytzinger-focus RESULT_KEY OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES=profile_queries:
     #!/usr/bin/env bash
     set -euo pipefail
     result_key={{quote(RESULT_KEY)}}
@@ -166,7 +169,7 @@ bench-v6-eytzinger-focus RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
         "$output_dir/bench_result-v6-approx_nearest_one-eytzinger-${result_key}.json" \
         profile_v6_approx_nearest_one_eytzinger
 
-bench-v6-query-family RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES='1000':
+bench-v6-query-family RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES=profile_queries:
     #!/usr/bin/env bash
     set -euo pipefail
     result_key={{quote(RESULT_KEY)}}
@@ -187,7 +190,7 @@ bench-v6-query-family RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='s
         "$output_dir/bench_result-v6-query-family-eytzinger-${result_key}.json" \
         profile_v6_query_family_eytzinger
 
-bench-v6-dist-metrics RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='1000' SCALAR_FEATURES='test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
+bench-v6-dist-metrics RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES=profile_queries SCALAR_FEATURES='test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
     #!/usr/bin/env bash
     set -euo pipefail
     result_key={{quote(RESULT_KEY)}}
@@ -228,7 +231,7 @@ bench-v6-dist-metrics RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='10
     run_mode avx2 "-C target-cpu=x86-64-v2 -C target-feature=+avx2" "$simd_features"
     run_mode avx512 "-C target-cpu=native" "$simd_features"
 
-bench-v6-leaf-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES='1000':
+bench-v6-leaf-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES=profile_queries:
     #!/usr/bin/env bash
     set -euo pipefail
     result_key={{quote(RESULT_KEY)}}
@@ -249,7 +252,7 @@ bench-v6-leaf-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES
         "$output_dir/bench_result-v6-leaf-strategies-${result_key}.json" \
         profile_v6_leaf_strategies
 
-bench-v6-stem-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES='1000' SCALAR_FEATURES='simd,test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
+bench-v6-stem-strategies RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES=profile_queries SCALAR_FEATURES='simd,test_utils,logging_off' SIMD_FEATURES='simd,test_utils,logging_off':
     #!/usr/bin/env bash
     set -euo pipefail
     result_key={{quote(RESULT_KEY)}}
@@ -329,8 +332,157 @@ bench-v6-construction RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='s
         "$output_dir/bench_result-v6-construction-avx512-${result_key}.json" \
         profile_v6_construction
 
+bench-v6-all RESULT_KEY=benchmark_result_key OUTPUT_DIR='.':
+    just bench-v6-eytzinger-focus {{quote(RESULT_KEY)}} {{quote(OUTPUT_DIR)}}
+    just bench-v6-query-family {{quote(RESULT_KEY)}} {{quote(OUTPUT_DIR)}}
+    just bench-v6-dist-metrics {{quote(RESULT_KEY)}} {{quote(OUTPUT_DIR)}}
+    just bench-v6-leaf-strategies {{quote(RESULT_KEY)}} {{quote(OUTPUT_DIR)}}
+    just bench-v6-stem-strategies {{quote(RESULT_KEY)}} {{quote(OUTPUT_DIR)}}
+
+bench-external-kd-trees RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='simd,test_utils,logging_off' QUERIES=profile_queries MIN_LOG2_POINTS=profile_min_log2_points MAX_LOG2_POINTS=profile_max_log2_points RADIUS='0.05':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        KIDDO_PROFILE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_PROFILE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        KIDDO_PROFILE_RADIUS={{quote(RADIUS)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_external_kd_trees \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-external-kd-trees-${result_key}.json" \
+        profile_external_kd_trees
+
+bench-v6-within-radius-projection RESULT_KEY=benchmark_result_key OUTPUT_DIR='./focused-results' FEATURES='simd,test_utils,logging_off' QUERIES='1000' MIN_LOG2_POINTS='16' MAX_LOG2_POINTS='27' RADIUS='0.05':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        KIDDO_PROFILE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_PROFILE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        KIDDO_PROFILE_RADIUS={{quote(RADIUS)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_v6_within_radius_projection \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-v6-within-radius-projection-${result_key}.json" \
+        profile_v6_within_radius_projection
+
+bench-neighbourhood-published RESULT_KEY=benchmark_result_key OUTPUT_DIR='./focused-results' FEATURES='simd,test_utils,logging_off' POINTS='100000000' QUERIES='20000' RUNS='1' EPSILONS='0.02,0.05,0.1,0.2':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_NEIGHBOURHOOD_POINTS={{quote(POINTS)}} \
+        KIDDO_NEIGHBOURHOOD_QUERIES={{quote(QUERIES)}} \
+        KIDDO_NEIGHBOURHOOD_RUNS={{quote(RUNS)}} \
+        KIDDO_NEIGHBOURHOOD_EPSILONS={{quote(EPSILONS)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo bench \
+            --bench profile_neighbourhood_published \
+            --features {{quote(FEATURES)}} \
+        | tee "$output_dir/bench_result-neighbourhood-published-${result_key}.tsv"
+
+chart-v6-within-radius-projection RESULT_KEY RESULTS_DIR='./focused-results' OUTPUT_DIR='./focused-charts' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_within_radius_projection_results.py charts \
+        --result {{quote(RESULTS_DIR)}}/bench_result-v6-within-radius-projection-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}}
+
+html-v6-within-radius-projection RESULT_KEY RESULTS_DIR='./focused-results' OUTPUT_DIR='./focused-charts' HTML_NAME='within-radius-projection-benchmarks.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_within_radius_projection_results.py all \
+        --result {{quote(RESULTS_DIR)}}/bench_result-v6-within-radius-projection-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}}
+
+view-v6-within-radius-projection RESULT_KEY RESULTS_DIR='./focused-results' OUTPUT_DIR='./focused-charts' HTML_NAME='within-radius-projection-benchmarks.html' PYTHON='python3':
+    just html-v6-within-radius-projection {{quote(RESULT_KEY)}} {{quote(RESULTS_DIR)}} {{quote(OUTPUT_DIR)}} {{quote(HTML_NAME)}} {{quote(PYTHON)}}
+    xdg-open {{quote(OUTPUT_DIR)}}/{{quote(HTML_NAME)}}
+
+html-v6-within-radius-item-only RESULT_KEY RESULTS_DIR='./focused-results' OUTPUT_DIR='./focused-charts' HTML_NAME='within-radius-item-only-comparison.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_within_radius_projection_results.py all \
+        --result {{quote(RESULTS_DIR)}}/bench_result-v6-within-radius-projection-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}} \
+        --item-only
+
+view-v6-within-radius-item-only RESULT_KEY RESULTS_DIR='./focused-results' OUTPUT_DIR='./focused-charts' HTML_NAME='within-radius-item-only-comparison.html' PYTHON='python3':
+    just html-v6-within-radius-item-only {{quote(RESULT_KEY)}} {{quote(RESULTS_DIR)}} {{quote(OUTPUT_DIR)}} {{quote(HTML_NAME)}} {{quote(PYTHON)}}
+    xdg-open {{quote(OUTPUT_DIR)}}/{{quote(HTML_NAME)}}
+
+chart-external-kd-tree-results EXTERNAL_RESULT_KEY KIDDO_RESULT_KEY=EXTERNAL_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_external_kd_tree_results.py charts \
+        --external {{quote(RESULTS_DIR)}}/bench_result-external-kd-trees-{{quote(EXTERNAL_RESULT_KEY)}}.json \
+        --kiddo-nearest-one {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_one-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-nearest-n {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_n-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-query-family {{quote(RESULTS_DIR)}}/bench_result-v6-query-family-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --result-label {{quote(EXTERNAL_RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}}
+
+html-external-kd-tree-results EXTERNAL_RESULT_KEY KIDDO_RESULT_KEY=EXTERNAL_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' HTML_NAME='external-kd-tree-benchmarks.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_external_kd_tree_results.py all \
+        --external {{quote(RESULTS_DIR)}}/bench_result-external-kd-trees-{{quote(EXTERNAL_RESULT_KEY)}}.json \
+        --kiddo-nearest-one {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_one-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-nearest-n {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_n-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-query-family {{quote(RESULTS_DIR)}}/bench_result-v6-query-family-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --result-label {{quote(EXTERNAL_RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}}
+
+chart-v5-v6-results V6_RESULT_KEY V5_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_v5_v6_results.py charts \
+        --v6-key {{quote(V6_RESULT_KEY)}} \
+        --v5-key {{quote(V5_RESULT_KEY)}} \
+        --results-dir {{quote(RESULTS_DIR)}} \
+        --output-dir {{quote(OUTPUT_DIR)}}
+
+html-v5-v6-results V6_RESULT_KEY V5_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' HTML_NAME='v5-v6-benchmarks.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_v5_v6_results.py all \
+        --v6-key {{quote(V6_RESULT_KEY)}} \
+        --v5-key {{quote(V5_RESULT_KEY)}} \
+        --results-dir {{quote(RESULTS_DIR)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}}
+
+view-v5-v6-results V6_RESULT_KEY V5_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' HTML_NAME='v5-v6-benchmarks.html' PYTHON='python3':
+    just html-v5-v6-results {{quote(V6_RESULT_KEY)}} {{quote(V5_RESULT_KEY)}} {{quote(RESULTS_DIR)}} {{quote(OUTPUT_DIR)}} {{quote(HTML_NAME)}} {{quote(PYTHON)}}
+    xdg-open {{quote(OUTPUT_DIR)}}/{{quote(HTML_NAME)}}
+
 chart-benchmark-results VARIANT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
     {{quote(PYTHON)}} scripts/chart_benchmark_results.py {{quote(VARIANT_KEY)}} --results-dir {{quote(RESULTS_DIR)}} --output-dir {{quote(OUTPUT_DIR)}}
+
+chart-default-results VARIANT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_benchmark_results.py {{quote(VARIANT_KEY)}} --baseline-key v6-baseline --v5-baseline-key v5-baseline --results-dir {{quote(RESULTS_DIR)}} --output-dir {{quote(OUTPUT_DIR)}}
+
+chart-v6-nearest-one-scratch-results RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_benchmark_results.py {{quote(RESULT_KEY)}} --scratch --html-name latest_v6_nearest_one_scratch.html --results-dir {{quote(RESULTS_DIR)}} --output-dir {{quote(OUTPUT_DIR)}}
 
 benchmark-site-build REF_NAME SHA RESULTS_DIR PAGES_ROOT SITE_URL_BASE='' PYTHON='python3':
     #!/usr/bin/env bash
@@ -382,29 +534,6 @@ benchmark-pr-comment-apply REF_NAME SHA PR_NUMBER REPO SITE_URL_BASE PAGES_ROOT 
     branch_path_key=$({{quote(PYTHON)}} scripts/benchmark_site.py derive-path-key --ref-name {{quote(REF_NAME)}})
     summary_file={{quote(PAGES_ROOT)}}/branches/"$branch_path_key"/latest/run.json
     {{quote(PYTHON)}} scripts/benchmark_site.py update-pr-comment --repo {{quote(REPO)}} --pr-number {{quote(PR_NUMBER)}} --summary-path "$summary_file" --site-url-base {{quote(SITE_URL_BASE)}}
-
-bench-v6-stem-strategies-focus FEATURES='simd,test_utils,logging_off' POINTS='4194304' QUERIES='10000':
-    RUSTC_WRAPPER= \
-    KIDDO_BENCH_POINTS={{POINTS}} \
-    KIDDO_BENCH_QUERIES={{QUERIES}} \
-    RUSTFLAGS='-C target-cpu=native' \
-    cargo criterion --bench v6_stem_strategies_focus --features {{FEATURES}}
-
-bench-v6-stem-strategies-big FEATURES='simd,test_utils,logging_off' POINTS='16777216' QUERIES='10000':
-    RUSTC_WRAPPER= \
-    KIDDO_BENCH_POINTS={{POINTS}} \
-    KIDDO_BENCH_QUERIES={{QUERIES}} \
-    RUSTFLAGS='-C target-cpu=native' \
-    cargo criterion --bench v6_stem_strategies_focus --features {{FEATURES}}
-
-bench-v6-result-collection-focus FEATURES='simd,test_utils,logging_off' POINTS='16777216' QUERIES='100' MAX_QTY='16' MAX_DIST='0.0025':
-    RUSTC_WRAPPER= \
-    KIDDO_BENCH_POINTS={{POINTS}} \
-    KIDDO_BENCH_QUERIES={{QUERIES}} \
-    KIDDO_BENCH_MAX_QTY={{MAX_QTY}} \
-    KIDDO_BENCH_MAX_DIST={{MAX_DIST}} \
-    RUSTFLAGS='-C target-cpu=native' \
-    cargo criterion --bench v6_result_collection_focus --features {{FEATURES}}
 
 asm-v6-sorted-nearest-n-within-donnelly-pf-focus-clean FEATURES='simd,cargo_asm,logging_off' SUFFIX='baseline':
     RUSTC_WRAPPER= cargo asm --simplify --features {{FEATURES}} --lib --target-cpu=native -C="opt-level=2" -C="target-cpu=native" "v6_sorted_nearest_n_within_donnelly_pf_focus_cargo_asm_hook" | python3 scripts/clean_cargo_asm.py > v6_sorted_nearest_n_within_donnelly_pf_focus_{{SUFFIX}}_clean.asm

--- a/scripts/chart_benchmark_results.py
+++ b/scripts/chart_benchmark_results.py
@@ -10,13 +10,14 @@ import html
 import json
 import math
 import re
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 
 RESULT_PREFIX = "bench_result-"
-BASELINE_SUFFIX = "-baseline.json"
+DEFAULT_BASELINE_KEY = "baseline"
 SAFE_KEY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
 NS_PER_US = 1_000.0
 DIST_METRIC_SUITE_PREFIX = "v6-dist-metrics-"
@@ -63,6 +64,18 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("variant_key", help="result key to compare with baseline")
     parser.add_argument(
+        "--baseline-key",
+        default=DEFAULT_BASELINE_KEY,
+        help="result key for the v6 baseline (default: baseline)",
+    )
+    parser.add_argument(
+        "--v5-baseline-key",
+        help=(
+            "optional result key for v5 nearest_one/nearest_n results to overlay "
+            "on matching v6 charts"
+        ),
+    )
+    parser.add_argument(
         "--results-dir",
         type=Path,
         default=Path.cwd(),
@@ -74,6 +87,8 @@ def parse_args() -> argparse.Namespace:
         default=Path.cwd(),
         help="directory for charts and HTML (default: current directory)",
     )
+    parser.add_argument("--scratch", action="store_true", help="chart scratch strategies as one comparison")
+    parser.add_argument("--html-name", default="latest_benchmark_run.html")
     return parser.parse_args()
 
 
@@ -156,6 +171,30 @@ def result_series(path: Path) -> dict[SeriesKey, list[Point]]:
     return series
 
 
+def cross_version_series(
+    series: dict[SeriesKey, list[Point]], path: Path
+) -> dict[tuple[str, str], list[Point]]:
+    """Key series by scalar type and function, ignoring the versioned group prefix."""
+    compatible: dict[tuple[str, str], list[Point]] = {}
+    for key, points in series.items():
+        scalar_type = key.group_id.rsplit("/", 1)[-1]
+        comparable_key = (scalar_type, key.function_id)
+        if comparable_key in compatible:
+            raise RuntimeError(
+                f"duplicate cross-version series {comparable_key!r} in {path}"
+            )
+        compatible[comparable_key] = points
+    return compatible
+
+
+def query_kind(suite: str) -> str | None:
+    if "nearest_one" in suite:
+        return "nearest_one"
+    if "nearest_n" in suite:
+        return "nearest_n"
+    return None
+
+
 def subbenchmark_name(key: SeriesKey) -> str:
     group_parts = key.group_id.split("/")
     parts = group_parts[1:] + [key.function_id]
@@ -185,6 +224,9 @@ def render_chart(
     baseline: list[Point],
     variant: list[Point],
     variant_key: str,
+    baseline_key: str,
+    v5_baseline: list[Point] | None,
+    v5_baseline_key: str | None,
     output_path: Path,
 ) -> None:
     if len(baseline) != len(variant):
@@ -200,10 +242,14 @@ def render_chart(
             )
 
     figure, axis = plt.subplots(figsize=(10, 6))
-    for label, points, color in (
-        ("baseline", baseline, "#3264a8"),
+    plotted_series = [
+        (baseline_key, baseline, "#3264a8"),
         (variant_key, variant, "#d35400"),
-    ):
+    ]
+    if v5_baseline is not None and v5_baseline_key is not None:
+        plotted_series.append((v5_baseline_key, v5_baseline, "#7d3c98"))
+
+    for label, points, color in plotted_series:
         x = [point.tree_log2 for point in points]
         y = [point.duration_ns / NS_PER_US for point in points]
         lower = [point.lower_ns / NS_PER_US for point in points]
@@ -212,7 +258,7 @@ def render_chart(
         axis.fill_between(x, lower, upper, color=color, alpha=0.14)
 
     x_ticks = sorted(
-        {point.tree_log2 for point in baseline} | {point.tree_log2 for point in variant}
+        {point.tree_log2 for _, points, _ in plotted_series for point in points}
     )
     axis.set_xticks(x_ticks)
     axis.set_xticklabels([f"{value:g}" for value in x_ticks])
@@ -267,6 +313,23 @@ def render_chart(
             },
         )
 
+    if v5_baseline is not None:
+        if len(v5_baseline) != len(baseline):
+            raise RuntimeError(f"v5 baseline point count mismatch for {suite}: {key.group_id} / {key.function_id}")
+        for baseline_point, v5_point in zip(baseline, v5_baseline):
+            if baseline_point.tree_log2 != v5_point.tree_log2:
+                raise RuntimeError(f"v5 baseline tree sizes differ for {suite}: {key.group_id} / {key.function_id}")
+            # Report v6 relative to v5, matching the usual "current vs reference"
+            # interpretation of the percentage marker.
+            delta_fraction = (baseline_point.duration_ns - v5_point.duration_ns) / v5_point.duration_ns
+            axis.annotate(
+                f"{delta_fraction * 100:+.0f}%",
+                (baseline_point.tree_log2, baseline_point.duration_ns / NS_PER_US),
+                textcoords="offset points", xytext=(0, -14), ha="center", va="top",
+                color="#3264a8", fontsize=8,
+                bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.8, "pad": 0.2},
+            )
+
     figure.tight_layout()
     figure.savefig(output_path, dpi=140)
     plt.close(figure)
@@ -289,6 +352,7 @@ def render_matrix_chart(
     title: str,
     series: list[tuple[str, list[Point], list[Point]]],
     variant_key: str,
+    baseline_key: str,
     output_path: Path,
 ) -> None:
     figure, axis = plt.subplots(figsize=(11, 7))
@@ -302,7 +366,7 @@ def render_matrix_chart(
         x_ticks.update(x)
 
         for run_label, points, line_style, alpha in (
-            ("baseline", baseline, "--", 0.72),
+            (baseline_key, baseline, "--", 0.72),
             (variant_key, variant, "-", 1.0),
         ):
             y = [point.duration_ns / NS_PER_US for point in points]
@@ -338,6 +402,41 @@ def matrix_change_score(series: list[tuple[str, list[Point], list[Point]]]) -> f
     return sum(change_score(baseline, variant) for _, baseline, variant in series)
 
 
+def render_scratch_chart(plt: Any, suite: str, scalar: str,
+                         series: dict[SeriesKey, list[Point]], output_path: Path) -> None:
+    figure, axis = plt.subplots(figsize=(10, 6))
+    colors = {"default": "#3264a8", "with_scratch": "#d35400", "local_scratch": "#7d3c98"}
+    for function_id in ("default", "with_scratch", "local_scratch"):
+        points = series.get(SeriesKey(f"{suite}/{scalar}", function_id))
+        if points is None:
+            continue
+        x = [p.tree_log2 for p in points]
+        axis.plot(x, [p.duration_ns / NS_PER_US for p in points], marker="o",
+                  linewidth=2, label=function_id, color=colors[function_id])
+    baseline = series.get(SeriesKey(f"{suite}/{scalar}", "default"))
+    if baseline is not None:
+        for function_id in ("with_scratch", "local_scratch"):
+            points = series.get(SeriesKey(f"{suite}/{scalar}", function_id))
+            if points is None or len(points) != len(baseline):
+                continue
+            for base_point, point in zip(baseline, points):
+                if base_point.tree_log2 != point.tree_log2:
+                    continue
+                delta = (point.duration_ns - base_point.duration_ns) / base_point.duration_ns
+                axis.annotate(
+                    f"{delta * 100:+.0f}%",
+                    (point.tree_log2, point.duration_ns / NS_PER_US),
+                    textcoords="offset points", xytext=(0, 8 if function_id == "with_scratch" else -14),
+                    ha="center", fontsize=8,
+                    color="#1f8f3a" if delta < 0 else "#c0392b",
+                    bbox={"facecolor": "white", "edgecolor": "none", "alpha": 0.8, "pad": 0.2},
+                )
+    axis.set_xticks(sorted({p.tree_log2 for points in series.values() for p in points}))
+    axis.set_xlabel("log2(tree size)"); axis.set_ylabel("Mean duration per query (us, log scale)")
+    axis.set_yscale("log"); axis.set_title(f"{suite}: {scalar} scratch strategies"); axis.grid(True, which="both", alpha=0.25); axis.legend()
+    figure.tight_layout(); figure.savefig(output_path, dpi=140); plt.close(figure)
+
+
 def change_score(baseline: list[Point], variant: list[Point]) -> float:
     if len(baseline) != len(variant):
         raise RuntimeError("cannot score unmatched baseline/variant series")
@@ -355,6 +454,8 @@ def change_score(baseline: list[Point], variant: list[Point]) -> float:
 def write_html(
     output_path: Path,
     variant_key: str,
+    baseline_key: str,
+    v5_baseline_key: str | None,
     charts: list[tuple[str, Path]],
 ) -> None:
     sections = []
@@ -369,12 +470,15 @@ def write_html(
             "</section>"
         )
 
+    comparison = f"{baseline_key} vs {variant_key}"
+    if v5_baseline_key is not None:
+        comparison += f" with {v5_baseline_key}"
     document = f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Benchmark run: baseline vs {html.escape(variant_key)}</title>
+  <title>Benchmark run: {html.escape(comparison)}</title>
   <style>
     body {{ margin: 0 auto; max-width: 1100px; padding: 2rem; font-family: system-ui, sans-serif; background: #f6f7f9; color: #202124; }}
     section {{ margin: 2rem 0; padding: 1rem; border-radius: .5rem; background: white; box-shadow: 0 1px 5px #0002; }}
@@ -383,7 +487,7 @@ def write_html(
   </style>
 </head>
 <body>
-  <h1>Benchmark run: baseline vs {html.escape(variant_key)}</h1>
+  <h1>Benchmark run: {html.escape(comparison)}</h1>
   <p>{len(charts)} charts generated from matching result-file pairs.</p>
   {''.join(sections)}
 </body>
@@ -413,6 +517,7 @@ def dist_metric_isa(suite: str) -> str | None:
 def generate_dist_metric_matrix_charts(
     plt: Any,
     variant_key: str,
+    baseline_key: str,
     output_dir: Path,
     pairs: dict[str, tuple[Path, Path]],
     paths_seen: set[Path],
@@ -473,7 +578,14 @@ def generate_dist_metric_matrix_charts(
             paths_seen,
         )
         title = f"Distance metric {key.function_id}: ISA comparison"
-        render_matrix_chart(plt, title, series, variant_key, chart_path)
+        render_matrix_chart(
+            plt,
+            title,
+            series,
+            variant_key,
+            baseline_key,
+            chart_path,
+        )
         charts.append((title, chart_path))
         metadata.append(
             {
@@ -507,7 +619,14 @@ def generate_dist_metric_matrix_charts(
             paths_seen,
         )
         title = f"Distance metrics: {isa} comparison"
-        render_matrix_chart(plt, title, series, variant_key, chart_path)
+        render_matrix_chart(
+            plt,
+            title,
+            series,
+            variant_key,
+            baseline_key,
+            chart_path,
+        )
         charts.append((title, chart_path))
         metadata.append(
             {
@@ -527,23 +646,34 @@ def generate_charts(
     variant_key: str,
     results_dir: Path,
     output_dir: Path,
+    baseline_key: str = DEFAULT_BASELINE_KEY,
+    v5_baseline_key: str | None = None,
 ) -> list[dict[str, str | float]]:
-    if variant_key == "baseline":
+    result_keys = [variant_key, baseline_key]
+    if v5_baseline_key is not None:
+        result_keys.append(v5_baseline_key)
+    for result_key in result_keys:
+        if not SAFE_KEY.fullmatch(result_key):
+            raise RuntimeError(
+                "result keys must contain only letters, digits, '.', '_', '+', ':', or '-'"
+            )
+    if variant_key in {baseline_key, v5_baseline_key}:
         raise RuntimeError("VARIANT_KEY must identify a non-baseline result")
-    if not SAFE_KEY.fullmatch(variant_key):
-        raise RuntimeError(
-            "VARIANT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'"
-        )
 
     _, plt = import_matplotlib()
     results_dir = results_dir.resolve()
     output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    baseline_suffix = f"-{baseline_key}.json"
+    # Older v6 runs were exported with the plain `baseline` key. Treat those
+    # files as the v6 baseline when the requested v6-baseline files are absent.
+    if not list(results_dir.glob(f"{RESULT_PREFIX}*{baseline_suffix}")) and baseline_key == "v6-baseline":
+        baseline_suffix = "-baseline.json"
     pairs: list[tuple[str, Path, Path]] = []
     dist_metric_pairs: dict[str, tuple[Path, Path]] = {}
-    for baseline_path in sorted(results_dir.glob(f"{RESULT_PREFIX}*{BASELINE_SUFFIX}")):
-        suite = baseline_path.name[len(RESULT_PREFIX) : -len(BASELINE_SUFFIX)]
+    for baseline_path in sorted(results_dir.glob(f"{RESULT_PREFIX}*{baseline_suffix}")):
+        suite = baseline_path.name[len(RESULT_PREFIX) : -len(baseline_suffix)]
         variant_path = results_dir / f"{RESULT_PREFIX}{suite}-{variant_key}.json"
         if variant_path.is_file():
             isa = dist_metric_isa(suite)
@@ -554,20 +684,39 @@ def generate_charts(
 
     if not pairs and not dist_metric_pairs:
         raise RuntimeError(
-            f"no baseline/result pairs found for variant {variant_key!r} in {results_dir}"
+            f"no {baseline_key!r}/result pairs found for variant {variant_key!r} "
+            f"in {results_dir}"
         )
 
     charts: list[tuple[str, Path]] = []
     metadata: list[dict[str, str | float]] = []
     paths_seen: set[Path] = set()
+    v5_cache: dict[Path, dict[tuple[str, str], list[Point]]] = {}
+    used_v5_baseline = False
     for suite, baseline_path, variant_path in pairs:
         baseline_series = result_series(baseline_path)
         variant_series = result_series(variant_path)
+        v5_series: dict[tuple[str, str], list[Point]] = {}
+        kind = query_kind(suite)
+        if v5_baseline_key is not None and kind is not None:
+            v5_path = (
+                results_dir
+                / f"{RESULT_PREFIX}v5-{kind}-{v5_baseline_key}.json"
+            )
+            if v5_path.is_file():
+                if v5_path not in v5_cache:
+                    v5_cache[v5_path] = cross_version_series(
+                        result_series(v5_path), v5_path
+                    )
+                v5_series = v5_cache[v5_path]
         common_keys = sorted(
             baseline_series.keys() & variant_series.keys(),
             key=lambda key: (key.group_id, key.function_id),
         )
         for key in common_keys:
+            scalar_type = key.group_id.rsplit("/", 1)[-1]
+            v5_points = v5_series.get((scalar_type, key.function_id))
+            used_v5_baseline |= v5_points is not None
             chart_path = unique_chart_path(output_dir, suite, key, variant_key, paths_seen)
             render_chart(
                 plt,
@@ -576,6 +725,9 @@ def generate_charts(
                 baseline_series[key],
                 variant_series[key],
                 variant_key,
+                baseline_key,
+                v5_points,
+                v5_baseline_key,
                 chart_path,
             )
             title = f"{suite}: {key.group_id} / {key.function_id}"
@@ -594,6 +746,7 @@ def generate_charts(
     matrix_charts, matrix_metadata = generate_dist_metric_matrix_charts(
         plt,
         variant_key,
+        baseline_key,
         output_dir,
         dist_metric_pairs,
         paths_seen,
@@ -605,13 +758,155 @@ def generate_charts(
         raise RuntimeError("matching result files contained no common benchmark series")
 
     html_path = output_dir / "latest_benchmark_run.html"
-    write_html(html_path, variant_key, charts)
+    write_html(
+        html_path,
+        variant_key,
+        baseline_key,
+        v5_baseline_key if used_v5_baseline else None,
+        charts,
+    )
     return metadata
+
+
+def generate_scratch_charts(result_key: str, results_dir: Path, output_dir: Path, html_name: str) -> None:
+    path = results_dir / f"{RESULT_PREFIX}v6-nearest_one-scratch-{result_key}.json"
+    if not path.is_file():
+        raise RuntimeError(f"missing scratch result file: {path}")
+    series = result_series(path)
+    colors = {
+        "default": "#3264a8",
+        "with_scratch": "#d35400",
+        "local_scratch": "#1f8f3a",
+    }
+    bands = {
+        "default": "rgba(50, 100, 168, 0.26)",
+        "with_scratch": "rgba(211, 84, 0, 0.26)",
+        "local_scratch": "rgba(31, 143, 58, 0.26)",
+    }
+    chart_series = []
+    for scalar in ("f32", "f64"):
+        default_points = series.get(
+            SeriesKey(f"profile_v6_nearest_one_scratch/{scalar}", "default")
+        )
+        default_by_tree = (
+            {point.tree_log2: point.duration_ns for point in default_points}
+            if default_points is not None
+            else {}
+        )
+        for function_id, label in (("default", "default"), ("with_scratch", "with_scratch"), ("local_scratch", "local_scratch")):
+            points = series.get(SeriesKey(f"profile_v6_nearest_one_scratch/{scalar}", function_id))
+            if points is None:
+                continue
+            chart_series.append({
+                "scalar": scalar,
+                "strategy": function_id,
+                "label": label,
+                "color": colors[function_id],
+                "band_color": bands[function_id],
+                "points": [
+                    {
+                        "tree_log2": p.tree_log2,
+                        "tree_size": round(2**p.tree_log2),
+                        "duration_ns": p.duration_ns,
+                        "lower_ns": p.lower_ns,
+                        "upper_ns": p.upper_ns,
+                        "change_from_default_percent": (
+                            ((p.duration_ns - default_by_tree[p.tree_log2]) / default_by_tree[p.tree_log2]) * 100
+                            if function_id != "default" and p.tree_log2 in default_by_tree
+                            else None
+                        ),
+                    }
+                    for p in points
+                ],
+            })
+    if not chart_series:
+        raise RuntimeError("scratch result contained no f32/f64 series")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    data_name = f"{RESULT_PREFIX}v6-nearest_one-scratch-{result_key}.chart-data.json"
+    data_path = output_dir / data_name
+    data_path.write_text(
+        json.dumps(
+            {
+                "result_key": result_key,
+                "source_file": path.name,
+                "suite": "profile_v6_nearest_one_scratch",
+                "title": "v6 nearest-one scratch strategies",
+                "series": chart_series,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    renderer_source = Path(__file__).with_name("d3_scratch_chart.js")
+    renderer_name = renderer_source.name
+    try:
+        renderer_ref = renderer_source.resolve().relative_to(output_dir.resolve()).as_posix()
+    except ValueError:
+        renderer_ref = renderer_name
+        renderer_target = output_dir / renderer_name
+        shutil.copyfile(renderer_source, renderer_target)
+
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>v6 nearest-one scratch strategies</title>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+  <style>
+    body {{ margin: 0 auto; max-width: 1100px; padding: 2rem; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f6f7f9; color: #202124; }}
+    header {{ margin-bottom: 1.5rem; }}
+    h1 {{ font-size: 1.8rem; margin: .2rem 0 .5rem; }}
+    p {{ color: #5f6368; }}
+    section {{ margin: 2rem 0; padding: 1rem; border-radius: .5rem; background: white; box-shadow: 0 1px 5px #0002; }}
+    .controls {{ display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; margin-bottom: 1rem; }}
+    label {{ font-weight: 600; color: #3c4043; }}
+    select {{ margin-left: .35rem; padding: .4rem .6rem; border: 1px solid #dadce0; border-radius: .35rem; background: #fff; font: inherit; }}
+    .chart-shell {{ position: relative; min-height: 680px; }}
+    .chart-tooltip {{ position: absolute; pointer-events: none; opacity: 0; background: #e4e7eb; border: 2px solid #68717d; border-radius: 5px; padding: 8px 10px; color: #202124; font-size: 13px; box-shadow: 0 4px 14px #0002; }}
+    .chart-tooltip table {{ border-collapse: collapse; }}
+    .chart-tooltip th {{ padding: 0 14px 3px 0; text-align: right; color: #3c4043; font-weight: 700; white-space: nowrap; }}
+    .chart-tooltip td {{ padding: 0 0 3px; white-space: nowrap; font-variant-numeric: tabular-nums; }}
+    .d3-chart svg {{ display: block; width: 100%; height: auto; cursor: default; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>v6 nearest-one scratch strategies</h1>
+    <p>Result key: <code>{html.escape(result_key)}</code>. Compare query execution strategies across tree sizes.</p>
+  </header>
+  <section>
+    <div class="controls">
+      <label>Scalar:<select data-control="scalar"><option>f64</option><option>f32</option></select></label>
+      <label>Y-axis:<select data-control="scale"><option value="log">Logarithmic</option><option value="linear">Linear</option></select></label>
+    </div>
+    <div class="chart-shell">
+      <div class="d3-chart" data-scratch-chart data-data-url="{html.escape(data_name, quote=True)}"></div>
+    </div>
+  </section>
+  <script src="{html.escape(renderer_ref, quote=True)}"></script>
+</body>
+</html>
+"""
+    (output_dir / html_name).write_text(document, encoding="utf-8")
 
 
 def main() -> int:
     args = parse_args()
-    generate_charts(args.variant_key, args.results_dir, args.output_dir)
+    if args.scratch:
+        generate_scratch_charts(args.variant_key, args.results_dir, args.output_dir, args.html_name)
+        return 0
+    generate_charts(
+        args.variant_key,
+        args.results_dir,
+        args.output_dir,
+        baseline_key=args.baseline_key,
+        v5_baseline_key=args.v5_baseline_key,
+    )
     return 0
 
 

--- a/scripts/chart_external_kd_tree_results.py
+++ b/scripts/chart_external_kd_tree_results.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Chart external k-d tree results against separately benchmarked Kiddo results."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+EXTERNAL_GROUP = "profile_external_kd_trees"
+KIDDO_GROUPS = {
+    "nearest_one": "profile_v6_nearest_one_eytzinger",
+    "nearest_n": "profile_v6_nearest_n_eytzinger",
+    "within_radius": "profile_v6_query_family_eytzinger",
+}
+LIBRARY_PREFIXES = (
+    ("neighbourhood_", "neighbourhood"),
+    ("kd_tree_", "kd-tree"),
+    ("fnntw_", "FNNTW"),
+    ("nabo_", "nabo"),
+)
+LIBRARY_ORDER = ("kiddo", "FNNTW", "nabo", "kd-tree", "neighbourhood")
+COLORS = {
+    "kiddo": "#3264a8",
+    "FNNTW": "#d35400",
+    "nabo": "#1f8f3a",
+    "kd-tree": "#8e44ad",
+    "neighbourhood": "#00838f",
+}
+SCALARS = ("f32", "f64")
+DEFAULT_RADIUS = 0.05
+SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+
+
+@dataclass(frozen=True)
+class Point:
+    tree_size: int
+    duration_ns: float
+    lower_ns: float
+    upper_ns: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare external Rust k-d tree Criterion exports with Kiddo's "
+            "separately collected 3D Eytzinger benchmarks."
+        )
+    )
+    parser.add_argument("mode", choices=("charts", "all"))
+    parser.add_argument("--external", type=Path, required=True)
+    parser.add_argument("--kiddo-nearest-one", type=Path, required=True)
+    parser.add_argument("--kiddo-nearest-n", type=Path, required=True)
+    parser.add_argument("--kiddo-query-family", type=Path, required=True)
+    parser.add_argument("--result-label", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--html-name", default="external-kd-tree-benchmarks.html")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"could not read {path}: {error}") from error
+    if not isinstance(value, dict) or not isinstance(value.get("results"), list):
+        raise RuntimeError(f"{path} is not a Criterion result export")
+    return value
+
+
+def finite_positive(value: Any, description: str, path: Path) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}") from error
+    if not math.isfinite(number) or number <= 0:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}")
+    return number
+
+
+def read_series(path: Path, expected_group: str) -> dict[tuple[str, str], list[Point]]:
+    series: dict[tuple[str, str], list[Point]] = {}
+    for result in load_json(path)["results"]:
+        metadata = result.get("metadata")
+        estimates = result.get("estimates")
+        if not isinstance(metadata, dict) or not isinstance(estimates, dict):
+            raise RuntimeError(f"{path} contains incomplete benchmark data")
+
+        group_id = metadata.get("group_id")
+        function_id = metadata.get("function_id")
+        if not isinstance(group_id, str) or not isinstance(function_id, str):
+            raise RuntimeError(f"{path} contains an invalid benchmark identity")
+        if group_id.rsplit("/", 1)[0] != expected_group:
+            raise RuntimeError(
+                f"{path} contains group {group_id!r}, expected {expected_group!r}"
+            )
+        scalar = group_id.rsplit("/", 1)[-1]
+        if scalar not in SCALARS:
+            raise RuntimeError(
+                f"{path} contains unsupported scalar/dimensional group {group_id!r}; "
+                "this comparison is strictly 3D f32/f64"
+            )
+
+        tree_size_value = finite_positive(metadata.get("value_str"), "tree size", path)
+        tree_size = int(tree_size_value)
+        if tree_size != tree_size_value or tree_size & (tree_size - 1):
+            raise RuntimeError(f"tree size is not a power of two in {path}: {tree_size_value}")
+
+        throughput = metadata.get("throughput")
+        query_count = throughput.get("Elements") if isinstance(throughput, dict) else None
+        query_count = finite_positive(query_count, "Elements throughput", path)
+        mean = estimates.get("mean")
+        interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
+        if not isinstance(mean, dict) or not isinstance(interval, dict):
+            raise RuntimeError(f"{path} contains no mean confidence interval")
+
+        point = Point(
+            tree_size,
+            finite_positive(mean.get("point_estimate"), "mean duration", path) / query_count,
+            finite_positive(interval.get("lower_bound"), "lower duration bound", path)
+            / query_count,
+            finite_positive(interval.get("upper_bound"), "upper duration bound", path)
+            / query_count,
+        )
+        series.setdefault((scalar, function_id), []).append(point)
+
+    for key, points in series.items():
+        points.sort(key=lambda point: point.tree_size)
+        sizes = [point.tree_size for point in points]
+        if len(sizes) != len(set(sizes)):
+            raise RuntimeError(f"duplicate tree sizes for {key!r} in {path}")
+    return series
+
+
+def external_identity(function_id: str) -> tuple[str, str]:
+    for prefix, library in LIBRARY_PREFIXES:
+        if function_id.startswith(prefix):
+            query = function_id[len(prefix) :]
+            if (
+                query == "nearest_one"
+                or re.fullmatch(r"nearest_n_k(?:5|20|50)", query)
+                or re.fullmatch(r"within_radius_r[0-9.eE+-]+", query)
+            ):
+                return library, query
+            raise RuntimeError(f"unsupported external query identity: {function_id}")
+    raise RuntimeError(
+        f"unexpected library in external benchmark identity {function_id!r}; "
+        "Kiddo must come from its focused benchmark exports"
+    )
+
+
+def kiddo_points(
+    scalar: str,
+    query: str,
+    nearest_one: dict[tuple[str, str], list[Point]],
+    nearest_n: dict[tuple[str, str], list[Point]],
+    query_family: dict[tuple[str, str], list[Point]],
+) -> list[Point]:
+    if query == "nearest_one":
+        source = nearest_one
+        function_id = query
+    elif query.startswith("nearest_n_k"):
+        source = nearest_n
+        function_id = query
+    else:
+        radius_match = re.fullmatch(r"within_radius_r([0-9.eE+-]+)", query)
+        if radius_match is None:
+            raise RuntimeError(f"unsupported query {query!r}")
+        radius = float(radius_match.group(1))
+        if not math.isclose(radius, DEFAULT_RADIUS, rel_tol=0.0, abs_tol=1.0e-12):
+            raise RuntimeError(
+                f"external radius {radius:g} has no equivalent focused Kiddo result; "
+                f"profile_v6_query_family_eytzinger uses radius {DEFAULT_RADIUS:g}"
+            )
+        source = query_family
+        function_id = "within_unsorted"
+
+    try:
+        return source[(scalar, function_id)]
+    except KeyError as error:
+        raise RuntimeError(
+            f"missing Kiddo {scalar}/{function_id} results required for {query}"
+        ) from error
+
+
+def collect_charts(
+    external_path: Path,
+    nearest_one_path: Path,
+    nearest_n_path: Path,
+    query_family_path: Path,
+) -> dict[tuple[str, str], dict[str, list[Point]]]:
+    external = read_series(external_path, EXTERNAL_GROUP)
+    nearest_one = read_series(nearest_one_path, KIDDO_GROUPS["nearest_one"])
+    nearest_n = read_series(nearest_n_path, KIDDO_GROUPS["nearest_n"])
+    query_family = read_series(
+        query_family_path, KIDDO_GROUPS["within_radius"]
+    )
+
+    charts: dict[tuple[str, str], dict[str, list[Point]]] = {}
+    for (scalar, function_id), points in external.items():
+        library, query = external_identity(function_id)
+        chart = charts.setdefault((scalar, query), {})
+        if library in chart:
+            raise RuntimeError(f"duplicate {library} series for {scalar}/{query}")
+        chart[library] = points
+
+    expected_queries = {
+        "nearest_one",
+        "nearest_n_k5",
+        "nearest_n_k20",
+        "nearest_n_k50",
+        f"within_radius_r{DEFAULT_RADIUS}",
+    }
+    expected_keys = {(scalar, query) for scalar in SCALARS for query in expected_queries}
+    missing = expected_keys - charts.keys()
+    extra = charts.keys() - expected_keys
+    if missing or extra:
+        raise RuntimeError(
+            "external result matrix does not match the expected 3D query matrix; "
+            f"missing={sorted(missing)!r}, extra={sorted(extra)!r}"
+        )
+
+    for (scalar, query), chart in charts.items():
+        chart["kiddo"] = kiddo_points(
+            scalar, query, nearest_one, nearest_n, query_family
+        )
+        size_sets = {
+            library: {point.tree_size for point in points}
+            for library, points in chart.items()
+        }
+        shared_sizes = set.intersection(*size_sets.values())
+        if not shared_sizes:
+            details = ", ".join(
+                f"{library}={sorted(sizes)}" for library, sizes in size_sets.items()
+            )
+            raise RuntimeError(f"no shared tree sizes for {scalar}/{query}: {details}")
+        for library, points in chart.items():
+            chart[library] = [
+                point for point in points if point.tree_size in shared_sizes
+            ]
+    return charts
+
+
+def query_sort_key(query: str) -> tuple[int, int | float]:
+    if query == "nearest_one":
+        return (0, 0)
+    nearest_n_match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    if nearest_n_match:
+        return (1, int(nearest_n_match.group(1)))
+    radius_match = re.fullmatch(r"within_radius_r(.+)", query)
+    return (2, float(radius_match.group(1)) if radius_match else 0)
+
+
+def query_title(query: str) -> str:
+    if query == "nearest_one":
+        return "nearest_one"
+    nearest_n_match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    if nearest_n_match:
+        return f"nearest_n (n={nearest_n_match.group(1)})"
+    radius = query.removeprefix("within_radius_r")
+    return f"within_radius (radius={radius})"
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]+", "-", value).strip("-_") or "benchmark"
+
+
+def render_charts(
+    charts: dict[tuple[str, str], dict[str, list[Point]]],
+    output_dir: Path,
+    result_label: str,
+) -> list[tuple[str, Path]]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as error:
+        raise RuntimeError("matplotlib is required to generate benchmark charts") from error
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[tuple[str, Path]] = []
+    ordered = sorted(
+        charts.items(),
+        key=lambda item: (SCALARS.index(item[0][0]), query_sort_key(item[0][1])),
+    )
+    for (scalar, query), series in ordered:
+        title = f"3D {query_title(query)} — {scalar}"
+        figure, axis = plt.subplots(figsize=(10.5, 6.2))
+        for library in LIBRARY_ORDER:
+            points = series.get(library)
+            if points is None:
+                continue
+            axis.errorbar(
+                [point.tree_size for point in points],
+                [point.duration_ns for point in points],
+                yerr=[
+                    [point.duration_ns - point.lower_ns for point in points],
+                    [point.upper_ns - point.duration_ns for point in points],
+                ],
+                marker="o",
+                markersize=4,
+                linewidth=1.8,
+                capsize=2,
+                color=COLORS[library],
+                label=library,
+            )
+
+        sizes = sorted(
+            {point.tree_size for points in series.values() for point in points}
+        )
+        axis.set_xscale("log", base=2)
+        axis.set_yscale("log", base=10)
+        axis.set_xticks(sizes)
+        axis.set_xticklabels([f"2^{size.bit_length() - 1}" for size in sizes])
+        axis.set_xlabel("Tree size (log₂ scale)")
+        axis.set_ylabel("Mean query duration (ns/query, log₁₀ scale)")
+        axis.set_title(title)
+        axis.grid(True, which="both", alpha=0.25)
+        axis.legend(title="Crate")
+        figure.tight_layout()
+
+        path = output_dir / (
+            f"bench_result-external-kd-trees-{slug(result_label)}-"
+            f"{scalar}-{slug(query)}.png"
+        )
+        figure.savefig(path, dpi=160)
+        plt.close(figure)
+        rendered.append((title, path))
+    return rendered
+
+
+def write_html(
+    path: Path,
+    charts: list[tuple[str, Path]],
+    result_label: str,
+    sources: list[Path],
+) -> None:
+    sections = "\n".join(
+        (
+            f"<section><h2>{html.escape(title)}</h2>"
+            f'<img src="{html.escape(chart.name, quote=True)}" '
+            f'alt="{html.escape(title, quote=True)}"></section>'
+        )
+        for title, chart in charts
+    )
+    source_items = "".join(f"<li><code>{html.escape(str(source))}</code></li>" for source in sources)
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>External Rust k-d tree benchmarks</title>
+  <style>
+    body {{ font: 16px/1.45 system-ui, sans-serif; max-width: 1180px; margin: 0 auto; padding: 2rem; color: #18212b; }}
+    section {{ margin: 2.5rem 0; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #d8dee4; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>External Rust k-d tree benchmarks</h1>
+  <p>Result label: <code>{html.escape(result_label)}</code>. All benchmarks are 3D. Each chart uses a base-2 logarithmic tree-size axis and a base-10 logarithmic per-query duration axis.</p>
+  <details><summary>Source result exports</summary><ul>{source_items}</ul></details>
+  {sections}
+</body>
+</html>
+"""
+    path.write_text(document, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    if not SAFE_LABEL.fullmatch(args.result_label):
+        raise RuntimeError(
+            "result label must contain only letters, digits, '.', '_', '+', ':', or '-'"
+        )
+    sources = [
+        args.external,
+        args.kiddo_nearest_one,
+        args.kiddo_nearest_n,
+        args.kiddo_query_family,
+    ]
+    charts = collect_charts(*sources)
+    rendered = render_charts(charts, args.output_dir, args.result_label)
+    if args.mode == "all":
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        write_html(args.output_dir / args.html_name, rendered, args.result_label, sources)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chart_v5_v6_results.py
+++ b/scripts/chart_v5_v6_results.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Generate direct Kiddo v5-versus-v6 benchmark charts and an HTML report."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCALARS = ("f32", "f64")
+SAFE_KEY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+SUITES = (
+    (
+        "nearest_one",
+        "nearest_one",
+        "profile_v5_nearest_one_eytzinger",
+        "profile_v6_nearest_one_eytzinger",
+    ),
+    (
+        "approx_nearest_one",
+        "approx_nearest_one",
+        "profile_v5_approx_nearest_one_eytzinger",
+        "profile_v6_approx_nearest_one_eytzinger",
+    ),
+    (
+        "nearest_n",
+        "nearest_n",
+        "profile_v5_nearest_n_eytzinger",
+        "profile_v6_nearest_n_eytzinger",
+    ),
+    (
+        "query-family",
+        "query family",
+        "profile_v5_query_family_eytzinger",
+        "profile_v6_query_family_eytzinger",
+    ),
+)
+COLORS = {"v5": "#7d3c98", "v6": "#3264a8"}
+
+
+@dataclass(frozen=True)
+class Point:
+    tree_size: int
+    duration_ns: float
+    lower_ns: float
+    upper_ns: float
+
+
+@dataclass(frozen=True)
+class Chart:
+    scalar: str
+    suite_label: str
+    function_id: str
+    v5: tuple[Point, ...]
+    v6: tuple[Point, ...]
+
+    @property
+    def title(self) -> str:
+        return f"{self.suite_label}: {display_query(self.function_id)} — {self.scalar}"
+
+    @property
+    def ratios(self) -> list[float]:
+        return [
+            v6.duration_ns / v5.duration_ns
+            for v5, v6 in zip(self.v5, self.v6, strict=True)
+        ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Chart matching Kiddo v5 and v6 Criterion result exports."
+    )
+    parser.add_argument("mode", choices=("charts", "all"))
+    parser.add_argument("--v6-key", required=True)
+    parser.add_argument("--v5-key", required=True)
+    parser.add_argument("--results-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--html-name", default="v5-v6-benchmarks.html")
+    return parser.parse_args()
+
+
+def result_path(results_dir: Path, version: str, suite: str, key: str) -> Path:
+    return results_dir / f"bench_result-{version}-{suite}-eytzinger-{key}.json"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"could not read {path}: {error}") from error
+    if not isinstance(value, dict) or not isinstance(value.get("results"), list):
+        raise RuntimeError(f"{path} is not a Criterion result export")
+    return value
+
+
+def finite_positive(value: Any, description: str, path: Path) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}") from error
+    if not math.isfinite(number) or number <= 0:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}")
+    return number
+
+
+def read_series(
+    path: Path, expected_group: str
+) -> dict[tuple[str, str], tuple[Point, ...]]:
+    series: dict[tuple[str, str], list[Point]] = {}
+    for result in load_json(path)["results"]:
+        metadata = result.get("metadata")
+        estimates = result.get("estimates")
+        if not isinstance(metadata, dict) or not isinstance(estimates, dict):
+            raise RuntimeError(f"{path} contains incomplete benchmark data")
+
+        group_id = metadata.get("group_id")
+        function_id = metadata.get("function_id")
+        if not isinstance(group_id, str) or not isinstance(function_id, str):
+            raise RuntimeError(f"{path} contains an invalid benchmark identity")
+        group, separator, scalar = group_id.rpartition("/")
+        if separator != "/" or group != expected_group or scalar not in SCALARS:
+            raise RuntimeError(
+                f"{path} contains group {group_id!r}; expected "
+                f"{expected_group}/{{f32,f64}}"
+            )
+
+        tree_size_value = finite_positive(metadata.get("value_str"), "tree size", path)
+        tree_size = int(tree_size_value)
+        if tree_size != tree_size_value or tree_size & (tree_size - 1):
+            raise RuntimeError(f"tree size is not a power of two in {path}: {tree_size_value}")
+
+        throughput = metadata.get("throughput")
+        query_count = throughput.get("Elements") if isinstance(throughput, dict) else None
+        query_count = finite_positive(query_count, "Elements throughput", path)
+        mean = estimates.get("mean")
+        interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
+        if not isinstance(mean, dict) or not isinstance(interval, dict):
+            raise RuntimeError(f"{path} contains no mean confidence interval")
+
+        point = Point(
+            tree_size=tree_size,
+            duration_ns=finite_positive(
+                mean.get("point_estimate"), "mean duration", path
+            )
+            / query_count,
+            lower_ns=finite_positive(
+                interval.get("lower_bound"), "lower duration bound", path
+            )
+            / query_count,
+            upper_ns=finite_positive(
+                interval.get("upper_bound"), "upper duration bound", path
+            )
+            / query_count,
+        )
+        series.setdefault((scalar, function_id), []).append(point)
+
+    finished: dict[tuple[str, str], tuple[Point, ...]] = {}
+    for key, points in series.items():
+        points.sort(key=lambda point: point.tree_size)
+        sizes = [point.tree_size for point in points]
+        if len(sizes) != len(set(sizes)):
+            raise RuntimeError(f"duplicate tree sizes for {key!r} in {path}")
+        finished[key] = tuple(points)
+    return finished
+
+
+def collect_charts(
+    v6_key: str, v5_key: str, results_dir: Path
+) -> tuple[list[Chart], list[Path]]:
+    charts: list[Chart] = []
+    sources: list[Path] = []
+    for suite, suite_label, v5_group, v6_group in SUITES:
+        v5_path = result_path(results_dir, "v5", suite, v5_key)
+        v6_path = result_path(results_dir, "v6", suite, v6_key)
+        sources.extend((v5_path, v6_path))
+        v5_series = read_series(v5_path, v5_group)
+        v6_series = read_series(v6_path, v6_group)
+        common_keys = sorted(
+            v5_series.keys() & v6_series.keys(),
+            key=lambda key: (SCALARS.index(key[0]), query_sort_key(key[1])),
+        )
+        if not common_keys:
+            raise RuntimeError(f"{v5_path} and {v6_path} have no common series")
+
+        for scalar, function_id in common_keys:
+            v5_by_size = {point.tree_size: point for point in v5_series[(scalar, function_id)]}
+            v6_by_size = {point.tree_size: point for point in v6_series[(scalar, function_id)]}
+            shared_sizes = sorted(v5_by_size.keys() & v6_by_size.keys())
+            if not shared_sizes:
+                raise RuntimeError(
+                    f"no common tree sizes for {suite}/{scalar}/{function_id}"
+                )
+            charts.append(
+                Chart(
+                    scalar=scalar,
+                    suite_label=suite_label,
+                    function_id=function_id,
+                    v5=tuple(v5_by_size[size] for size in shared_sizes),
+                    v6=tuple(v6_by_size[size] for size in shared_sizes),
+                )
+            )
+    return charts, sources
+
+
+def query_sort_key(function_id: str) -> tuple[int, tuple[int, ...], str]:
+    if function_id == "nearest_one":
+        return (0, (), function_id)
+    if function_id == "approx_nearest_one":
+        return (1, (), function_id)
+    numbers = tuple(int(value) for value in re.findall(r"\d+", function_id))
+    if function_id.startswith("nearest_n_k"):
+        category = 2
+    elif function_id == "within":
+        category = 3
+    elif function_id == "within_unsorted":
+        category = 4
+    elif function_id.startswith("nearest_n_within_k"):
+        category = 5
+    elif function_id.startswith("nearest_n_within_unsorted_k"):
+        category = 6
+    elif function_id.startswith("best_n_within_k"):
+        category = 7
+    else:
+        category = 8
+    return (category, numbers, function_id)
+
+
+def display_query(function_id: str) -> str:
+    return re.sub(r"_k(\d+)$", r" (n=\1)", function_id)
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]+", "-", value).strip("-_") or "benchmark"
+
+
+def render_charts(
+    charts: list[Chart], output_dir: Path, v6_key: str, v5_key: str
+) -> list[tuple[Chart, Path]]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as error:
+        raise RuntimeError("matplotlib is required to generate benchmark charts") from error
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[tuple[Chart, Path]] = []
+    for chart in charts:
+        figure, axis = plt.subplots(figsize=(10.5, 6.2))
+        for version, points in (("v5", chart.v5), ("v6", chart.v6)):
+            axis.errorbar(
+                [point.tree_size for point in points],
+                [point.duration_ns for point in points],
+                yerr=[
+                    [point.duration_ns - point.lower_ns for point in points],
+                    [point.upper_ns - point.duration_ns for point in points],
+                ],
+                marker="o",
+                markersize=5,
+                linewidth=2,
+                capsize=2,
+                color=COLORS[version],
+                label=f"{version} ({v5_key if version == 'v5' else v6_key})",
+            )
+
+        sizes = [point.tree_size for point in chart.v5]
+        axis.set_xscale("log", base=2)
+        axis.set_yscale("log", base=10)
+        axis.set_xticks(sizes)
+        axis.set_xticklabels([f"2^{size.bit_length() - 1}" for size in sizes])
+        axis.set_xlabel("Tree size (log₂ scale)")
+        axis.set_ylabel("Mean query duration (ns/query, log₁₀ scale)")
+        axis.set_title(chart.title)
+        axis.grid(True, which="both", alpha=0.25)
+        axis.legend()
+        figure.tight_layout()
+
+        path = output_dir / (
+            f"bench_result-v5-v6-{slug(v5_key)}-{slug(v6_key)}-"
+            f"{chart.scalar}-{slug(chart.function_id)}.png"
+        )
+        figure.savefig(path, dpi=160)
+        plt.close(figure)
+        rendered.append((chart, path))
+    return rendered
+
+
+def format_change(ratio: float) -> str:
+    if ratio < 1:
+        return f"v6 {1 / ratio:.2f}× faster"
+    if ratio > 1:
+        return f"v6 {ratio:.2f}× slower"
+    return "equal"
+
+
+def write_html(
+    path: Path,
+    rendered: list[tuple[Chart, Path]],
+    v6_key: str,
+    v5_key: str,
+    sources: list[Path],
+) -> None:
+    all_ratios = [ratio for chart, _ in rendered for ratio in chart.ratios]
+    summary_rows = "\n".join(
+        (
+            "<tr>"
+            f"<td>{html.escape(chart.scalar)}</td>"
+            f"<td>{html.escape(chart.suite_label)}</td>"
+            f"<td><code>{html.escape(chart.function_id)}</code></td>"
+            f"<td>{html.escape(format_change(statistics.geometric_mean(chart.ratios)))}</td>"
+            f"<td>{min(chart.ratios):.3f}–{max(chart.ratios):.3f}×</td>"
+            "</tr>"
+        )
+        for chart, _ in rendered
+    )
+    sections = "\n".join(
+        (
+            f"<section><h2>{html.escape(chart.title)}</h2>"
+            f"<p>{html.escape(format_change(statistics.geometric_mean(chart.ratios)))}</p>"
+            f'<img src="{html.escape(chart_path.name, quote=True)}" '
+            f'alt="{html.escape(chart.title, quote=True)}"></section>'
+        )
+        for chart, chart_path in rendered
+    )
+    source_items = "".join(
+        f"<li><code>{html.escape(str(source))}</code></li>" for source in sources
+    )
+    overall = format_change(statistics.geometric_mean(all_ratios))
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kiddo v5 versus v6 benchmarks</title>
+  <style>
+    body {{ font: 16px/1.45 system-ui, sans-serif; max-width: 1180px; margin: 0 auto; padding: 2rem; color: #18212b; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th, td {{ border-bottom: 1px solid #d8dee4; padding: .5rem; text-align: left; }}
+    section {{ margin: 2.5rem 0; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #d8dee4; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>Kiddo v5 versus v6 benchmarks</h1>
+  <p>v5: <code>{html.escape(v5_key)}</code>; v6: <code>{html.escape(v6_key)}</code>. Overall geometric mean: <strong>{html.escape(overall)}</strong>.</p>
+  <p>Each chart uses a base-2 logarithmic tree-size axis and a base-10 logarithmic per-query duration axis. Ratios are v6 duration divided by v5 duration, so values below 1 are improvements.</p>
+  <details><summary>Source result exports</summary><ul>{source_items}</ul></details>
+  <h2>Summary</h2>
+  <table>
+    <thead><tr><th>Scalar</th><th>Suite</th><th>Query</th><th>Geometric mean</th><th>v6/v5 range</th></tr></thead>
+    <tbody>{summary_rows}</tbody>
+  </table>
+  {sections}
+</body>
+</html>
+"""
+    path.write_text(document, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    for label, key in (("v6 key", args.v6_key), ("v5 key", args.v5_key)):
+        if not SAFE_KEY.fullmatch(key):
+            raise RuntimeError(
+                f"{label} must contain only letters, digits, '.', '_', '+', ':', or '-'"
+            )
+    charts, sources = collect_charts(args.v6_key, args.v5_key, args.results_dir)
+    rendered = render_charts(charts, args.output_dir, args.v6_key, args.v5_key)
+    if args.mode == "all":
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        write_html(
+            args.output_dir / args.html_name,
+            rendered,
+            args.v6_key,
+            args.v5_key,
+            sources,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chart_within_radius_projection_results.py
+++ b/scripts/chart_within_radius_projection_results.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Chart the focused within-radius projection benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_GROUP = "profile_v6_within_radius_projection"
+SCALARS = ("f32", "f64")
+SERIES = (
+    ("kiddo_item_distance", "Kiddo: item + distance"),
+    ("kiddo_item_only", "Kiddo: item only"),
+    ("kiddo_point_item_distance", "Kiddo: point + item + distance"),
+    ("kiddo_point_item", "Kiddo: point + item"),
+    ("neighbourhood_item_only", "neighbourhood: item only"),
+)
+ITEM_ONLY_SERIES = (
+    ("kiddo_item_only", "Kiddo: item only"),
+    ("neighbourhood_item_only", "neighbourhood: item only"),
+)
+COLORS = {
+    "kiddo_item_distance": "#3264a8",
+    "kiddo_item_only": "#1f8f3a",
+    "kiddo_point_item_distance": "#d35400",
+    "kiddo_point_item": "#8e44ad",
+    "neighbourhood_item_only": "#00838f",
+}
+SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+
+
+@dataclass(frozen=True)
+class Point:
+    tree_size: int
+    duration_ns: float
+    lower_ns: float
+    upper_ns: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("charts", "all"))
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--result-label", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--html-name", default="within-radius-projection-benchmarks.html"
+    )
+    parser.add_argument(
+        "--item-only",
+        action="store_true",
+        help="render only Kiddo item-only and neighbourhood item-only",
+    )
+    return parser.parse_args()
+
+
+def finite_positive(value: Any, description: str, path: Path) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}") from error
+    if not math.isfinite(number) or number <= 0:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}")
+    return number
+
+
+def read_results(path: Path) -> dict[str, dict[str, list[Point]]]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"could not read {path}: {error}") from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+        raise RuntimeError(f"{path} is not a Criterion result export")
+
+    results: dict[str, dict[str, list[Point]]] = {
+        scalar: {} for scalar in SCALARS
+    }
+    for result in payload["results"]:
+        metadata = result.get("metadata")
+        estimates = result.get("estimates")
+        if not isinstance(metadata, dict) or not isinstance(estimates, dict):
+            raise RuntimeError(f"{path} contains incomplete benchmark data")
+
+        group_id = metadata.get("group_id")
+        function_id = metadata.get("function_id")
+        if not isinstance(group_id, str) or not isinstance(function_id, str):
+            raise RuntimeError(f"{path} contains an invalid benchmark identity")
+        prefix, separator, scalar = group_id.rpartition("/")
+        if separator != "/" or prefix != EXPECTED_GROUP or scalar not in SCALARS:
+            raise RuntimeError(f"unexpected benchmark group {group_id!r} in {path}")
+        if function_id not in dict(SERIES):
+            raise RuntimeError(f"unexpected benchmark function {function_id!r} in {path}")
+
+        tree_size_value = finite_positive(
+            metadata.get("value_str"), "tree size", path
+        )
+        tree_size = int(tree_size_value)
+        if tree_size != tree_size_value or tree_size & (tree_size - 1):
+            raise RuntimeError(f"tree size is not a power of two in {path}")
+
+        throughput = metadata.get("throughput")
+        query_count = (
+            throughput.get("Elements") if isinstance(throughput, dict) else None
+        )
+        query_count = finite_positive(query_count, "Elements throughput", path)
+        mean = estimates.get("mean")
+        interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
+        if not isinstance(mean, dict) or not isinstance(interval, dict):
+            raise RuntimeError(f"{path} contains no mean confidence interval")
+
+        point = Point(
+            tree_size,
+            finite_positive(mean.get("point_estimate"), "mean duration", path)
+            / query_count,
+            finite_positive(interval.get("lower_bound"), "lower bound", path)
+            / query_count,
+            finite_positive(interval.get("upper_bound"), "upper bound", path)
+            / query_count,
+        )
+        results[scalar].setdefault(function_id, []).append(point)
+
+    expected_functions = {function_id for function_id, _ in SERIES}
+    for scalar, scalar_results in results.items():
+        missing = expected_functions - scalar_results.keys()
+        extra = scalar_results.keys() - expected_functions
+        if missing or extra:
+            raise RuntimeError(
+                f"{scalar} result matrix mismatch: "
+                f"missing={sorted(missing)!r}, extra={sorted(extra)!r}"
+            )
+        sizes = None
+        for points in scalar_results.values():
+            points.sort(key=lambda point: point.tree_size)
+            point_sizes = [point.tree_size for point in points]
+            if len(point_sizes) != len(set(point_sizes)):
+                raise RuntimeError(f"duplicate {scalar} tree sizes in {path}")
+            if sizes is None:
+                sizes = point_sizes
+            elif sizes != point_sizes:
+                raise RuntimeError(f"{scalar} series use different tree sizes in {path}")
+    return results
+
+
+def render_charts(
+    results: dict[str, dict[str, list[Point]]],
+    output_dir: Path,
+    result_label: str,
+    series: tuple[tuple[str, str], ...],
+    filename_suffix: str,
+    item_only: bool,
+) -> list[tuple[str, Path]]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as error:
+        raise RuntimeError("matplotlib is required to generate charts") from error
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered = []
+    for scalar in SCALARS:
+        figure, axis = plt.subplots(figsize=(10.5, 6.2))
+        for function_id, display_name in series:
+            points = results[scalar][function_id]
+            axis.errorbar(
+                [point.tree_size for point in points],
+                [point.duration_ns for point in points],
+                yerr=[
+                    [point.duration_ns - point.lower_ns for point in points],
+                    [point.upper_ns - point.duration_ns for point in points],
+                ],
+                marker="o",
+                markersize=4,
+                linewidth=1.8,
+                capsize=2,
+                color=COLORS[function_id],
+                label=display_name,
+            )
+
+        sizes = [
+            point.tree_size
+            for point in results[scalar]["kiddo_item_only"]
+        ]
+        axis.set_xscale("log", base=2)
+        axis.set_yscale("log", base=10)
+        axis.set_xticks(sizes, [f"2^{size.bit_length() - 1}" for size in sizes])
+        axis.set_xlabel("Tree size (log₂ scale)")
+        axis.set_ylabel("Mean query duration (ns/query, log₁₀ scale)")
+        chart_subject = (
+            "item-only comparison" if item_only else "result projections"
+        )
+        axis.set_title(f"3D within-radius {chart_subject} — {scalar}")
+        axis.grid(True, which="both", alpha=0.25)
+        axis.legend(title="Implementation" if item_only else "Result projection")
+
+        if item_only:
+            lower_y, upper_y = axis.get_ylim()
+            axis.set_ylim(lower_y / 1.2, upper_y)
+            kiddo_points = results[scalar]["kiddo_item_only"]
+            neighbourhood_points = results[scalar]["neighbourhood_item_only"]
+            if len(kiddo_points) != len(neighbourhood_points):
+                raise RuntimeError(
+                    f"{scalar} item-only series use different point counts"
+                )
+            for index, (kiddo_point, neighbourhood_point) in enumerate(
+                zip(kiddo_points, neighbourhood_points)
+            ):
+                if kiddo_point.tree_size != neighbourhood_point.tree_size:
+                    raise RuntimeError(
+                        f"{scalar} item-only series use different tree sizes"
+                    )
+                faster_percent = (
+                    1.0
+                    - kiddo_point.duration_ns / neighbourhood_point.duration_ns
+                ) * 100.0
+                horizontal_alignment = "center"
+                if index == 0:
+                    horizontal_alignment = "left"
+                elif index == len(kiddo_points) - 1:
+                    horizontal_alignment = "right"
+                axis.annotate(
+                    f"{faster_percent:.0f}%",
+                    (kiddo_point.tree_size, kiddo_point.duration_ns),
+                    textcoords="offset points",
+                    xytext=(0, -13),
+                    ha=horizontal_alignment,
+                    va="top",
+                    color="#176d2b",
+                    fontsize=8,
+                    bbox={
+                        "facecolor": "white",
+                        "edgecolor": "none",
+                        "alpha": 0.82,
+                        "pad": 0.2,
+                    },
+                )
+        figure.tight_layout()
+
+        safe_label = re.sub(r"[^A-Za-z0-9_-]+", "-", result_label).strip("-")
+        path = output_dir / (
+            f"bench_result-v6-within-radius-projection-{safe_label}"
+            f"{filename_suffix}-{scalar}.png"
+        )
+        figure.savefig(path, dpi=160)
+        plt.close(figure)
+        rendered.append((scalar, path))
+    return rendered
+
+
+def render_html(
+    charts: list[tuple[str, Path]],
+    output_dir: Path,
+    html_name: str,
+    result_label: str,
+    result_path: Path,
+    item_only: bool,
+) -> Path:
+    sections = "\n".join(
+        (
+            f"<section><h2>{html.escape(scalar)}</h2>"
+            f'<img src="{html.escape(path.name)}" alt="{html.escape(scalar)}"></section>'
+        )
+        for scalar, path in charts
+    )
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Within-radius projection benchmarks</title>
+  <style>
+    body {{ font: 16px/1.45 system-ui, sans-serif; max-width: 1180px; margin: 0 auto; padding: 2rem; color: #18212b; }}
+    section {{ margin: 2.5rem 0; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #d8dee4; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>Within-radius {"item-only comparison" if item_only else "projection benchmarks"}</h1>
+  <p>Result label: <code>{html.escape(result_label)}</code>. All benchmarks use the same seeded 3D data and radius as the external comparison.</p>
+  <p>Source result: <code>{html.escape(str(result_path))}</code></p>
+  {sections}
+</body>
+</html>
+"""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    html_path = output_dir / html_name
+    html_path.write_text(document, encoding="utf-8")
+    return html_path
+
+
+def main() -> None:
+    args = parse_args()
+    if not SAFE_LABEL.fullmatch(args.result_label):
+        raise RuntimeError(
+            "result label must contain only letters, digits, '.', '_', '+', ':', or '-'"
+        )
+    results = read_results(args.result)
+    series = ITEM_ONLY_SERIES if args.item_only else SERIES
+    filename_suffix = "-item-only" if args.item_only else ""
+    charts = render_charts(
+        results,
+        args.output_dir,
+        args.result_label,
+        series,
+        filename_suffix,
+        args.item_only,
+    )
+    for _, path in charts:
+        print(path)
+    if args.mode == "all":
+        print(
+            render_html(
+                charts,
+                args.output_dir,
+                args.html_name,
+                args.result_label,
+                args.result,
+                args.item_only,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the benchmark and charting infrastructure used to compare Kiddo v6 with external k-d-tree implementations, including neighbourhood's published benchmark shape.

## Included

- Configurable tree-size and query-count controls for the existing v6 benchmark suites.
- External-library comparison runner for neighbourhood, kd-tree, FNNTW, and nabo where their APIs support the comparison.
- Focused 3D within-radius projection runner covering Kiddo item-only and point-bearing result projections.
- Reproduction runner for neighbourhood's published benchmark.
- Charting/reporting scripts and corresponding justfile tasks, including v5/v6 comparison support.

Raw benchmark outputs, PNG/HTML artefacts, and the neighbourhood console `.txt` output are intentionally excluded.
