### PR TITLE
fix: allow mutable splits past constant axes

### DIFF
--- a/src/float/construction.rs
+++ b/src/float/construction.rs
@@ -25,6 +25,11 @@ where
     ///
     /// assert_eq!(tree.size(), 1);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if more than `B` items are added at exactly the same point. Mutable v5 trees use
+    /// fixed-size leaf buckets, and identical points cannot be separated by a spatial split.
     #[inline]
     pub fn add(&mut self, query: &[A; K], item: T) {
         unsafe {
@@ -52,16 +57,21 @@ where
             let mut leaf_idx = stem_idx - IDX::leaf_offset();
             let mut leaf_node = self.leaves.get_unchecked_mut(leaf_idx.az::<usize>());
 
-            if leaf_node.size == B.az::<IDX>() {
-                stem_idx = self.split(leaf_idx, split_dim, parent_idx, is_left_child);
+            while leaf_node.size == B.az::<IDX>() {
+                stem_idx = self.split(leaf_idx, split_dim, parent_idx, is_left_child, query);
                 let node = self.stems.get_unchecked_mut(stem_idx.az::<usize>());
 
-                leaf_idx = (if *query.get_unchecked(split_dim) < node.split_val {
+                let child_idx = if *query.get_unchecked(split_dim) < node.split_val {
+                    is_left_child = true;
                     node.left
                 } else {
+                    is_left_child = false;
                     node.right
-                } - IDX::leaf_offset());
+                };
 
+                parent_idx = stem_idx;
+                split_dim = (split_dim + 1).rem(K);
+                leaf_idx = child_idx - IDX::leaf_offset();
                 leaf_node = self.leaves.get_unchecked_mut(leaf_idx.az::<usize>());
             }
 
@@ -150,6 +160,7 @@ where
         split_dim: usize,
         parent_idx: IDX,
         was_parents_left: bool,
+        query: &[A; K],
     ) -> IDX {
         let orig = self.leaves.get_unchecked_mut(leaf_idx.az::<usize>());
         let mut pivot_idx = (B / 2).az::<IDX>();
@@ -211,6 +222,7 @@ where
                 );
 
                 pivot_idx = orig_pivot_idx;
+                let mut all_equal = false;
                 while *orig
                     .content_points
                     .get_unchecked(pivot_idx.az::<usize>())
@@ -220,15 +232,48 @@ where
                     pivot_idx = pivot_idx + IDX::one();
 
                     if pivot_idx.az::<usize>() == B {
-                        panic!("Too many items with the same position on one axis. Bucket size must be increased to at least 1 more than the number of items with the same position on one axis.");
+                        all_equal = true;
+                        break;
                     }
                 }
-            }
 
-            split_val = *orig
-                .content_points
-                .get_unchecked(pivot_idx.az::<usize>())
-                .get_unchecked(split_dim);
+                if all_equal {
+                    let query_val = *query.get_unchecked(split_dim);
+
+                    if query_val > split_val {
+                        // Keep the full original leaf on the left and create an empty right leaf
+                        // for the new point.
+                        split_val = query_val;
+                    } else {
+                        if query_val == split_val
+                            && orig.content_points.iter().all(|point| point == query)
+                        {
+                            panic!(
+                                "Cannot insert another item at {query:?}: this leaf already contains \
+                                 {B} items at exactly the same point. Kiddo v5's fixed-size leaf \
+                                 buckets cannot spatially split points whose coordinates are \
+                                 identical on every axis. Increase the bucket size `B` above the \
+                                 maximum duplicate count, deduplicate the input, or bulk-build a \
+                                 Kiddo v6 `ImmutableKdTree` with soft leaf buckets."
+                            );
+                        }
+
+                        // Put the full original leaf on the right. If the new point has the same
+                        // coordinate, add() will continue to the next split dimension.
+                        pivot_idx = IDX::zero();
+                    }
+                } else {
+                    split_val = *orig
+                        .content_points
+                        .get_unchecked(pivot_idx.az::<usize>())
+                        .get_unchecked(split_dim);
+                }
+            } else {
+                split_val = *orig
+                    .content_points
+                    .get_unchecked(pivot_idx.az::<usize>())
+                    .get_unchecked(split_dim);
+            }
         }
 
         let mut right = LeafNode::new();

--- a/tests/issue_475.rs
+++ b/tests/issue_475.rs
@@ -1,0 +1,57 @@
+use kiddo::{KdTree, SquaredEuclidean};
+
+#[test]
+fn add_accepts_more_than_one_bucket_of_points_sharing_an_axis_coordinate() {
+    let mut tree: KdTree<f64, 2> = KdTree::new();
+
+    for item in 0..33u64 {
+        tree.add(&[5.0, item as f64], item);
+    }
+
+    assert_eq!(tree.size(), 33);
+
+    for item in 0..33u64 {
+        let nearest = tree.nearest_one::<SquaredEuclidean>(&[5.0, item as f64]);
+        assert_eq!(nearest.distance, 0.0);
+        assert_eq!(nearest.item, item);
+    }
+
+    for item in 0..33u64 {
+        assert_eq!(tree.remove(&[5.0, item as f64], item), 1);
+    }
+    assert_eq!(tree.size(), 0);
+}
+
+#[test]
+fn add_can_advance_past_constant_axes_in_either_direction() {
+    type SmallTree = kiddo::float::kdtree::KdTree<f64, u64, 2, 4, u32>;
+
+    let mut above: SmallTree = SmallTree::new();
+    for item in 0..4 {
+        above.add(&[5.0, 5.0], item);
+    }
+    above.add(&[5.0, 6.0], 4);
+
+    let mut below: SmallTree = SmallTree::new();
+    for item in 0..4 {
+        below.add(&[5.0, 5.0], item);
+    }
+    below.add(&[5.0, 4.0], 4);
+
+    assert_eq!(above.nearest_one::<SquaredEuclidean>(&[5.0, 6.0]).item, 4);
+    assert_eq!(below.nearest_one::<SquaredEuclidean>(&[5.0, 4.0]).item, 4);
+}
+
+#[test]
+#[should_panic(
+    expected = "Cannot insert another item at [5.0, 5.0]: this leaf already contains 4 items at \
+                exactly the same point."
+)]
+fn add_rejects_only_an_unsplittable_bucket_of_identical_points() {
+    type SmallTree = kiddo::float::kdtree::KdTree<f64, u64, 2, 4, u32>;
+
+    let mut tree: SmallTree = SmallTree::new();
+    for item in 0..5 {
+        tree.add(&[5.0, 5.0], item);
+    }
+}


### PR DESCRIPTION
## Summary

- replace the shared-axis panic with a valid one-sided split that advances to the next depth-derived split dimension
- continue splitting until the selected leaf has room, allowing collinear points such as the issue reproducer
- retain and document the unavoidable fixed-bucket limit for more than `B` entries at an identical point, with an actionable panic message

## Regression coverage

- reproduces the reported 33-point vertical line and verifies all points can be inserted, queried, and removed
- covers separation above and below a constant axis
- covers the remaining fully-identical-point panic and its message

## Verification

- `cargo test`
- CI-equivalent fixture generation plus `cargo test --workspace --features=serde,rkyv,rkyv_08,test_utils`
- `cargo test --all-features --lib --tests`
- `cargo test --release --features=serde,rkyv,rkyv_08,test_utils --test issue_475`
- Rust 1.85: `cargo test --test issue_475`
- stable/nightly CI Clippy feature commands
- `cargo fmt -- --check`

Closes #475.