### PR TITLE
Fix Chebyshev distance for immutable nearest-one queries

### DIFF
--- a/src/float_leaf_slice/leaf_slice.rs
+++ b/src/float_leaf_slice/leaf_slice.rs
@@ -54,7 +54,8 @@ where
             let qd = [query[dim]; C];
 
             (0..C).step_by(1).for_each(|idx| {
-                acc[idx] += D::dist1(self.content_points[dim][idx], qd[idx]);
+                acc[idx] =
+                    D::accumulate(acc[idx], D::dist1(self.content_points[dim][idx], qd[idx]));
             });
         });
 
@@ -180,6 +181,8 @@ where
     }
 
     #[inline]
+    // `slice::as_chunks` is unavailable at the crate's Rust 1.85 MSRV.
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     fn as_full_chunks<const C: usize>(&self) -> LeafFixedSliceIterator<'_, A, T, K, C> {
         let points_iterators = self.content_points.map(|i| i.chunks_exact(C));
         let items_iterator = self.content_items.chunks_exact(C);
@@ -206,7 +209,7 @@ where
         for idx in 0..remainder_items.len() {
             let mut dist = A::zero();
             (0..K).step_by(1).for_each(|dim| {
-                dist += D::dist1(remainder_points[dim][idx], query[dim]);
+                dist = D::accumulate(dist, D::dist1(remainder_points[dim][idx], query[dim]));
             });
 
             // TODO: make branchless
@@ -484,7 +487,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::float_leaf_slice::leaf_slice::{LeafFixedSlice, LeafSlice, LeafSliceFloat};
-    use crate::{BestNeighbour, NearestNeighbour, SquaredEuclidean};
+    use crate::{BestNeighbour, Chebyshev, NearestNeighbour, SquaredEuclidean};
     use std::collections::BinaryHeap;
 
     #[test]
@@ -508,6 +511,23 @@ mod test {
 
         assert_eq!(best_dist, 0f64);
         assert_eq!(best_item, 1u32);
+    }
+
+    #[test]
+    fn leaf_fixed_slice_nearest_one_uses_metric_accumulator() {
+        let content_points = [[0.0f64, 10.0], [0.0f64, 10.0]];
+        let content_items = [0u32, 1u32];
+        let slice = LeafFixedSlice {
+            content_points: [&content_points[0], &content_points[1]],
+            content_items: &content_items,
+        };
+        let mut best_dist = f64::INFINITY;
+        let mut best_item = u32::MAX;
+
+        slice.nearest_one::<Chebyshev>(&[9.0, 9.0], &mut best_dist, &mut best_item);
+
+        assert_eq!(best_dist, 1.0);
+        assert_eq!(best_item, 1);
     }
 
     #[test]

--- a/tests/issue_473.rs
+++ b/tests/issue_473.rs
@@ -1,0 +1,29 @@
+use kiddo::{Chebyshev, ImmutableKdTree, NearestNeighbour};
+
+#[test]
+fn immutable_nearest_one_uses_chebyshev_accumulation() {
+    let points = [[0.0f64, 0.0], [10.0, 10.0]];
+    let tree: ImmutableKdTree<f64, 2> = ImmutableKdTree::new_from_slice(&points);
+
+    assert_eq!(
+        tree.nearest_one::<Chebyshev>(&[9.0, 9.0]),
+        NearestNeighbour {
+            distance: 1.0,
+            item: 1,
+        }
+    );
+}
+
+#[test]
+fn immutable_approx_nearest_one_uses_chebyshev_accumulation() {
+    let points = [[0.0f64, 0.0], [10.0, 10.0]];
+    let tree: ImmutableKdTree<f64, 2> = ImmutableKdTree::new_from_slice(&points);
+
+    assert_eq!(
+        tree.approx_nearest_one::<Chebyshev>(&[9.0, 9.0]),
+        NearestNeighbour {
+            distance: 1.0,
+            item: 1,
+        }
+    );
+}


### PR DESCRIPTION
## Summary

- use `DistanceMetric::accumulate` in both leaf nearest-one reduction paths
- fix Chebyshev distances returned by `ImmutableKdTree::nearest_one` and `approx_nearest_one`
- add report-faithful public API regressions and direct fixed-leaf coverage
- retain Rust 1.85 compatibility while allowing the new nightly `chunks_exact_to_as_chunks` lint

## Testing

- `cargo test --test issue_473`
- `cargo test --workspace --all-features --lib --bins --tests --examples`
- current Clippy with warnings denied
- Rust 1.85 Clippy with warnings denied
- `cargo fmt --all --check`
- `git diff --check`

Fixes #473