### PR TITLE
Add batch query API

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -58,12 +58,12 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          options: --features fixed,parallel,rkyv_08,serde --no-deps
+          options: --features fixed,rkyv_08,serde --no-deps
           name: Clippy nightly
 
       - name: Clippy (Nightly)
         if: github.actor == 'dependabot[bot]'
-        run: cargo clippy --features fixed,parallel,rkyv_08,serde --no-deps
+        run: cargo clippy --features fixed,rkyv_08,serde --no-deps
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
@@ -122,11 +122,11 @@ jobs:
 
       - name: Cargo nextest (dev build)
         run: |
-          cargo nextest run --workspace --features "csv,f16,las,parallel,serde,simd,rkyv_08,test_utils"
+          cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
 
       - name: Cargo test (Doctests)
         run: |
-          cargo test --workspace --doc --features "csv,f16,las,parallel,serde,simd,rkyv_08,test_utils"
+          cargo test --workspace --doc --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
 
   test-nightly-release:
     name: Test (Nightly / Release)
@@ -176,7 +176,7 @@ jobs:
 
       - name: Cargo nextest (release build)
         run: |
-          cargo nextest run --workspace --features "csv,f16,las,parallel,serde,simd,rkyv_08,test_utils" --release
+          cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils" --release
 
   test-nightly:
     name: Test (Nightly)

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -58,12 +58,12 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          options: --features fixed,rkyv_08,serde --no-deps
+          options: --features fixed,parallel,rkyv_08,serde --no-deps
           name: Clippy nightly
 
       - name: Clippy (Nightly)
         if: github.actor == 'dependabot[bot]'
-        run: cargo clippy --features fixed,rkyv_08,serde --no-deps
+        run: cargo clippy --features fixed,parallel,rkyv_08,serde --no-deps
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
@@ -122,11 +122,11 @@ jobs:
 
       - name: Cargo nextest (dev build)
         run: |
-          cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
+          cargo nextest run --workspace --features "csv,f16,las,parallel,serde,simd,rkyv_08,test_utils"
 
       - name: Cargo test (Doctests)
         run: |
-          cargo test --workspace --doc --features "csv,f16,las,serde,simd,rkyv_08,test_utils"
+          cargo test --workspace --doc --features "csv,f16,las,parallel,serde,simd,rkyv_08,test_utils"
 
   test-nightly-release:
     name: Test (Nightly / Release)
@@ -176,7 +176,7 @@ jobs:
 
       - name: Cargo nextest (release build)
         run: |
-          cargo nextest run --workspace --features "csv,f16,las,serde,simd,rkyv_08,test_utils" --release
+          cargo nextest run --workspace --features "csv,f16,las,parallel,serde,simd,rkyv_08,test_utils" --release
 
   test-nightly:
     name: Test (Nightly)

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -51,7 +51,7 @@ jobs:
         run: bash .github/scripts/prepare-example-artifacts.sh
 
       - name: Run Clippy
-        run: cargo clippy --features=parallel,serde,rkyv_08,test_utils --no-deps
+        run: cargo clippy --features=serde,rkyv_08,test_utils --no-deps
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
@@ -61,6 +61,12 @@ jobs:
 
       - name: Cargo Hack (check all stable targets and features)
         run: cargo hack check --workspace --each-feature --all-targets --exclude-features simd
+
+      # `--all-targets` unifies features via the dev-dependency on kiddo itself,
+      # which re-enables `multi-threaded`. Check the lib alone so the serial
+      # construction and batch-query fallbacks stay compiled.
+      - name: Check single-threaded fallback paths
+        run: cargo check --lib --no-default-features --features=fixed
 
   test-stable:
     name: Test (Stable)
@@ -95,8 +101,8 @@ jobs:
 
       - name: Cargo nextest
         run: |
-          cargo nextest run --workspace --features=parallel,serde,rkyv_08,test_utils
+          cargo nextest run --workspace --features=serde,rkyv_08,test_utils
 
       - name: Cargo test (Doctests)
         run: |
-          cargo test --workspace --doc --features=parallel,serde,rkyv_08,test_utils
+          cargo test --workspace --doc --features=serde,rkyv_08,test_utils

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -51,7 +51,7 @@ jobs:
         run: bash .github/scripts/prepare-example-artifacts.sh
 
       - name: Run Clippy
-        run: cargo clippy --features=serde,rkyv_08,test_utils --no-deps
+        run: cargo clippy --features=parallel,serde,rkyv_08,test_utils --no-deps
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
@@ -95,8 +95,8 @@ jobs:
 
       - name: Cargo nextest
         run: |
-          cargo nextest run --workspace --features=serde,rkyv_08,test_utils
+          cargo nextest run --workspace --features=parallel,serde,rkyv_08,test_utils
 
       - name: Cargo test (Doctests)
         run: |
-          cargo test --workspace --doc --features=serde,rkyv_08,test_utils
+          cargo test --workspace --doc --features=parallel,serde,rkyv_08,test_utils

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ all-features = true
 [features]
 cargo_asm = ["dep:rand", "dep:rand_chacha"]
 csv = ["dep:csv"]
-default = ["fixed"]
+default = ["fixed", "multi-threaded"]
 buffered_result_collection = ["dep:smallvec"]
 huge_pages = ["dep:libc"]
 leaf_view_chunked = []
@@ -42,7 +42,7 @@ logging_off = [
 ]
 no_inline = []
 las = ["dep:las"]
-parallel = ["dep:rayon"]
+multi-threaded = ["dep:rayon"]
 result_collection_stats = []
 serde = ["dep:serde", "serde/derive", "fixed/serde", "aligned-vec/serde"]
 simd = []
@@ -111,6 +111,7 @@ optional = true
 
 [dependencies.rayon]
 version = "1"
+optional = true
 
 [dependencies.rkyv_08]
 package = "rkyv"
@@ -157,7 +158,6 @@ radians = "0.3"
 rand = "0.10"
 rand_09 = { package = "rand", version = "0.9", features = ["small_rng"] }
 rand_distr = "0.6"
-rayon = "1"
 reqwest = { version = "0.13", default-features = false, features = [
   "blocking",
   "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ logging_off = [
 ]
 no_inline = []
 las = ["dep:las"]
+parallel = ["dep:rayon"]
 result_collection_stats = []
 serde = ["dep:serde", "serde/derive", "fixed/serde", "aligned-vec/serde"]
 simd = []

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ assert_eq!(results[0].item, 0);
 assert_eq!(results[1].item, 2);
 ```
 
-Enable the `parallel` feature to let Kiddo spread a batch across multiple threads. Results stay indexed by query position no matter how the work was scheduled, and `for_each` is available for allocation-free streaming.
+Batches spread across multiple threads by default, via the `multi-threaded` feature. Results stay indexed by query position no matter how the work was scheduled, and `for_each` is available for allocation-free streaming.
 
 How a batch is scheduled — the order query points are executed in, which thread runs each one, and how work is grouped — is deliberately unspecified, so that batch execution can keep getting faster without breaking callers. The `kiddo::batch` module documents exactly what is and is not guaranteed.
 
@@ -212,7 +212,9 @@ Kiddo exposes a number of optional crate features:
 
 - `simd` **(NIGHTLY)** enables handwritten SIMD and prefetch intrinsics for additional performance where available. This requires a nightly Rust toolchain.
 
-- `parallel` lets batch queries spread their work across multiple threads via [`rayon`](https://docs.rs/rayon/latest/rayon/). Batch queries compile and run either way; without this feature they execute on the calling thread.
+- `multi-threaded` **(default)** lets tree construction and batch queries use multiple threads, via the current [`rayon`](https://docs.rs/rayon/latest/rayon/) thread pool, and is what pulls `rayon` in as a dependency.
+
+  Disabling it drops that dependency and configures the threaded APIs out rather than quietly downgrading them: `ParallelConstruction`, `KdTreeBuilder::with_parallel_construction`, the `*_parallel` constructors, `Executor::parallel()` and `Executor::with_min_queries_per_task()` no longer exist, so code that used them fails to compile instead of silently running on one thread. Whatever still compiles keeps working and produces identical trees and results. Use it for WASM, embedded, or single-core targets, or wherever an extra dependency is not worth it.
 
 - `huge_pages` enables Linux-specific huge-page advice helpers for owned and archived tree storage.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,31 @@ let neighbours = kdtree
 assert_eq!(neighbours.len(), 2);
 ```
 
+## Batch Queries
+
+When many query points are known up front, run them as one batch. A batch query is configured exactly like a single-point query and returns one result per query point, indexed by position in the input slice:
+
+```rust
+use kiddo::{ImmutableKdTree, SquaredEuclidean};
+
+let entries = vec![[0f64, 0f64], [1f64, 1f64], [2f64, 2f64]];
+let kdtree = ImmutableKdTree::new_from_slice(&entries).unwrap();
+
+let queries = [[0.1f64, 0.1], [1.9, 1.9]];
+
+let results = kdtree
+    .query_batch(&queries)
+    .nearest_one::<SquaredEuclidean<f64>>()
+    .execute();
+
+assert_eq!(results[0].item, 0);
+assert_eq!(results[1].item, 2);
+```
+
+Enable the `parallel` feature to let Kiddo spread a batch across multiple threads. Results stay indexed by query position no matter how the work was scheduled, and `for_each` is available for allocation-free streaming.
+
+How a batch is scheduled — the order query points are executed in, which thread runs each one, and how work is grouped — is deliberately unspecified, so that batch execution can keep getting faster without breaking callers. The `kiddo::batch` module documents exactly what is and is not guaranteed.
+
 ## Optional Features
 
 Kiddo exposes a number of optional crate features:
@@ -186,6 +211,8 @@ Kiddo exposes a number of optional crate features:
 - `rkyv_08` enables zero-copy serialization and deserialization via [`rkyv`](https://docs.rs/rkyv/latest/rkyv/) 0.8.x. This is particularly useful for prebuilt immutable trees that you want to load very quickly, especially in conjunction with memory-mapped files.
 
 - `simd` **(NIGHTLY)** enables handwritten SIMD and prefetch intrinsics for additional performance where available. This requires a nightly Rust toolchain.
+
+- `parallel` lets batch queries spread their work across multiple threads via [`rayon`](https://docs.rs/rayon/latest/rayon/). Batch queries compile and run either way; without this feature they execute on the calling thread.
 
 - `huge_pages` enables Linux-specific huge-page advice helpers for owned and archived tree storage.
 

--- a/src/kd_tree/builder.rs
+++ b/src/kd_tree/builder.rs
@@ -2,21 +2,26 @@ use crate::kd_tree::ConstructionError;
 use crate::traits::leaf_strategy::ConstructibleLeafStrategy;
 use crate::{Axis, Content, KdTree, StemStrategy};
 
-use super::construction::{
-    validate_auto_generated_items, ParallelConstruction, SerialConstruction,
-    DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD,
-};
+use super::construction::{validate_auto_generated_items, DefaultConstruction, SerialConstruction};
+#[cfg(feature = "multi-threaded")]
+use super::construction::{ParallelConstruction, DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD};
 
 /// Configures how a [`KdTree`] is constructed.
 ///
-/// The builder defaults to parallel construction at or above
-/// [`DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD`] points, using the current Rayon
-/// thread pool. Callers can use [`rayon::ThreadPool::install`] to control its
-/// thread count, or [`KdTreeBuilder::with_serial_construction`] to opt out.
+/// With the default `multi-threaded` feature the builder starts from parallel
+/// construction at or above `DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD` points,
+/// using the current Rayon thread pool. Callers can use
+/// `rayon::ThreadPool::install` to control its thread count, or
+/// [`KdTreeBuilder::with_serial_construction`] to opt out.
+///
+/// Without that feature the parallel policy does not exist: the builder starts
+/// from [`SerialConstruction`], and `with_parallel_construction` and its
+/// threshold variant are not compiled. See [`DefaultConstruction`].
 ///
 /// # Examples
 ///
 /// ```rust
+/// # #[cfg(feature = "multi-threaded")] {
 /// use kiddo::leaf_strategy::FlatVec;
 /// use kiddo::{Eytzinger, KdTree};
 ///
@@ -25,13 +30,17 @@ use super::construction::{
 /// let points = vec![[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]];
 /// let tree = Tree::builder()
 ///     .with_parallel_construction_threshold(1_000)
-///     .build_from_slice(&points)?;
+///     .build_from_slice(&points)
+///     .unwrap();
 ///
 /// assert_eq!(tree.size(), 2);
-/// # Ok::<(), kiddo::kd_tree::ConstructionError>(())
+/// # }
 /// ```
 #[must_use = "a construction builder does nothing until a build method is called"]
-pub struct KdTreeBuilder<A, T, SS, LS, const K: usize, const B: usize, P = ParallelConstruction> {
+pub struct KdTreeBuilder<A, T, SS, LS, const K: usize, const B: usize, P = DefaultConstruction> {
+    // Only the parallel build path reads the policy; the serial one is a ZST
+    // marker, so without `multi-threaded` this field is never loaded.
+    #[cfg_attr(not(feature = "multi-threaded"), allow(dead_code))]
     pub(in crate::kd_tree) policy: P,
     pub(in crate::kd_tree) _phantom: std::marker::PhantomData<(A, T, SS, LS)>,
 }
@@ -49,6 +58,9 @@ impl<A, T, SS, LS, const K: usize, const B: usize, P> KdTreeBuilder<A, T, SS, LS
     ///
     /// Hard-bucket strategies currently retain their serial construction
     /// algorithm.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     pub fn with_parallel_construction(
         self,
     ) -> KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction> {
@@ -63,6 +75,9 @@ impl<A, T, SS, LS, const K: usize, const B: usize, P> KdTreeBuilder<A, T, SS, LS
     ///
     /// The threshold also controls recursive Rayon join granularity.
     /// A threshold of zero is treated as forced parallel construction.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     pub fn with_parallel_construction_threshold(
         self,
         item_count: usize,
@@ -163,6 +178,7 @@ where
     }
 }
 
+#[cfg(feature = "multi-threaded")]
 impl<A, T, SS, LS, const K: usize, const B: usize> Default
     for KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction>
 {
@@ -174,6 +190,7 @@ impl<A, T, SS, LS, const K: usize, const B: usize> Default
     }
 }
 
+#[cfg(feature = "multi-threaded")]
 impl<A, T, SS, LS, const K: usize, const B: usize>
     KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction>
 where
@@ -242,6 +259,7 @@ where
     }
 }
 
+#[cfg(feature = "multi-threaded")]
 impl<A, SS, LS, const K: usize, const B: usize>
     KdTreeBuilder<A, (), SS, LS, K, B, ParallelConstruction>
 where

--- a/src/kd_tree/construction/mod.rs
+++ b/src/kd_tree/construction/mod.rs
@@ -10,10 +10,12 @@ use crate::{Axis, Content, KdTree, StemStrategy};
 
 use super::builder::KdTreeBuilder;
 
+#[cfg(feature = "multi-threaded")]
 mod parallel;
 mod serial;
 mod shared;
 
+#[cfg(feature = "multi-threaded")]
 pub use parallel::ParallelConstruction;
 pub use serial::SerialConstruction;
 pub(in crate::kd_tree) use shared::validate_auto_generated_items;
@@ -21,7 +23,25 @@ use shared::{
     construction_index_fits_u32, ConstructionIndex, ConstructionLeafScratch, SoftConstructionMode,
 };
 
+/// The construction policy [`KdTree::builder`] starts from.
+///
+/// This is [`ParallelConstruction`] with the `multi-threaded` feature enabled,
+/// and [`SerialConstruction`] without it.
+#[cfg(feature = "multi-threaded")]
+pub type DefaultConstruction = ParallelConstruction;
+
+/// The construction policy [`KdTree::builder`] starts from.
+///
+/// This is `ParallelConstruction` with the `multi-threaded` feature enabled,
+/// and [`SerialConstruction`] without it.
+#[cfg(not(feature = "multi-threaded"))]
+pub type DefaultConstruction = SerialConstruction;
+
 /// Point-count threshold used by the default adaptive construction policy.
+///
+/// Requires the `multi-threaded` feature; without it construction is always
+/// serial and there is no threshold to cross.
+#[cfg(feature = "multi-threaded")]
 pub const DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD: usize = 262_144;
 
 impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
@@ -294,7 +314,7 @@ where
     /// source length cannot be represented by `T`.
     ///
     /// Construction is serial below
-    /// [`DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD`] points and parallel at or
+    /// `DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD` points and parallel at or
     /// above it. Use [`KdTree::builder`] to select a different threshold or
     /// force either construction mode.
     ///
@@ -334,14 +354,17 @@ where
 
     /// Creates a `KdTree` from a slice of points using parallel construction.
     ///
+    /// Requires the `multi-threaded` feature.
+    ///
     /// This compatibility convenience constructor uses the same thresholded
     /// policy as [`KdTree::new_from_slice`]. Use
     /// [`KdTreeBuilder::with_parallel_construction`] to force the parallel
     /// algorithm below the default threshold.
     ///
     /// This method runs on the current Rayon thread pool. Use
-    /// [`rayon::ThreadPool::install`] when a caller needs to select a specific
+    /// `rayon::ThreadPool::install` when a caller needs to select a specific
     /// thread count.
+    #[cfg(feature = "multi-threaded")]
     pub fn new_from_slice_parallel(source: &[[A; K]]) -> Result<Self, ConstructionError>
     where
         A: Send + Sync,
@@ -437,6 +460,9 @@ where
     /// policy as [`KdTree::new_from_source`]. Coordinate access must be
     /// thread-safe because partitioning may invoke `axis_at` concurrently.
     /// Item construction remains sequential.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     pub fn new_from_source_parallel<X, FA, FI>(
         source: &[X],
         axis_at: FA,
@@ -490,6 +516,9 @@ where
 
     /// Creates a `KdTree` from item/point pairs using the default thresholded
     /// parallel construction policy.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     pub fn new_from_entries_parallel(source: &[(T, [A; K])]) -> Result<Self, ConstructionError>
     where
         A: Send + Sync,
@@ -535,6 +564,7 @@ where
         }
     }
 
+    #[cfg(feature = "multi-threaded")]
     pub(in crate::kd_tree) fn new_from_source_with_parallel_policy<X, FA, FI>(
         source: &[X],
         axis_at: FA,
@@ -782,6 +812,9 @@ where
 
     /// Creates a `KdTree` with no stored items using the default thresholded
     /// parallel construction policy.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     pub fn new_from_slice_no_items_parallel(source: &[[A; K]]) -> Result<Self, ConstructionError>
     where
         A: Send + Sync,

--- a/src/kd_tree/construction/tests.rs
+++ b/src/kd_tree/construction/tests.rs
@@ -173,6 +173,7 @@ fn unsplittable_immutable_hard_bucket_returns_error() {
     ));
 }
 
+#[cfg(feature = "multi-threaded")]
 #[test]
 fn mutable_split_preserves_point_item_associations_when_pivot_scan_retries() {
     type TestTree = KdTree<f32, u32, Eytzinger, VecOfArrays<f32, u32, 2, 16>, 2, 16>;
@@ -251,6 +252,7 @@ fn parallel_construction_threshold_is_inclusive() {
     assert_eq!(DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD, 262_144);
 }
 
+#[cfg(feature = "multi-threaded")]
 #[test]
 fn parallel_soft_construction_matches_sequential_construction() {
     type FlatTree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, 2, 32>, 2, 32>;
@@ -312,6 +314,7 @@ fn parallel_soft_construction_matches_sequential_construction() {
     assert_parallel_matches!(ArenaTree);
 }
 
+#[cfg(feature = "multi-threaded")]
 #[test]
 fn parallel_soft_construction_handles_block_strategy_root_padding() {
     type TestTree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 2, 4>, 2, 4>;
@@ -356,6 +359,7 @@ fn parallel_soft_construction_handles_block_strategy_root_padding() {
     }
 }
 
+#[cfg(feature = "multi-threaded")]
 #[test]
 fn parallel_constructor_preserves_hard_bucket_construction() {
     type TestTree = KdTree<f32, u32, Eytzinger, VecOfArrays<f32, u32, 2, 32>, 2, 32>;
@@ -376,6 +380,7 @@ fn parallel_constructor_preserves_hard_bucket_construction() {
     );
 }
 
+#[cfg(feature = "multi-threaded")]
 #[test]
 fn builder_supports_parallel_entries_sources_and_no_items() {
     type ItemTree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, 2, 32>, 2, 32>;

--- a/src/kd_tree/mod.rs
+++ b/src/kd_tree/mod.rs
@@ -19,7 +19,7 @@ mod builder;
 mod construction;
 mod iter;
 pub(crate) mod orchestrator;
-mod query;
+pub(crate) mod query;
 pub(crate) mod query_context;
 pub(crate) mod query_stack;
 pub(crate) mod query_stack_simd;

--- a/src/kd_tree/mod.rs
+++ b/src/kd_tree/mod.rs
@@ -31,9 +31,14 @@ use nonmax::NonMaxUsize;
 #[doc(hidden)]
 pub use crate::traits::kd_tree::{KdTreeAccessor, StemLeafResolution};
 pub use builder::KdTreeBuilder;
-pub use construction::DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD;
+pub use construction::DefaultConstruction;
+#[cfg(feature = "multi-threaded")]
 #[doc(hidden)]
-pub use construction::{ParallelConstruction, SerialConstruction};
+pub use construction::ParallelConstruction;
+#[doc(hidden)]
+pub use construction::SerialConstruction;
+#[cfg(feature = "multi-threaded")]
+pub use construction::DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD;
 pub use iter::{KdTreeIter, WithinUnsortedIter};
 #[doc(hidden)]
 pub use orchestrator::KdTreeQueryOps;

--- a/src/kd_tree/query/batch.rs
+++ b/src/kd_tree/query/batch.rs
@@ -1,0 +1,1258 @@
+//! Batch query execution.
+//!
+//! Batch queries run many query points against one tree in a single call. The
+//! API deliberately says as little as possible about *how* that happens, so
+//! that the execution strategy can keep improving without breaking callers.
+//!
+//! # What is guaranteed
+//!
+//! * Results are addressed by the **index of the query point in the input
+//!   slice**. [`BatchResults`] and [`BatchGroups`] are indexed the same way as
+//!   `queries`, and [`BatchQueryBuilder::for_each`] passes the index alongside
+//!   each result.
+//! * Every query point produces exactly one entry.
+//! * Results are identical to running the same query individually through
+//!   [`KdTree::query`](crate::kd_tree::KdTree::query).
+//!
+//! # What is explicitly *not* guaranteed
+//!
+//! These are the degrees of freedom the implementation reserves, and they may
+//! change in any release:
+//!
+//! * The order in which query points are executed.
+//! * Which thread executes any given query point, or how many threads are used.
+//! * Whether query points are copied, reordered, grouped, or interleaved
+//!   internally.
+//! * The order in which a [`for_each`](BatchQueryBuilder::for_each) visitor is
+//!   invoked, and which thread invokes it.
+//! * The in-memory representation of [`BatchResults`] and [`BatchGroups`].
+//!
+//! Code that depends on any of the above is relying on unspecified behaviour.
+
+use std::collections::BinaryHeap;
+use std::num::NonZeroUsize;
+use std::ops::{Deref, Index};
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use super::builder::{
+    ApproxQueryBuilder, BestNWithinQueryBuilder, ExclusiveBoundariesQueryBuilder,
+    ExecuteQueryBuilder, NearestNQueryBuilder, NearestOneQueryBuilder,
+    PeriodicBoundaryConditionQueryBuilder, UnsortedQueryBuilder, WithDistancesQueryBuilder,
+    WithItemsQueryBuilder, WithPointsQueryBuilder, WithResultCapacityQueryBuilder,
+    WithinQueryBuilder, WithoutDistancesQueryBuilder, WithoutItemsQueryBuilder,
+    WithoutPointsQueryBuilder,
+};
+use crate::dist::DistanceMetric;
+use crate::results::query_result_item::QueryResultItem;
+
+/// How a batch query should be executed.
+///
+/// This is an opaque scheduling policy rather than a thread-pool handle. It
+/// carries a coarse choice (serial vs parallel) plus advisory hints; the
+/// meaning of the hints, and the machinery used to honour them, may change
+/// between releases.
+///
+/// To run a batch on a specific Rayon thread pool, use Rayon's own scoping:
+///
+/// ```ignore
+/// pool.install(|| tree.query_batch(&queries).nearest_one::<D>().execute());
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use kiddo::batch::Executor;
+/// use std::num::NonZeroUsize;
+///
+/// let executor = Executor::parallel()
+///     .with_min_queries_per_task(NonZeroUsize::new(256).unwrap());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Executor {
+    kind: ExecutorKind,
+    min_queries_per_task: Option<NonZeroUsize>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ExecutorKind {
+    Serial,
+    Parallel,
+}
+
+impl Default for Executor {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Executor {
+    /// Creates the default executor.
+    ///
+    /// The default is parallel execution when the `parallel` feature is
+    /// enabled, and serial execution otherwise.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            kind: if cfg!(feature = "parallel") {
+                ExecutorKind::Parallel
+            } else {
+                ExecutorKind::Serial
+            },
+            min_queries_per_task: None,
+        }
+    }
+
+    /// Creates an executor that runs every query on the calling thread.
+    ///
+    /// Query points are still processed in an unspecified order.
+    #[inline]
+    pub fn serial() -> Self {
+        Self {
+            kind: ExecutorKind::Serial,
+            min_queries_per_task: None,
+        }
+    }
+
+    /// Creates an executor that may spread queries across multiple threads.
+    ///
+    /// Falls back to serial execution when the `parallel` feature is disabled,
+    /// so that enabling or disabling the feature never changes which code
+    /// compiles.
+    #[inline]
+    pub fn parallel() -> Self {
+        Self {
+            kind: ExecutorKind::Parallel,
+            min_queries_per_task: None,
+        }
+    }
+
+    /// Hints at the smallest number of query points worth handing to one task.
+    ///
+    /// This is advisory. It exists so that callers with unusually cheap or
+    /// unusually expensive queries can nudge the scheduler, and it may be
+    /// ignored entirely.
+    #[inline]
+    pub fn with_min_queries_per_task(mut self, min_queries_per_task: NonZeroUsize) -> Self {
+        self.min_queries_per_task = Some(min_queries_per_task);
+        self
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline]
+    fn is_parallel(&self) -> bool {
+        matches!(self.kind, ExecutorKind::Parallel)
+    }
+
+    #[cfg(feature = "parallel")]
+    #[inline]
+    fn min_len(&self) -> usize {
+        self.min_queries_per_task.map_or(1, NonZeroUsize::get)
+    }
+}
+
+/// One result per query point, addressed by query index.
+///
+/// Returned by [`BatchQueryBuilder::execute`] for query families that produce a
+/// single result per query point, such as
+/// [`nearest_one`](BatchQueryBuilder::nearest_one).
+///
+/// The internal representation is not part of the public API; access results
+/// through the slice-oriented methods, or take ownership with
+/// [`into_vec`](Self::into_vec).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchResults<R> {
+    results: Vec<R>,
+}
+
+impl<R> BatchResults<R> {
+    #[inline]
+    pub(crate) fn from_vec(results: Vec<R>) -> Self {
+        Self { results }
+    }
+
+    /// Returns the number of query points in the batch.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Returns `true` if the batch contained no query points.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty()
+    }
+
+    /// Returns the result for the query point at `index`, if in range.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&R> {
+        self.results.get(index)
+    }
+
+    /// Returns all results, in query-point order.
+    #[inline]
+    pub fn as_slice(&self) -> &[R] {
+        &self.results
+    }
+
+    /// Iterates over results in query-point order.
+    #[inline]
+    pub fn iter(&self) -> std::slice::Iter<'_, R> {
+        self.results.iter()
+    }
+
+    /// Converts into a `Vec` of results, in query-point order.
+    #[inline]
+    pub fn into_vec(self) -> Vec<R> {
+        self.results
+    }
+}
+
+impl<R> Deref for BatchResults<R> {
+    type Target = [R];
+
+    #[inline]
+    fn deref(&self) -> &[R] {
+        &self.results
+    }
+}
+
+impl<R> Index<usize> for BatchResults<R> {
+    type Output = R;
+
+    #[inline]
+    fn index(&self, index: usize) -> &R {
+        &self.results[index]
+    }
+}
+
+impl<R> IntoIterator for BatchResults<R> {
+    type Item = R;
+    type IntoIter = std::vec::IntoIter<R>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.results.into_iter()
+    }
+}
+
+impl<'r, R> IntoIterator for &'r BatchResults<R> {
+    type Item = &'r R;
+    type IntoIter = std::slice::Iter<'r, R>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.results.iter()
+    }
+}
+
+/// A group of results per query point, addressed by query index.
+///
+/// Returned by [`BatchQueryBuilder::execute`] for query families that produce
+/// zero or more results per query point, such as
+/// [`nearest_n`](BatchQueryBuilder::nearest_n),
+/// [`within`](BatchQueryBuilder::within) and
+/// [`best_n_within`](BatchQueryBuilder::best_n_within).
+///
+/// Groups are exposed as slices so that the underlying storage can change —
+/// for example to a single flat allocation — without breaking callers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatchGroups<R> {
+    groups: Vec<Vec<R>>,
+}
+
+impl<R> BatchGroups<R> {
+    #[inline]
+    pub(crate) fn from_nested_vec(groups: Vec<Vec<R>>) -> Self {
+        Self { groups }
+    }
+
+    /// Returns the number of query points in the batch.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Returns `true` if the batch contained no query points.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+
+    /// Returns the total number of results across every query point.
+    #[inline]
+    pub fn total_len(&self) -> usize {
+        self.groups.iter().map(Vec::len).sum()
+    }
+
+    /// Returns the results for the query point at `index`, if in range.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&[R]> {
+        self.groups.get(index).map(Vec::as_slice)
+    }
+
+    /// Iterates over per-query-point result groups, in query-point order.
+    #[inline]
+    pub fn iter(&self) -> GroupIter<'_, R> {
+        GroupIter {
+            inner: self.groups.iter(),
+        }
+    }
+
+    /// Converts into one `Vec` per query point, in query-point order.
+    #[inline]
+    pub fn into_nested_vec(self) -> Vec<Vec<R>> {
+        self.groups
+    }
+
+    /// Concatenates every group into one `Vec`, in query-point order.
+    ///
+    /// Group boundaries are lost; use this when only the union of results
+    /// matters.
+    #[inline]
+    pub fn into_flat_vec(self) -> Vec<R> {
+        let mut flat = Vec::with_capacity(self.total_len());
+        for group in self.groups {
+            flat.extend(group);
+        }
+        flat
+    }
+}
+
+impl<R> Index<usize> for BatchGroups<R> {
+    type Output = [R];
+
+    #[inline]
+    fn index(&self, index: usize) -> &[R] {
+        &self.groups[index]
+    }
+}
+
+impl<'g, R> IntoIterator for &'g BatchGroups<R> {
+    type Item = &'g [R];
+    type IntoIter = GroupIter<'g, R>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over the per-query-point result groups of a [`BatchGroups`].
+#[derive(Clone, Debug)]
+pub struct GroupIter<'g, R> {
+    inner: std::slice::Iter<'g, Vec<R>>,
+}
+
+impl<'g, R> Iterator for GroupIter<'g, R> {
+    type Item = &'g [R];
+
+    #[inline]
+    fn next(&mut self) -> Option<&'g [R]> {
+        self.inner.next().map(Vec::as_slice)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<R> ExactSizeIterator for GroupIter<'_, R> {}
+
+impl<R> DoubleEndedIterator for GroupIter<'_, R> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(Vec::as_slice)
+    }
+}
+
+/// Maps a single-query result type onto the container used to hold a batch of
+/// them.
+///
+/// Implementation detail of [`BatchQueryBuilder::execute`].
+#[doc(hidden)]
+pub trait BatchCollect: Sized {
+    #[doc(hidden)]
+    type Batch;
+
+    #[doc(hidden)]
+    fn collect_batch(results: Vec<Self>) -> Self::Batch;
+}
+
+impl<P, T, D> BatchCollect for QueryResultItem<P, T, D> {
+    type Batch = BatchResults<Self>;
+
+    #[inline]
+    fn collect_batch(results: Vec<Self>) -> Self::Batch {
+        BatchResults::from_vec(results)
+    }
+}
+
+impl<R> BatchCollect for Vec<R> {
+    type Batch = BatchGroups<R>;
+
+    #[inline]
+    fn collect_batch(results: Vec<Self>) -> Self::Batch {
+        BatchGroups::from_nested_vec(results)
+    }
+}
+
+impl<R: Ord> BatchCollect for BinaryHeap<R> {
+    type Batch = BatchGroups<R>;
+
+    #[inline]
+    fn collect_batch(results: Vec<Self>) -> Self::Batch {
+        BatchGroups::from_nested_vec(
+            results
+                .into_iter()
+                .map(BinaryHeap::into_sorted_vec)
+                .collect(),
+        )
+    }
+}
+
+/// A configured single-point query that a batch can re-point at each query
+/// point in turn.
+///
+/// Implementation detail of [`BatchQueryBuilder`].
+#[doc(hidden)]
+pub trait BatchQuerySink<'a, A, const K: usize>: Copy {
+    #[doc(hidden)]
+    fn set_query_point(&mut self, query: &'a [A; K]);
+}
+
+/// A fluent batch query builder, created by
+/// [`KdTree::query_batch`](crate::kd_tree::KdTree::query_batch).
+///
+/// A batch query is configured exactly like a single-point query — the same
+/// query families, modifiers and result projections are available, with the
+/// same names — and differs only in its terminal methods, which return one
+/// result per query point instead of one result overall.
+///
+/// ```
+/// use kiddo::batch::Executor;
+/// use kiddo::dist::SquaredEuclidean;
+/// use kiddo::leaf_strategy::FlatVec;
+/// use kiddo::{Eytzinger, KdTree};
+/// use std::num::NonZeroUsize;
+///
+/// type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+///
+/// let entries = [(10_u32, [0.0, 0.0]), (11_u32, [1.0, 1.0]), (12_u32, [0.2, 0.1])];
+/// let tree = Tree::new_from_entries(&entries).unwrap();
+///
+/// let queries = [[0.1, 0.1], [0.9, 0.9], [0.25, 0.15]];
+///
+/// let results = tree
+///     .query_batch(&queries)
+///     .nearest_one::<SquaredEuclidean<f64>>()
+///     .execute();
+///
+/// assert_eq!(results.len(), 3);
+/// assert_eq!(results[0].item, 12);
+/// assert_eq!(results[1].item, 11);
+/// ```
+///
+/// See the [module documentation](self) for exactly which properties of batch
+/// execution are guaranteed and which are free to change.
+pub struct BatchQueryBuilder<'a, Qb, A, const K: usize> {
+    /// The configured single-point query, cloned per query point at execution
+    /// time. `None` only when the batch is empty, in which case there is no
+    /// query point to anchor the prototype's borrow.
+    prototype: Option<Qb>,
+    queries: &'a [[A; K]],
+    executor: Executor,
+}
+
+impl<'a, Qb, A, const K: usize> BatchQueryBuilder<'a, Qb, A, K> {
+    #[inline]
+    pub(crate) fn new(prototype: Option<Qb>, queries: &'a [[A; K]]) -> Self {
+        Self {
+            prototype,
+            queries,
+            executor: Executor::new(),
+        }
+    }
+
+    /// Applies a single-point builder transition to the batch's prototype.
+    #[inline]
+    fn map<Qb2>(self, transition: impl FnOnce(Qb) -> Qb2) -> BatchQueryBuilder<'a, Qb2, A, K> {
+        BatchQueryBuilder {
+            prototype: self.prototype.map(transition),
+            queries: self.queries,
+            executor: self.executor,
+        }
+    }
+
+    /// Returns the number of query points in the batch.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.queries.len()
+    }
+
+    /// Returns `true` if the batch contains no query points.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.queries.is_empty()
+    }
+
+    /// Sets the execution policy for this batch.
+    ///
+    /// Defaults to [`Executor::new`].
+    #[inline]
+    pub fn with_executor(mut self, executor: &Executor) -> Self {
+        self.executor = executor.clone();
+        self
+    }
+}
+
+/// Query family selection and result projection.
+///
+/// Each method mirrors the identically-named method on
+/// [`QueryBuilder`](crate::kd_tree::QueryBuilder) and is available under
+/// exactly the same conditions.
+impl<'a, Qb, A, const K: usize> BatchQueryBuilder<'a, Qb, A, K> {
+    /// Excludes stored point coordinates from the eventual query results.
+    #[inline]
+    pub fn without_points(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: WithoutPointsQueryBuilder,
+    {
+        self.map(Qb::without_points)
+    }
+
+    /// Includes stored point coordinates in the eventual query results.
+    #[inline]
+    pub fn with_points(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: WithPointsQueryBuilder,
+    {
+        self.map(Qb::with_points)
+    }
+
+    /// Includes stored items in the eventual query results.
+    #[inline]
+    pub fn with_items(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: WithItemsQueryBuilder,
+    {
+        self.map(Qb::with_items)
+    }
+
+    /// Excludes stored items from the eventual query results.
+    #[inline]
+    pub fn without_items(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: WithoutItemsQueryBuilder,
+    {
+        self.map(Qb::without_items)
+    }
+
+    /// Includes distances in the eventual query results.
+    #[inline]
+    pub fn with_distances(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: WithDistancesQueryBuilder,
+    {
+        self.map(Qb::with_distances)
+    }
+
+    /// Excludes distances from the eventual query results.
+    #[inline]
+    pub fn without_distances(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: WithoutDistancesQueryBuilder,
+    {
+        self.map(Qb::without_distances)
+    }
+
+    /// Interprets every query point in the batch using periodic boundary
+    /// conditions.
+    #[inline]
+    pub fn periodic_boundary_condition(
+        self,
+        box_size: &'a [A; K],
+    ) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: PeriodicBoundaryConditionQueryBuilder<'a, A, K>,
+    {
+        self.map(|prototype| prototype.periodic_boundary_condition(box_size))
+    }
+
+    /// Selects an exact nearest-neighbour query.
+    #[inline]
+    pub fn nearest_one<Dq>(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        A: Copy,
+        Dq: DistanceMetric<A>,
+        Qb: NearestOneQueryBuilder<A, K, Dq>,
+    {
+        self.map(Qb::nearest_one)
+    }
+
+    /// Selects a k-nearest-neighbours query.
+    #[inline]
+    pub fn nearest_n<Dq>(self, max_qty: NonZeroUsize) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        A: Copy,
+        Dq: DistanceMetric<A>,
+        Qb: NearestNQueryBuilder<A, K, Dq>,
+    {
+        self.map(|prototype| prototype.nearest_n(max_qty))
+    }
+
+    /// Selects a radius query, or adds a radius bound to a k-nearest-neighbours
+    /// query.
+    ///
+    /// The same radius applies to every query point in the batch.
+    #[inline]
+    pub fn within<Dq>(self, radius: Dq::Output) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        A: Copy,
+        Dq: DistanceMetric<A>,
+        Qb: WithinQueryBuilder<A, K, Dq>,
+    {
+        self.map(|prototype| prototype.within(radius))
+    }
+
+    /// Selects a radius query that keeps the best `max_qty` entries by item
+    /// ordering.
+    ///
+    /// The single-point query returns a `BinaryHeap`, whose iteration order is
+    /// unspecified. [`execute`](Self::execute) instead yields each query
+    /// point's group as a slice sorted by item ordering, so that batch results
+    /// are reproducible.
+    #[inline]
+    pub fn best_n_within<Dq>(
+        self,
+        radius: Dq::Output,
+        max_qty: NonZeroUsize,
+    ) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        A: Copy,
+        Dq: DistanceMetric<A>,
+        Qb: BestNWithinQueryBuilder<A, K, Dq>,
+    {
+        self.map(|prototype| prototype.best_n_within(radius, max_qty))
+    }
+
+    /// Switches exact nearest-neighbour search to approximate descent-only mode.
+    #[inline]
+    pub fn approx(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: ApproxQueryBuilder,
+    {
+        self.map(Qb::approx)
+    }
+
+    /// Returns results in traversal order instead of sorted-by-distance order.
+    #[inline]
+    pub fn unsorted(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: UnsortedQueryBuilder,
+    {
+        self.map(Qb::unsorted)
+    }
+
+    /// Uses strict `< radius` semantics instead of inclusive `<= radius`.
+    #[inline]
+    pub fn exclusive_boundaries(self) -> BatchQueryBuilder<'a, Qb::Output, A, K>
+    where
+        Qb: ExclusiveBoundariesQueryBuilder,
+    {
+        self.map(Qb::exclusive_boundaries)
+    }
+
+    /// Reserves space for the expected number of results *per query point*.
+    #[inline]
+    pub fn with_result_capacity(self, result_capacity: usize) -> Self
+    where
+        Qb: WithResultCapacityQueryBuilder,
+    {
+        self.map(|prototype| prototype.with_result_capacity(result_capacity))
+    }
+}
+
+/// Terminal methods.
+impl<'a, Qb, A, const K: usize> BatchQueryBuilder<'a, Qb, A, K>
+where
+    A: Sync,
+    Qb: ExecuteQueryBuilder + BatchQuerySink<'a, A, K> + Send + Sync,
+    Qb::Output: BatchCollect + Send,
+{
+    /// Executes every query point in the batch and collects the results.
+    ///
+    /// Results are addressed by the index of their query point in the slice
+    /// passed to
+    /// [`query_batch`](crate::kd_tree::KdTree::query_batch), regardless of the
+    /// order in which they were computed or which thread computed them.
+    #[inline]
+    pub fn execute(self) -> <Qb::Output as BatchCollect>::Batch {
+        let Some(prototype) = self.prototype else {
+            return <Qb::Output as BatchCollect>::collect_batch(Vec::new());
+        };
+
+        let run = |query: &'a [A; K]| {
+            let mut query_builder = prototype;
+            query_builder.set_query_point(query);
+            query_builder.execute()
+        };
+
+        #[cfg(feature = "parallel")]
+        if self.executor.is_parallel() {
+            let results = self
+                .queries
+                .par_iter()
+                .with_min_len(self.executor.min_len())
+                .map(run)
+                .collect::<Vec<_>>();
+
+            return <Qb::Output as BatchCollect>::collect_batch(results);
+        }
+
+        <Qb::Output as BatchCollect>::collect_batch(self.queries.iter().map(run).collect())
+    }
+
+    /// Executes every query point in the batch, passing each result to
+    /// `visitor` as it is produced.
+    ///
+    /// `visitor` receives the index of the query point in the slice passed to
+    /// [`query_batch`](crate::kd_tree::KdTree::query_batch), along with that
+    /// query point's result.
+    ///
+    /// # Concurrency
+    ///
+    /// `visitor` may be called from any thread, from several threads at once,
+    /// and in any order — which is why it is `Fn + Send + Sync` rather than
+    /// `FnMut`. Accumulate through shared state that tolerates this, such as an
+    /// atomic, a `Mutex`, or per-index writes into a preallocated buffer.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kiddo::dist::SquaredEuclidean;
+    /// use kiddo::leaf_strategy::FlatVec;
+    /// use kiddo::{Eytzinger, KdTree};
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
+    ///
+    /// type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+    ///
+    /// let entries = [(10_u32, [0.0, 0.0]), (11_u32, [1.0, 1.0])];
+    /// let tree = Tree::new_from_entries(&entries).unwrap();
+    /// let queries = [[0.1, 0.1], [0.9, 0.9]];
+    ///
+    /// let matches = AtomicUsize::new(0);
+    /// tree.query_batch(&queries)
+    ///     .nearest_one::<SquaredEuclidean<f64>>()
+    ///     .for_each(|_index, result| {
+    ///         if result.item == 10 {
+    ///             matches.fetch_add(1, Ordering::Relaxed);
+    ///         }
+    ///     });
+    ///
+    /// assert_eq!(matches.load(Ordering::Relaxed), 1);
+    /// ```
+    #[inline]
+    pub fn for_each<F>(self, visitor: F)
+    where
+        F: Fn(usize, Qb::Output) + Send + Sync,
+    {
+        let Some(prototype) = self.prototype else {
+            return;
+        };
+
+        let run = |(index, query): (usize, &'a [A; K])| {
+            let mut query_builder = prototype;
+            query_builder.set_query_point(query);
+            visitor(index, query_builder.execute());
+        };
+
+        #[cfg(feature = "parallel")]
+        if self.executor.is_parallel() {
+            self.queries
+                .par_iter()
+                .enumerate()
+                .with_min_len(self.executor.min_len())
+                .for_each(run);
+
+            return;
+        }
+
+        self.queries.iter().enumerate().for_each(run);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    use std::num::NonZeroUsize;
+    use std::sync::Mutex;
+
+    use crate::batch::Executor;
+    use crate::dist::{Manhattan, SquaredEuclidean};
+    use crate::kd_tree::KdTree;
+    use crate::leaf_strategy::{FlatVec, VecOfArenas, VecOfArrays};
+    use crate::Eytzinger;
+
+    const RNG_SEED: u64 = 42;
+    const K: usize = 3;
+    const BUCKET: usize = 32;
+
+    type Tree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, K, BUCKET>, K, BUCKET>;
+    type SmallTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+
+    pub(super) fn tree_and_queries(points: usize, queries: usize) -> (Tree, Vec<[f64; K]>) {
+        let mut rng = StdRng::seed_from_u64(RNG_SEED);
+        let content: Vec<[f64; K]> = (0..points).map(|_| rng.random()).collect();
+        let queries: Vec<[f64; K]> = (0..queries).map(|_| rng.random()).collect();
+
+        (Tree::new_from_slice(&content).unwrap(), queries)
+    }
+
+    #[test]
+    fn nearest_one_batch_matches_single_point_queries() {
+        let (tree, queries) = tree_and_queries(2048, 257);
+
+        for executor in [Executor::serial(), Executor::parallel(), Executor::new()] {
+            let batch = tree
+                .query_batch(&queries)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_executor(&executor)
+                .execute();
+
+            assert_eq!(batch.len(), queries.len());
+
+            for (index, query) in queries.iter().enumerate() {
+                let expected = tree
+                    .query(query)
+                    .nearest_one::<SquaredEuclidean<f64>>()
+                    .execute();
+
+                assert_eq!(batch[index].item, expected.item, "index {index}");
+                assert_eq!(batch[index].distance, expected.distance, "index {index}");
+            }
+        }
+    }
+
+    #[test]
+    fn nearest_n_batch_matches_single_point_queries() {
+        let (tree, queries) = tree_and_queries(2048, 129);
+        let max_qty = NonZeroUsize::new(7).unwrap();
+
+        for executor in [Executor::serial(), Executor::parallel()] {
+            let batch = tree
+                .query_batch(&queries)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .with_executor(&executor)
+                .execute();
+
+            assert_eq!(batch.len(), queries.len());
+            assert_eq!(batch.total_len(), queries.len() * max_qty.get());
+
+            for (index, query) in queries.iter().enumerate() {
+                let expected = tree
+                    .query(query)
+                    .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                    .execute();
+
+                let actual = batch.get(index).unwrap();
+                assert_eq!(actual.len(), expected.len(), "index {index}");
+
+                for (actual, expected) in actual.iter().zip(expected.iter()) {
+                    assert_eq!(actual.item, expected.item, "index {index}");
+                    assert_eq!(actual.distance, expected.distance, "index {index}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn nearest_n_within_batch_matches_single_point_queries() {
+        let (tree, queries) = tree_and_queries(2048, 65);
+        let max_qty = NonZeroUsize::new(5).unwrap();
+        let radius = 0.05;
+
+        let batch = tree
+            .query_batch(&queries)
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .execute();
+
+            let actual = &batch[index];
+            assert_eq!(actual.len(), expected.len(), "index {index}");
+
+            for (actual, expected) in actual.iter().zip(expected.iter()) {
+                assert_eq!(actual.item, expected.item, "index {index}");
+                assert_eq!(actual.distance, expected.distance, "index {index}");
+            }
+        }
+    }
+
+    #[test]
+    fn batch_queries_work_against_a_mutable_tree() {
+        let mut rng = StdRng::seed_from_u64(RNG_SEED);
+        let mut tree: KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, K, BUCKET>, K, BUCKET> =
+            KdTree::default();
+
+        for item in 0..512u32 {
+            tree.add(&rng.random::<[f64; K]>(), item).unwrap();
+        }
+
+        let queries: Vec<[f64; K]> = (0..64).map(|_| rng.random()).collect();
+
+        let batch = tree
+            .query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .execute();
+
+            assert_eq!(batch[index].item, expected.item, "index {index}");
+        }
+    }
+
+    #[test]
+    fn within_batch_matches_single_point_queries() {
+        let (tree, queries) = tree_and_queries(2048, 65);
+        let radius = 0.05;
+
+        let batch = tree
+            .query_batch(&queries)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .execute();
+
+        assert_eq!(batch.len(), queries.len());
+
+        let mut flat_len = 0;
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .execute();
+
+            let actual = &batch[index];
+            assert_eq!(actual.len(), expected.len(), "index {index}");
+            flat_len += expected.len();
+
+            for (actual, expected) in actual.iter().zip(expected.iter()) {
+                assert_eq!(actual.item, expected.item, "index {index}");
+            }
+        }
+
+        assert_eq!(batch.total_len(), flat_len);
+        assert_eq!(batch.into_flat_vec().len(), flat_len);
+    }
+
+    #[test]
+    fn best_n_within_batch_matches_single_point_queries() {
+        let (tree, queries) = tree_and_queries(2048, 33);
+        let radius = 0.05;
+        let max_qty = NonZeroUsize::new(5).unwrap();
+
+        let batch = tree
+            .query_batch(&queries)
+            .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            // Batch groups are sorted by item ordering; the single-point query
+            // hands back a heap whose iteration order is unspecified.
+            let expected = tree
+                .query(query)
+                .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+                .execute()
+                .into_sorted_vec();
+
+            let actual = &batch[index];
+            assert_eq!(actual.len(), expected.len(), "index {index}");
+
+            for (actual, expected) in actual.iter().zip(expected.iter()) {
+                assert_eq!(actual.item, expected.item, "index {index}");
+                assert_eq!(actual.distance, expected.distance, "index {index}");
+            }
+        }
+    }
+
+    #[test]
+    fn projections_and_modifiers_carry_through_to_batch() {
+        let (tree, queries) = tree_and_queries(1024, 17);
+        let max_qty = NonZeroUsize::new(3).unwrap();
+
+        let batch = tree
+            .query_batch(&queries)
+            .nearest_n::<Manhattan<f64>>(max_qty)
+            .with_points()
+            .without_items()
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .nearest_n::<Manhattan<f64>>(max_qty)
+                .with_points()
+                .without_items()
+                .execute();
+
+            for (actual, expected) in batch[index].iter().zip(expected.iter()) {
+                assert_eq!(actual.point, expected.point, "index {index}");
+                assert_eq!(actual.distance, expected.distance, "index {index}");
+                assert_eq!(actual.item, (), "index {index}");
+            }
+        }
+    }
+
+    #[test]
+    fn unsorted_and_exclusive_boundaries_carry_through_to_batch() {
+        let (tree, queries) = tree_and_queries(1024, 17);
+        let radius = 0.05;
+
+        let batch = tree
+            .query_batch(&queries)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .unsorted()
+            .exclusive_boundaries()
+            .with_result_capacity(8)
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .unsorted()
+                .exclusive_boundaries()
+                .with_result_capacity(8)
+                .execute();
+
+            assert_eq!(batch[index].len(), expected.len(), "index {index}");
+        }
+    }
+
+    #[test]
+    fn approx_nearest_one_carries_through_to_batch() {
+        let (tree, queries) = tree_and_queries(1024, 17);
+
+        let batch = tree
+            .query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .approx()
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .approx()
+                .execute();
+
+            assert_eq!(batch[index].item, expected.item, "index {index}");
+        }
+    }
+
+    #[test]
+    fn periodic_boundary_conditions_carry_through_to_batch() {
+        let (tree, queries) = tree_and_queries(1024, 17);
+        let box_size = [1.0f64; K];
+
+        let batch = tree
+            .query_batch(&queries)
+            .periodic_boundary_condition(&box_size)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+
+        for (index, query) in queries.iter().enumerate() {
+            let expected = tree
+                .query(query)
+                .periodic_boundary_condition(&box_size)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .execute();
+
+            assert_eq!(batch[index].item, expected.item, "index {index}");
+            assert_eq!(batch[index].distance, expected.distance, "index {index}");
+        }
+    }
+
+    #[test]
+    fn for_each_visits_every_query_exactly_once_with_its_own_index() {
+        let (tree, queries) = tree_and_queries(2048, 513);
+
+        for executor in [Executor::serial(), Executor::parallel()] {
+            let seen: Mutex<Vec<Option<u32>>> = Mutex::new(vec![None; queries.len()]);
+
+            tree.query_batch(&queries)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_executor(&executor)
+                .for_each(|index, result| {
+                    let mut seen = seen.lock().unwrap();
+                    assert!(seen[index].is_none(), "index {index} visited twice");
+                    seen[index] = Some(result.item);
+                });
+
+            let seen = seen.into_inner().unwrap();
+            for (index, query) in queries.iter().enumerate() {
+                let expected = tree
+                    .query(query)
+                    .nearest_one::<SquaredEuclidean<f64>>()
+                    .execute();
+                assert_eq!(seen[index], Some(expected.item), "index {index}");
+            }
+        }
+    }
+
+    #[test]
+    fn empty_batch_yields_empty_results() {
+        let (tree, _) = tree_and_queries(256, 0);
+        let queries: [[f64; K]; 0] = [];
+
+        let nearest_one = tree
+            .query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        assert!(nearest_one.is_empty());
+        assert_eq!(nearest_one.len(), 0);
+        assert!(nearest_one.into_vec().is_empty());
+
+        let nearest_n = tree
+            .query_batch(&queries)
+            .nearest_n::<SquaredEuclidean<f64>>(NonZeroUsize::new(4).unwrap())
+            .execute();
+        assert!(nearest_n.is_empty());
+        assert_eq!(nearest_n.total_len(), 0);
+        assert_eq!(nearest_n.iter().count(), 0);
+
+        // A visitor over an empty batch must never fire.
+        tree.query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .for_each(|_, _| panic!("visitor called for an empty batch"));
+    }
+
+    #[test]
+    fn single_query_batch_is_supported() {
+        let entries = [
+            (10_u32, [0.0, 0.0]),
+            (11_u32, [1.0, 1.0]),
+            (12_u32, [0.2, 0.1]),
+        ];
+        let tree = SmallTree::new_from_entries(&entries).unwrap();
+        let queries = [[0.9, 0.9]];
+
+        let results = tree
+            .query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].item, 11);
+    }
+
+    #[test]
+    fn builder_reports_batch_size_before_execution() {
+        let (tree, queries) = tree_and_queries(256, 9);
+
+        let builder = tree.query_batch(&queries);
+        assert_eq!(builder.len(), 9);
+        assert!(!builder.is_empty());
+
+        let empty: [[f64; K]; 0] = [];
+        assert!(tree.query_batch(&empty).is_empty());
+    }
+
+    #[test]
+    fn min_queries_per_task_hint_does_not_change_results() {
+        let (tree, queries) = tree_and_queries(1024, 200);
+
+        let baseline = tree
+            .query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .with_executor(&Executor::serial())
+            .execute();
+
+        for min in [1usize, 7, 64, 4096] {
+            let executor =
+                Executor::parallel().with_min_queries_per_task(NonZeroUsize::new(min).unwrap());
+
+            let hinted = tree
+                .query_batch(&queries)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_executor(&executor)
+                .execute();
+
+            assert_eq!(hinted.as_slice(), baseline.as_slice(), "min_len {min}");
+        }
+    }
+
+    #[test]
+    fn results_containers_expose_owned_and_borrowed_views() {
+        let (tree, queries) = tree_and_queries(512, 5);
+
+        let results = tree
+            .query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        let borrowed: Vec<u32> = results.iter().map(|result| result.item).collect();
+        let by_ref: Vec<u32> = (&results).into_iter().map(|result| result.item).collect();
+        let owned: Vec<u32> = results.into_iter().map(|result| result.item).collect();
+        assert_eq!(borrowed, owned);
+        assert_eq!(by_ref, owned);
+
+        let groups = tree
+            .query_batch(&queries)
+            .nearest_n::<SquaredEuclidean<f64>>(NonZeroUsize::new(2).unwrap())
+            .execute();
+        let group_lens: Vec<usize> = groups.iter().map(<[_]>::len).collect();
+        let by_ref_lens: Vec<usize> = (&groups).into_iter().map(<[_]>::len).collect();
+        assert_eq!(group_lens, vec![2; queries.len()]);
+        assert_eq!(by_ref_lens, group_lens);
+        assert_eq!(groups.into_nested_vec().len(), queries.len());
+    }
+}
+
+#[cfg(all(test, feature = "parallel"))]
+mod parallel_tests {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    use std::thread::ThreadId;
+
+    use crate::batch::Executor;
+    use crate::dist::SquaredEuclidean;
+
+    use super::tests::tree_and_queries;
+
+    /// Not an API guarantee — a smoke test that the parallel executor really
+    /// does reach Rayon rather than silently falling back to the serial path.
+    #[test]
+    fn parallel_executor_uses_the_rayon_pool() {
+        if rayon::current_num_threads() < 2 {
+            return;
+        }
+
+        let (tree, queries) = tree_and_queries(4096, 8192);
+        let threads: Mutex<HashSet<ThreadId>> = Mutex::new(HashSet::new());
+
+        tree.query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .with_executor(&Executor::parallel())
+            .for_each(|_, _| {
+                threads.lock().unwrap().insert(std::thread::current().id());
+            });
+
+        assert!(
+            threads.into_inner().unwrap().len() > 1,
+            "expected work to reach more than one thread"
+        );
+    }
+}

--- a/src/kd_tree/query/batch.rs
+++ b/src/kd_tree/query/batch.rs
@@ -33,7 +33,7 @@ use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Deref, Index};
 
-#[cfg(feature = "parallel")]
+#[cfg(feature = "multi-threaded")]
 use rayon::prelude::*;
 
 use super::builder::{
@@ -54,6 +54,11 @@ use crate::results::query_result_item::QueryResultItem;
 /// meaning of the hints, and the machinery used to honour them, may change
 /// between releases.
 ///
+/// Multi-threaded execution requires the `multi-threaded` crate feature, which
+/// is enabled by default. Without it `parallel` and
+/// `with_min_queries_per_task` are not compiled, and [`new`](Self::new) is
+/// equivalent to [`serial`](Self::serial).
+///
 /// To run a batch on a specific Rayon thread pool, use Rayon's own scoping:
 ///
 /// ```ignore
@@ -63,21 +68,25 @@ use crate::results::query_result_item::QueryResultItem;
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "multi-threaded")] {
 /// use kiddo::batch::Executor;
 /// use std::num::NonZeroUsize;
 ///
 /// let executor = Executor::parallel()
 ///     .with_min_queries_per_task(NonZeroUsize::new(256).unwrap());
+/// # }
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Executor {
     kind: ExecutorKind,
+    #[cfg(feature = "multi-threaded")]
     min_queries_per_task: Option<NonZeroUsize>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ExecutorKind {
     Serial,
+    #[cfg(feature = "multi-threaded")]
     Parallel,
 }
 
@@ -91,17 +100,19 @@ impl Default for Executor {
 impl Executor {
     /// Creates the default executor.
     ///
-    /// The default is parallel execution when the `parallel` feature is
-    /// enabled, and serial execution otherwise.
+    /// The default is `parallel` with the `multi-threaded`
+    /// feature enabled — which it is unless a caller turns default features off
+    /// — and [`serial`](Self::serial) without it.
     #[inline]
     pub fn new() -> Self {
-        Self {
-            kind: if cfg!(feature = "parallel") {
-                ExecutorKind::Parallel
-            } else {
-                ExecutorKind::Serial
-            },
-            min_queries_per_task: None,
+        #[cfg(feature = "multi-threaded")]
+        {
+            Self::parallel()
+        }
+
+        #[cfg(not(feature = "multi-threaded"))]
+        {
+            Self::serial()
         }
     }
 
@@ -112,15 +123,15 @@ impl Executor {
     pub fn serial() -> Self {
         Self {
             kind: ExecutorKind::Serial,
+            #[cfg(feature = "multi-threaded")]
             min_queries_per_task: None,
         }
     }
 
     /// Creates an executor that may spread queries across multiple threads.
     ///
-    /// Falls back to serial execution when the `parallel` feature is disabled,
-    /// so that enabling or disabling the feature never changes which code
-    /// compiles.
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     #[inline]
     pub fn parallel() -> Self {
         Self {
@@ -134,19 +145,22 @@ impl Executor {
     /// This is advisory. It exists so that callers with unusually cheap or
     /// unusually expensive queries can nudge the scheduler, and it may be
     /// ignored entirely.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
     #[inline]
     pub fn with_min_queries_per_task(mut self, min_queries_per_task: NonZeroUsize) -> Self {
         self.min_queries_per_task = Some(min_queries_per_task);
         self
     }
 
-    #[cfg(feature = "parallel")]
+    #[cfg(feature = "multi-threaded")]
     #[inline]
     fn is_parallel(&self) -> bool {
         matches!(self.kind, ExecutorKind::Parallel)
     }
 
-    #[cfg(feature = "parallel")]
+    #[cfg(feature = "multi-threaded")]
     #[inline]
     fn min_len(&self) -> usize {
         self.min_queries_per_task.map_or(1, NonZeroUsize::get)
@@ -456,7 +470,7 @@ pub trait BatchQuerySink<'a, A, const K: usize>: Copy {
 /// assert_eq!(results[1].item, 11);
 /// ```
 ///
-/// See the [module documentation](self) for exactly which properties of batch
+/// See the [module documentation](crate::batch) for exactly which properties of batch
 /// execution are guaranteed and which are free to change.
 pub struct BatchQueryBuilder<'a, Qb, A, const K: usize> {
     /// The configured single-point query, cloned per query point at execution
@@ -701,7 +715,7 @@ where
             query_builder.execute()
         };
 
-        #[cfg(feature = "parallel")]
+        #[cfg(feature = "multi-threaded")]
         if self.executor.is_parallel() {
             let results = self
                 .queries
@@ -770,7 +784,7 @@ where
             visitor(index, query_builder.execute());
         };
 
-        #[cfg(feature = "parallel")]
+        #[cfg(feature = "multi-threaded")]
         if self.executor.is_parallel() {
             self.queries
                 .par_iter()
@@ -813,11 +827,25 @@ mod tests {
         (Tree::new_from_slice(&content).unwrap(), queries)
     }
 
+    /// Every executor available in this build. `Executor::parallel` only
+    /// exists with the `multi-threaded` feature.
+    fn executors() -> Vec<Executor> {
+        #[cfg(feature = "multi-threaded")]
+        {
+            vec![Executor::serial(), Executor::parallel(), Executor::new()]
+        }
+
+        #[cfg(not(feature = "multi-threaded"))]
+        {
+            vec![Executor::serial(), Executor::new()]
+        }
+    }
+
     #[test]
     fn nearest_one_batch_matches_single_point_queries() {
         let (tree, queries) = tree_and_queries(2048, 257);
 
-        for executor in [Executor::serial(), Executor::parallel(), Executor::new()] {
+        for executor in executors() {
             let batch = tree
                 .query_batch(&queries)
                 .nearest_one::<SquaredEuclidean<f64>>()
@@ -843,7 +871,7 @@ mod tests {
         let (tree, queries) = tree_and_queries(2048, 129);
         let max_qty = NonZeroUsize::new(7).unwrap();
 
-        for executor in [Executor::serial(), Executor::parallel()] {
+        for executor in executors() {
             let batch = tree
                 .query_batch(&queries)
                 .nearest_n::<SquaredEuclidean<f64>>(max_qty)
@@ -1090,7 +1118,7 @@ mod tests {
     fn for_each_visits_every_query_exactly_once_with_its_own_index() {
         let (tree, queries) = tree_and_queries(2048, 513);
 
-        for executor in [Executor::serial(), Executor::parallel()] {
+        for executor in executors() {
             let seen: Mutex<Vec<Option<u32>>> = Mutex::new(vec![None; queries.len()]);
 
             tree.query_batch(&queries)
@@ -1171,6 +1199,7 @@ mod tests {
         assert!(tree.query_batch(&empty).is_empty());
     }
 
+    #[cfg(feature = "multi-threaded")]
     #[test]
     fn min_queries_per_task_hint_does_not_change_results() {
         let (tree, queries) = tree_and_queries(1024, 200);
@@ -1221,7 +1250,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "parallel"))]
+#[cfg(all(test, feature = "multi-threaded"))]
 mod parallel_tests {
     use std::collections::HashSet;
     use std::sync::Mutex;

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -19,6 +19,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 };
 use crate::{Axis, BestQueryResultItem, Content, LeafStrategy, QueryResultItem, StemStrategy};
 
+use super::batch::{BatchQueryBuilder, BatchQuerySink};
+
 use super::periodic::{periodic_nearest_one_result, periodic_nearest_results};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1541,6 +1543,9 @@ where
 {
     /// Reserves space for the expected number of materialized radius-query results.
     ///
+    /// See [`WithResultCapacityQueryBuilder`] for the equivalent used by batch
+    /// queries.
+    ///
     /// A good estimate avoids growth reallocations without limiting the number
     /// of results returned. Overestimating can reserve substantially more memory
     /// than the query needs, so omit the hint when no reasonable estimate is
@@ -1922,6 +1927,63 @@ pub trait ExclusiveBoundariesQueryBuilder {
 
     #[doc(hidden)]
     fn exclusive_boundaries(self) -> Self::Output;
+}
+
+#[doc(hidden)]
+pub trait WithResultCapacityQueryBuilder: Sized {
+    #[doc(hidden)]
+    fn with_result_capacity(self, result_capacity: usize) -> Self;
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        Space,
+        Pj,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > WithResultCapacityQueryBuilder
+    for QueryBuilder<'a, Tree, A, T, SS, LS, D, WithinState, Space, Pj, SORTED, EXCLUSIVE, K, B>
+where
+    D: BuilderMetric<A, K>,
+{
+    #[inline]
+    fn with_result_capacity(self, result_capacity: usize) -> Self {
+        QueryBuilder::with_result_capacity(self, result_capacity)
+    }
+}
+
+impl<
+        'a,
+        Tree,
+        A,
+        T,
+        SS,
+        LS,
+        D,
+        Family,
+        Space,
+        Pj,
+        const SORTED: bool,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    > BatchQuerySink<'a, A, K>
+    for QueryBuilder<'a, Tree, A, T, SS, LS, D, Family, Space, Pj, SORTED, EXCLUSIVE, K, B>
+where
+    D: BuilderMetric<A, K>,
+{
+    #[inline(always)]
+    fn set_query_point(&mut self, query: &'a [A; K]) {
+        self.query = query;
+    }
 }
 
 impl<
@@ -2348,6 +2410,53 @@ where
         }
     }
 
+    /// Starts a fluent batch query against this tree.
+    ///
+    /// A batch query is configured exactly like a single-point query, but runs
+    /// every point in `queries` and returns one result per point, indexed by
+    /// position in `queries`.
+    ///
+    /// The execution strategy — ordering, threading, and how work is grouped —
+    /// is deliberately unspecified and may change between releases; see the
+    /// [`batch`](crate::batch) module documentation for the exact guarantees,
+    /// and [`Executor`](crate::batch::Executor) for the available policies.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use kiddo::dist::SquaredEuclidean;
+    /// use kiddo::leaf_strategy::FlatVec;
+    /// use kiddo::{Eytzinger, KdTree};
+    /// use std::num::NonZeroUsize;
+    ///
+    /// type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+    ///
+    /// let entries = [
+    ///     (10_u32, [0.0, 0.0]),
+    ///     (11_u32, [1.0, 1.0]),
+    ///     (12_u32, [0.2, 0.1]),
+    /// ];
+    /// let tree = Tree::new_from_entries(&entries).unwrap();
+    ///
+    /// let queries = [[0.1, 0.1], [0.9, 0.9], [0.25, 0.15]];
+    ///
+    /// let results = tree
+    ///     .query_batch(&queries)
+    ///     .nearest_n::<SquaredEuclidean<f64>>(NonZeroUsize::new(2).unwrap())
+    ///     .execute();
+    ///
+    /// assert_eq!(results.len(), 3);
+    /// assert_eq!(results[0][0].item, 12);
+    /// assert_eq!(results[1][0].item, 11);
+    /// ```
+    #[inline]
+    pub fn query_batch<'a>(
+        &'a self,
+        queries: &'a [[A; K]],
+    ) -> BatchQueryBuilder<'a, RootQueryBuilder<'a, Self, A, T, SS, LS, K, B>, A, K> {
+        BatchQueryBuilder::new(queries.first().map(|query| self.query(query)), queries)
+    }
+
     /// Creates reusable scratch storage for scratch-aware query builder paths.
     ///
     /// Pass the returned value to [`QueryBuilder::with_scratch`] to avoid the
@@ -2426,6 +2535,24 @@ where
             radius: (),
             _phantom: PhantomData,
         }
+    }
+
+    /// Starts a fluent batch query against this archived tree.
+    ///
+    /// See [`KdTree::query_batch`] for the full batch-query guide, and the
+    /// [`batch`](crate::batch) module documentation for what batch execution
+    /// does and does not guarantee.
+    #[inline]
+    pub fn query_batch<'a>(
+        &'a self,
+        queries: &'a [[A; K]],
+    ) -> BatchQueryBuilder<
+        'a,
+        RootQueryBuilder<'a, Self, A, T, SS, rkyv_08::Archived<LS>, K, B>,
+        A,
+        K,
+    > {
+        BatchQueryBuilder::new(queries.first().map(|query| self.query(query)), queries)
     }
 
     /// Creates reusable scratch storage for scratch-aware query builder paths.

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -1543,8 +1543,8 @@ where
 {
     /// Reserves space for the expected number of materialized radius-query results.
     ///
-    /// See [`WithResultCapacityQueryBuilder`] for the equivalent used by batch
-    /// queries.
+    /// Batch queries expose the same option through
+    /// [`BatchQueryBuilder::with_result_capacity`](crate::batch::BatchQueryBuilder::with_result_capacity).
     ///
     /// A good estimate avoids growth reallocations without limiting the number
     /// of results returned. Overestimating can reserve substantially more memory

--- a/src/kd_tree/query/mod.rs
+++ b/src/kd_tree/query/mod.rs
@@ -1,4 +1,5 @@
 mod approx_nearest_one;
+pub mod batch;
 mod best_n_within;
 pub mod builder;
 mod periodic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,34 @@
 //!
 //! See the [examples documentation](https://github.com/sdd/kiddo/tree/master/examples) for some more in-depth examples.
 //!
+//! ## Batch Queries
+//!
+//! When many query points are known up front, run them as one batch. A batch
+//! query is configured exactly like a single-point query and returns one result
+//! per query point, indexed by position in the input slice:
+//!
+//! ```rust
+//! use kiddo::{ImmutableKdTree, SquaredEuclidean};
+//!
+//! let entries = vec![[0f64, 0f64], [1f64, 1f64], [2f64, 2f64]];
+//! let kdtree = ImmutableKdTree::new_from_slice(&entries).unwrap();
+//!
+//! let queries = [[0.1f64, 0.1], [1.9, 1.9]];
+//!
+//! let results = kdtree
+//!     .query_batch(&queries)
+//!     .nearest_one::<SquaredEuclidean<f64>>()
+//!     .execute();
+//!
+//! assert_eq!(results[0].item, 0);
+//! assert_eq!(results[1].item, 2);
+//! ```
+//!
+//! Enabling the `parallel` feature lets Kiddo spread a batch across multiple
+//! threads. How that work is scheduled — ordering, threading, and grouping — is
+//! deliberately unspecified so it can keep improving without breaking callers;
+//! see the [`batch`] module for exactly what is and is not guaranteed.
+//!
 //! ## Optional Features
 //!
 //! Kiddo exposes a number of optional crate features:
@@ -175,6 +203,11 @@
 //! - `simd` **(NIGHTLY)** enables handwritten SIMD and prefetch intrinsics for
 //!   additional performance where available. This requires a nightly Rust
 //!   toolchain.
+//!
+//! - `parallel` lets batch queries spread their work across multiple threads
+//!   via [`rayon`](https://docs.rs/rayon/latest/rayon/). Batch queries compile
+//!   and run either way; without this feature they execute on the calling
+//!   thread. See the [`batch`] module.
 //!
 //! - `huge_pages` enables Linux-specific huge-page advice helpers for owned and
 //!   archived tree storage.
@@ -215,6 +248,13 @@ pub mod kd_tree;
 #[doc(hidden)]
 pub type KdTree<A, T, SS, LS, const K: usize, const B: usize> = kd_tree::KdTree<A, T, SS, LS, K, B>;
 pub use kd_tree::{KdTreeBuilder, QueryScratch, DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD};
+
+/// Batch query execution: running many query points against one tree per call.
+pub mod batch {
+    pub use crate::kd_tree::query::batch::{
+        BatchGroups, BatchQueryBuilder, BatchResults, Executor, GroupIter,
+    };
+}
 
 /// Distance metrics
 pub mod dist;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,8 @@
 //! assert_eq!(results[1].item, 2);
 //! ```
 //!
-//! Enabling the `parallel` feature lets Kiddo spread a batch across multiple
-//! threads. How that work is scheduled — ordering, threading, and grouping — is
+//! Batches spread across threads by default, via the `multi-threaded` feature.
+//! How that work is scheduled — ordering, threading, and grouping — is
 //! deliberately unspecified so it can keep improving without breaking callers;
 //! see the [`batch`] module for exactly what is and is not guaranteed.
 //!
@@ -204,10 +204,20 @@
 //!   additional performance where available. This requires a nightly Rust
 //!   toolchain.
 //!
-//! - `parallel` lets batch queries spread their work across multiple threads
-//!   via [`rayon`](https://docs.rs/rayon/latest/rayon/). Batch queries compile
-//!   and run either way; without this feature they execute on the calling
-//!   thread. See the [`batch`] module.
+//! - `multi-threaded` **(default)** lets tree construction and batch queries
+//!   use multiple threads, via the current
+//!   [`rayon`](https://docs.rs/rayon/latest/rayon/) thread pool, and is what
+//!   pulls `rayon` in as a dependency.
+//!
+//!   Disabling it drops that dependency and configures the threaded APIs out
+//!   rather than quietly downgrading them: `ParallelConstruction`,
+//!   `KdTreeBuilder::with_parallel_construction`,
+//!   the `*_parallel` constructors, `Executor::parallel` and
+//!   `Executor::with_min_queries_per_task` no longer exist, so code that used
+//!   them fails to compile instead of silently running on one thread. Whatever
+//!   still compiles keeps working and produces identical trees and results.
+//!   Use it for WASM, embedded, or single-core targets, or wherever an extra
+//!   dependency is not worth it.
 //!
 //! - `huge_pages` enables Linux-specific huge-page advice helpers for owned and
 //!   archived tree storage.
@@ -247,7 +257,9 @@ mod custom_serde;
 pub mod kd_tree;
 #[doc(hidden)]
 pub type KdTree<A, T, SS, LS, const K: usize, const B: usize> = kd_tree::KdTree<A, T, SS, LS, K, B>;
-pub use kd_tree::{KdTreeBuilder, QueryScratch, DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD};
+#[cfg(feature = "multi-threaded")]
+pub use kd_tree::DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD;
+pub use kd_tree::{KdTreeBuilder, QueryScratch};
 
 /// Batch query execution: running many query points against one tree per call.
 pub mod batch {


### PR DESCRIPTION
* rename `parallel` crate feature to `multi-threaded`. Enable it by default. Use it to gate the multi-threaded construction and query capability
* add batch query API