### PR TITLE
ci: stop ignoring the pinned v5 lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
-/Cargo.lock
 /.idea
 /perf.data*
 /flamegraph.svg


### PR DESCRIPTION
## Summary

Remove `/Cargo.lock` from `.gitignore` on `v5.x.x`.

The lockfile is intentionally committed to pin the v5 MSRV dependency graph, but release-plz refuses to run while a committed lockfile is also ignored. This change resolves the release-plz failure and allows it to create the next v5 release PR.

## Verification

- confirmed `Cargo.lock` is tracked
- confirmed `git check-ignore Cargo.lock` no longer matches
- `git diff --check`