### PR TITLE
chore: release v6.0.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Kiddo Changelog
 
+## [6.0.0-alpha.4] - 2026-07-27
+
+### ✨ Features
+
+- Add result capacity hint for radius queries ([@sdd](https://github.com/sdd))
+
+- Add adaptive parallel tree construction ([@sdd](https://github.com/sdd))
+
+- Specialize within-radius result projection ([@sdd](https://github.com/sdd))
+
+
+### 🐛 Bug Fixes
+
+- Handle padded stems in parallel construction ([@sdd](https://github.com/sdd))
+
+
+### ♻️ Refactor
+
+- Within_unsorted to a visitor ([@sdd](https://github.com/sdd))
+
+- Switch from propagating points as indexes to actual values ([@sdd](https://github.com/sdd))
+
+
+### 🧪 Testing
+
+- Add result collection threshold profiler ([@sdd](https://github.com/sdd))
+
+- Add v6 release parity benchmark suites ([@sdd](https://github.com/sdd))
+
+- Add point projection benchmark ([@sdd](https://github.com/sdd))
+
+
+### 🤖 CI
+
+- Add stem strategy benchmark variant ([@sdd](https://github.com/sdd))
+
+- Rename basic benchmark variant ([@sdd](https://github.com/sdd))
+
+- Pass benchmark features explicitly ([@sdd](https://github.com/sdd))
+
+- Cap leaf benchmark tree size ([@sdd](https://github.com/sdd))
+
+- Fix leaf benchmark export filter ([@sdd](https://github.com/sdd))
+
+- Cap benchmark trees at 2^25 ([@sdd](https://github.com/sdd))
+
+- Fix benchmark v5-v6 chart matching ([@sdd](https://github.com/sdd))
+
+- Add ISA-specific stem benchmark reporting ([@sdd](https://github.com/sdd))
+
+- Add tree construction benchmarks ([@sdd](https://github.com/sdd))
+
+
+### 🧹 Chore
+
+- Bump actions/download-artifact from 4 to 8 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
+- Bump actions/upload-artifact from 4 to 7 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
+- Bump actions/setup-python from 5 to 7 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
+- Add external comparison and projection tooling ([@sdd](https://github.com/sdd))
+
+- Remove projection design markdown ([@sdd](https://github.com/sdd))
+
+- Remove throwaway projection benchmark ([@sdd](https://github.com/sdd))
+
 ## [6.0.0-alpha.3] - 2026-07-21
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,15 @@
 
 - Specialize within-radius result projection ([@sdd](https://github.com/sdd))
 
-
 ### 🐛 Bug Fixes
 
 - Handle padded stems in parallel construction ([@sdd](https://github.com/sdd))
-
 
 ### ♻️ Refactor
 
 - Within_unsorted to a visitor ([@sdd](https://github.com/sdd))
 
 - Switch from propagating points as indexes to actual values ([@sdd](https://github.com/sdd))
-
 
 ### 🧪 Testing
 
@@ -30,7 +27,6 @@
 - Add v6 release parity benchmark suites ([@sdd](https://github.com/sdd))
 
 - Add point projection benchmark ([@sdd](https://github.com/sdd))
-
 
 ### 🤖 CI
 
@@ -51,7 +47,6 @@
 - Add ISA-specific stem benchmark reporting ([@sdd](https://github.com/sdd))
 
 - Add tree construction benchmarks ([@sdd](https://github.com/sdd))
-
 
 ### 🧹 Chore
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "6.0.0-alpha.3"
+version = "6.0.0-alpha.4"
 edition = "2021"
 rust-version = "1.89.0"
 authors = ["Scott Donnelly <scott@donnel.ly>"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add `kiddo` to `Cargo.toml`
 
 ```toml
 [dependencies]
-kiddo = "6.0.0-alpha.3"
+kiddo = "6.0.0-alpha.4"
 ```
 
 Add points to a k-d tree and query the nearest points with a distance metric:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/6.0.0-alpha.3")]
+#![doc(html_root_url = "https://docs.rs/kiddo/6.0.0-alpha.4")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 #![allow(clippy::pointers_in_nomem_asm_block)]
 #![allow(clippy::too_many_arguments)]
@@ -105,7 +105,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "6.0.0-alpha.3"
+//! kiddo = "6.0.0-alpha.4"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION



## 🤖 New release

* `kiddo`: 6.0.0-alpha.3 -> 6.0.0-alpha.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.0-alpha.4] - 2026-07-27

### ✨ Features

- Add result capacity hint for radius queries ([@sdd](https://github.com/sdd))

- Add adaptive parallel tree construction ([@sdd](https://github.com/sdd))

- Specialize within-radius result projection ([@sdd](https://github.com/sdd))


### 🐛 Bug Fixes

- Handle padded stems in parallel construction ([@sdd](https://github.com/sdd))


### ♻️ Refactor

- Within_unsorted to a visitor ([@sdd](https://github.com/sdd))

- Switch from propagating points as indexes to actual values ([@sdd](https://github.com/sdd))


### 🧪 Testing

- Add result collection threshold profiler ([@sdd](https://github.com/sdd))

- Add v6 release parity benchmark suites ([@sdd](https://github.com/sdd))

- Add point projection benchmark ([@sdd](https://github.com/sdd))


### 🤖 CI

- Add stem strategy benchmark variant ([@sdd](https://github.com/sdd))

- Rename basic benchmark variant ([@sdd](https://github.com/sdd))

- Pass benchmark features explicitly ([@sdd](https://github.com/sdd))

- Cap leaf benchmark tree size ([@sdd](https://github.com/sdd))

- Fix leaf benchmark export filter ([@sdd](https://github.com/sdd))

- Cap benchmark trees at 2^25 ([@sdd](https://github.com/sdd))

- Fix benchmark v5-v6 chart matching ([@sdd](https://github.com/sdd))

- Add ISA-specific stem benchmark reporting ([@sdd](https://github.com/sdd))

- Add tree construction benchmarks ([@sdd](https://github.com/sdd))


### 🧹 Chore

- Bump actions/download-artifact from 4 to 8 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)

- Bump actions/upload-artifact from 4 to 7 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)

- Bump actions/setup-python from 5 to 7 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)

- Add external comparison and projection tooling ([@sdd](https://github.com/sdd))

- Remove projection design markdown ([@sdd](https://github.com/sdd))

- Remove throwaway projection benchmark ([@sdd](https://github.com/sdd))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).