### PR TITLE
Fix aligned stem deallocation in rkyv conversion

### DIFF
--- a/src/float_leaf_slice/leaf_slice.rs
+++ b/src/float_leaf_slice/leaf_slice.rs
@@ -180,6 +180,8 @@ where
     }
 
     #[inline]
+    // `slice::as_chunks` is unavailable at the crate's Rust 1.85 MSRV.
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     fn as_full_chunks<const C: usize>(&self) -> LeafFixedSliceIterator<'_, A, T, K, C> {
         let points_iterators = self.content_points.map(|i| i.chunks_exact(C));
         let items_iterator = self.content_items.chunks_exact(C);

--- a/src/immutable/float/kdtree.rs
+++ b/src/immutable/float/kdtree.rs
@@ -47,6 +47,8 @@
 //!
 pub use crate::float::kdtree::Axis;
 use crate::float_leaf_slice::leaf_slice::{LeafSlice, LeafSliceFloat, LeafSliceFloatChunk};
+#[cfg(feature = "rkyv")]
+use crate::immutable::float::rkyv_07_aligned_vec::EncodeAVec as EncodeAVec07;
 #[cfg(feature = "rkyv_08")]
 use crate::immutable::float::rkyv_aligned_vec::EncodeAVec;
 #[cfg(feature = "modified_van_emde_boas")]
@@ -115,7 +117,8 @@ pub struct ImmutableKdTree<A: Copy + Default, T: Copy + Default, const K: usize,
 #[cfg(feature = "rkyv")]
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub struct ImmutableKdTreeRK<A: Copy + Default, T: Copy + Default, const K: usize, const B: usize> {
-    pub(crate) stems: Vec<A>,
+    #[with(EncodeAVec07<A>)]
+    pub(crate) stems: AVec<A>,
     pub(crate) leaf_points: [Vec<A>; K],
     pub(crate) leaf_items: Vec<T>,
     pub(crate) leaf_extents: Vec<(u32, u32)>,
@@ -158,9 +161,6 @@ where
             max_stem_level,
         } = orig;
 
-        let (ptr, _, length, capacity) = stems.into_raw_parts();
-        let stems = unsafe { Vec::from_raw_parts(ptr, length, capacity) };
-
         ImmutableKdTreeRK {
             stems,
             leaf_points,
@@ -168,6 +168,61 @@ where
             leaf_extents,
             max_stem_level,
         }
+    }
+}
+
+#[cfg(all(test, feature = "rkyv"))]
+mod rkyv_tests {
+    use super::{ImmutableKdTree, ImmutableKdTreeRK};
+    use aligned_vec::CACHELINE_ALIGN;
+    use rkyv::Deserialize;
+
+    #[test]
+    fn conversion_preserves_aligned_stems_allocation() {
+        let points: Vec<[f64; 3]> = (0..2000)
+            .map(|i| [i as f64, (i * 3 % 977) as f64, (i * 7 % 613) as f64])
+            .collect();
+        let tree: ImmutableKdTree<f64, u32, 3, 32> = ImmutableKdTree::new_from_slice(&points);
+        let aligned_stems_ptr = tree.stems.as_ptr();
+        let tree_rk: ImmutableKdTreeRK<f64, u32, 3, 32> = tree.into();
+
+        assert_eq!(tree_rk.stems.as_ptr(), aligned_stems_ptr);
+        assert_eq!(tree_rk.stems.alignment(), CACHELINE_ALIGN);
+    }
+
+    #[test]
+    fn avec_adapter_preserves_archive_format_and_roundtrips() {
+        #[derive(rkyv::Archive, rkyv::Serialize)]
+        struct LegacyImmutableKdTreeRK {
+            stems: Vec<f64>,
+            leaf_points: [Vec<f64>; 3],
+            leaf_items: Vec<u32>,
+            leaf_extents: Vec<(u32, u32)>,
+            max_stem_level: i32,
+        }
+
+        let points: Vec<[f64; 3]> = (0..2000)
+            .map(|i| [i as f64, (i * 3 % 977) as f64, (i * 7 % 613) as f64])
+            .collect();
+        let tree: ImmutableKdTree<f64, u32, 3, 32> = ImmutableKdTree::new_from_slice(&points);
+        let legacy = LegacyImmutableKdTreeRK {
+            stems: tree.stems.to_vec(),
+            leaf_points: tree.leaf_points.clone(),
+            leaf_items: tree.leaf_items.clone(),
+            leaf_extents: tree.leaf_extents.clone(),
+            max_stem_level: tree.max_stem_level,
+        };
+        let tree_rk: ImmutableKdTreeRK<f64, u32, 3, 32> = tree.into();
+
+        let legacy_bytes = rkyv::to_bytes::<_, 256>(&legacy).unwrap();
+        let bytes = rkyv::to_bytes::<_, 256>(&tree_rk).unwrap();
+        assert_eq!(bytes.as_slice(), legacy_bytes.as_slice());
+
+        let archived = unsafe { rkyv::archived_root::<ImmutableKdTreeRK<f64, u32, 3, 32>>(&bytes) };
+        let deserialized: ImmutableKdTreeRK<f64, u32, 3, 32> =
+            archived.deserialize(&mut rkyv::Infallible).unwrap();
+        assert_eq!(deserialized.stems.as_slice(), tree_rk.stems.as_slice());
+        assert_eq!(deserialized.stems.alignment(), CACHELINE_ALIGN);
     }
 }
 

--- a/src/immutable/float/mod.rs
+++ b/src/immutable/float/mod.rs
@@ -26,5 +26,8 @@ pub mod kdtree;
 #[doc(hidden)]
 pub mod query;
 
+#[cfg(feature = "rkyv")]
+mod rkyv_07_aligned_vec;
+
 #[cfg(feature = "rkyv_08")]
 mod rkyv_aligned_vec;

--- a/src/immutable/float/rkyv_07_aligned_vec.rs
+++ b/src/immutable/float/rkyv_07_aligned_vec.rs
@@ -1,0 +1,56 @@
+use aligned_vec::{AVec, CACHELINE_ALIGN};
+use rkyv::{
+    ser::{ScratchSpace, Serializer},
+    vec::{ArchivedVec, VecResolver},
+    with::{ArchiveWith, DeserializeWith, SerializeWith},
+    Archive, Deserialize, Fallible, Serialize,
+};
+use std::marker::PhantomData;
+
+pub(crate) struct EncodeAVec<T> {
+    _p: PhantomData<T>,
+}
+
+impl<T: Archive> ArchiveWith<AVec<T>> for EncodeAVec<T> {
+    type Archived = ArchivedVec<T::Archived>;
+    type Resolver = VecResolver;
+
+    unsafe fn resolve_with(
+        field: &AVec<T>,
+        pos: usize,
+        resolver: Self::Resolver,
+        out: *mut Self::Archived,
+    ) {
+        ArchivedVec::resolve_from_slice(field.as_slice(), pos, resolver, out);
+    }
+}
+
+impl<T, S> SerializeWith<AVec<T>, S> for EncodeAVec<T>
+where
+    T: Serialize<S>,
+    S: ScratchSpace + Serializer + ?Sized,
+{
+    fn serialize_with(field: &AVec<T>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedVec::serialize_from_slice(field.as_slice(), serializer)
+    }
+}
+
+impl<T, D> DeserializeWith<ArchivedVec<T::Archived>, AVec<T>, D> for EncodeAVec<T>
+where
+    T: Archive,
+    T::Archived: Deserialize<T, D>,
+    D: Fallible + ?Sized,
+{
+    fn deserialize_with(
+        field: &ArchivedVec<T::Archived>,
+        deserializer: &mut D,
+    ) -> Result<AVec<T>, D::Error> {
+        let mut result = AVec::with_capacity(CACHELINE_ALIGN, field.len());
+
+        for item in field.iter() {
+            result.push(item.deserialize(deserializer)?);
+        }
+
+        Ok(result)
+    }
+}

--- a/tests/issue_474.rs
+++ b/tests/issue_474.rs
@@ -1,0 +1,84 @@
+#![cfg(feature = "rkyv")]
+
+use kiddo::immutable::float::kdtree::{ImmutableKdTree, ImmutableKdTreeRK};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+const ALLOCATION_SLOTS: usize = 1024;
+static POINTERS: [AtomicUsize; ALLOCATION_SLOTS] =
+    [const { AtomicUsize::new(0) }; ALLOCATION_SLOTS];
+static SIZES: [AtomicUsize; ALLOCATION_SLOTS] = [const { AtomicUsize::new(0) }; ALLOCATION_SLOTS];
+static ALIGNMENTS: [AtomicUsize; ALLOCATION_SLOTS] =
+    [const { AtomicUsize::new(0) }; ALLOCATION_SLOTS];
+static MISMATCH: [AtomicUsize; 5] = [const { AtomicUsize::new(0) }; 5];
+
+struct TrackingAllocator;
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+
+        if !pointer.is_null() && layout.align() >= 64 {
+            for index in 0..ALLOCATION_SLOTS {
+                if POINTERS[index]
+                    .compare_exchange(0, pointer as usize, SeqCst, SeqCst)
+                    .is_ok()
+                {
+                    SIZES[index].store(layout.size(), SeqCst);
+                    ALIGNMENTS[index].store(layout.align(), SeqCst);
+                    break;
+                }
+            }
+        }
+
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        for index in 0..ALLOCATION_SLOTS {
+            if POINTERS[index].load(SeqCst) == pointer as usize {
+                let allocated_size = SIZES[index].load(SeqCst);
+                let allocated_alignment = ALIGNMENTS[index].load(SeqCst);
+
+                if (allocated_size, allocated_alignment) != (layout.size(), layout.align())
+                    && MISMATCH[0].load(SeqCst) == 0
+                {
+                    MISMATCH[1].store(allocated_size, SeqCst);
+                    MISMATCH[2].store(allocated_alignment, SeqCst);
+                    MISMATCH[3].store(layout.size(), SeqCst);
+                    MISMATCH[4].store(layout.align(), SeqCst);
+                    MISMATCH[0].store(pointer as usize, SeqCst);
+                }
+
+                POINTERS[index].store(usize::MAX, SeqCst);
+                break;
+            }
+        }
+
+        unsafe { System.dealloc(pointer, layout) };
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+#[test]
+fn converting_to_rkyv_tree_deallocates_stems_with_their_original_layout() {
+    let points: Vec<[f64; 3]> = (0..2000)
+        .map(|i| [i as f64, (i * 3 % 977) as f64, (i * 7 % 613) as f64])
+        .collect();
+    let tree: ImmutableKdTree<f64, u32, 3, 32> = ImmutableKdTree::new_from_slice(&points);
+    let tree_rk: ImmutableKdTreeRK<f64, u32, 3, 32> = tree.into();
+    drop(tree_rk);
+
+    assert_eq!(
+        MISMATCH[0].load(SeqCst),
+        0,
+        "allocation layout mismatch: allocated with size={} align={}, \
+         deallocated with size={} align={}",
+        MISMATCH[1].load(SeqCst),
+        MISMATCH[2].load(SeqCst),
+        MISMATCH[3].load(SeqCst),
+        MISMATCH[4].load(SeqCst),
+    );
+}


### PR DESCRIPTION
## Summary

- retain the aligned `AVec` allocation when converting to `ImmutableKdTreeRK`
- archive the aligned stems as `ArchivedVec` through an rkyv 0.7 adapter, preserving the existing archive format
- add ownership, archive compatibility, round-trip, and tracking-allocator regression coverage

## Testing

- `cargo test --all-features --lib --tests`
- `cargo check --all-features --examples`
- `cargo fmt --check`
- `git diff --check`

Fixes #474