### PR TITLE
docs: migrate benchmark boot profile tooling to bench-profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,35 @@ The benchmarks are repeated against 2d, 3d and 4d trees, as well as with points 
 
 The trees are populated with random source data whose points are all on a unit sphere. This use case is representative of common k-d tree usages in geospatial and astronomical contexts.
 
+### Reproducible local benchmarking
+
+The controlled benchmark suites in `scripts/` — the Donnelly variant matrix, the query-pool perf passes and the competitor matrices — are designed to run under a dedicated benchmark boot profile rather than a normal desktop session. That tooling lives in its own project:
+
+**[github.com/sdd/bench-profile](https://github.com/sdd/bench-profile)**
+
+It adds three boot entries, one per measurement question, and applies the matching CPU policy automatically at boot:
+
+| Profile       | Answers                         | CPU state                                                        |
+| ------------- | ------------------------------- | ---------------------------------------------------------------- |
+| `single-core` | "Is A faster than B?"           | One isolated core, scheduler load balancing off                  |
+| `multi-core`  | "How does it scale?"            | A whole core complex as a real parallel pool, SMT off, boost off |
+| `unlimited`   | "How fast can this machine go?" | Every thread, SMT on, boost on, no isolation                     |
+
+Install it, reboot into the entry matching the suite you want, and the scripts here will gate themselves on the correct state:
+
+```sh
+git clone https://github.com/sdd/bench-profile && cd bench-profile && just install
+# reboot into "... benchmark single-core", then, back in kiddo:
+./scripts/run_donnelly_variant_query_pool_matrix.sh
+```
+
+Two commands from that project are used directly by the scripts and just recipes here:
+
+- `bench-profile-run <command>` — pins the command tree to the profile's benchmark CPUs and audits hardware IRQs around the run, exiting **125** if any arrive so the caller can discard and retry the measurement.
+- `bench-profile-status expect-<profile>` — asserts the machine is in the required state, and exits non-zero if not. Note that the **bare** `bench-profile-status` is a report that always exits 0; it is meant for logging the environment alongside results, not for gating.
+
+Choosing the wrong profile is not a cosmetic mistake. Running a parallel suite under the `single-core` profile silently collapses every thread pool onto one core, because `isolcpus=domain` disables load balancing across the isolated set — the affinity mask alone is not enough to spread work. The `multi-core` profile exists specifically to avoid this, and `bench-profile-status expect-multi-core` runs a dispatch canary that proves work is actually spreading.
+
 ## MSRV
 
 Kiddo v6's current minimum supported Rust version (MSRV) is **1.89.0** (**1.85.0** for `v5.x.x`).

--- a/justfile
+++ b/justfile
@@ -1002,7 +1002,12 @@ bench-v6-donnelly-vs-eytzinger-query-pool POINT_LOG2='27' POOL_SIZES='256,512,10
         profile_v6_query_pool
 
 # IRQ-audited variant. Compilation occurs first; the benchmark executable and
-# all Criterion records live on tmpfs during the CPU-8 measurement interval.
+# all Criterion records live on tmpfs during the measurement interval.
+#
+# Needs the SINGLE-CORE benchmark boot profile from bench-profile
+# (https://github.com/sdd/bench-profile), which supplies bench-profile-run.
+# That wrapper pins the command tree to the profile's benchmark CPU and exits
+# 125 if any hardware IRQ lands there during the run.
 bench-v6-donnelly-vs-eytzinger-query-pool-clean POINT_LOG2='27' POOL_SIZES='256,512,1000,2048,4096,8192,16384' WARMUP='3' MEASUREMENT='8' SAMPLE_SIZE='30' RESULT_KEY='query-pool' OUTPUT_DIR='./focused-results' AXIS='both':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -1177,6 +1182,9 @@ view-v6-donnelly-vs-eytzinger-query-pool RESULT_KEY RESULTS_DIR='./focused-resul
 # Fixed-work exact-NN counter run. Construction and warmup finish before the
 # benchmark SIGSTOPs; perf attaches to the stopped process and only then resumes
 # the measured query loop. Keep exact_query_stats disabled here.
+#
+# Also needs the single-core benchmark boot profile from bench-profile
+# (https://github.com/sdd/bench-profile) for bench-profile-run.
 perf-v6-donnelly-vs-eytzinger-query-pool POINT_LOG2='27' POOL_SIZE='2048' TOTAL_QUERIES='4000000' WARMUP_REPEATS='2' AXIS='f64' STRATEGY='eytzinger' EVENT_SET='cache' RESULT_KEY='query-pool-perf' OUTPUT_DIR='./focused-results':
     #!/usr/bin/env bash
     set -euo pipefail

--- a/scripts/run_donnelly_variant_query_pool_matrix.sh
+++ b/scripts/run_donnelly_variant_query_pool_matrix.sh
@@ -8,8 +8,13 @@ set -euo pipefail
 # 2. f32/4D/2^25: cyclic layouts only, at a useful cache-pressure size; and
 # 3. f32/4D/2^21: block-dimension strategies at their balanced supercycle.
 #
-# Run from the dedicated benchmark boot profile. Each tree-height interval is
-# pinned and IRQ-audited by bench-profile-run through the underlying just task.
+# Run from the SINGLE-CORE benchmark boot profile, provided by bench-profile:
+# https://github.com/sdd/bench-profile
+#
+# These measurements are sequential, so they want the maximum-isolation case:
+# one isolated core with scheduler load balancing disabled across the set, which
+# is exactly what that profile provides. Each tree-height interval is pinned and
+# IRQ-audited by bench-profile-run through the underlying just task.
 # Each cell has its own overridable strategy list. Every list must retain the
 # Eytzinger baseline because the generated charts plot advantage over it.
 
@@ -200,7 +205,11 @@ run_irq_retry_logged() {
 capture_profile_status() {
     local destination=$1 phase=$2 profile_status
     set +e
-    bench-profile-status >"$destination" 2>&1
+    # `bench-profile-status` with no argument is a report that never exits
+    # non-zero, so it cannot gate anything -- it exists to be logged beside
+    # results on any boot. The assertion form is `expect-<profile>`, and this
+    # suite is sequential and pinned to one core, so it wants single-core.
+    bench-profile-status expect-single-core >"$destination" 2>&1
     profile_status=$?
     set -e
     if (( profile_status != 0 )); then


### PR DESCRIPTION
The benchmark boot profile tooling has moved to its own project:
**https://github.com/sdd/bench-profile**

It is not kiddo-specific, and it is reusable across other projects.

## What changed here

- **`scripts/run_donnelly_variant_query_pool_matrix.sh`** — `capture_profile_status` now asserts with `bench-profile-status expect-single-core` instead of relying on the bare form's exit code, and the header points at the standalone project.
- **`justfile`** — the two `bench-profile-run` recipes document which boot profile they require. No behavioural change; `bench-profile-run` is still provided, by the new project.
- **`README.md`** — new *Reproducible local benchmarking* subsection under Benchmarks: the three profiles, install and usage, and the distinction between the assertion and report forms of `bench-profile-status`.

## The gate this fixes

`capture_profile_status` gated on a bare `bench-profile-status` exiting non-zero. In the standalone tooling that form is deliberately **advisory and always exits 0**, so it can be logged next to results on any boot — including a normal desktop one — without failing the job it is documenting. Left as-is, the environment gate on the query-pool suite would have silently stopped gating anything.

Assertions are now `bench-profile-status expect-<profile>`. These suites are sequential and pinned to one core, so `expect-single-core` is the correct expectation.

## Why the profile choice matters

The single-core profile boots with `isolcpus=domain`, which removes the benchmark CPUs from every scheduler load-balancing domain. An affinity mask over the set is then **not** enough to spread a thread pool — the kernel never migrates threads between isolated CPUs, so every worker piles onto one core and timeshares it. Nothing errors; throughput just looks like poor scaling.

This is not hypothetical. A full 29-cell parallel competitor matrix was collected against a machine in exactly that state before it was noticed:

| f64, 2^24 points, 100k queries | 16 cores, unpinned | isolated profile, "8 cores" |
| --- | --- | --- |
| kiddo serial | 1.61M q/s | 1.83M q/s |
| kiddo parallel | 22.2M q/s (13.8x serial) | 1.80M q/s (**0.98x**) |
| Pkd-tree | 13.1M q/s | 0.86M q/s (**1/15.2**) |

The distortion was also asymmetric — rayon's coarse chunking lost 2% to timesharing while ParlayLib's spinning work-stealer lost 52% — so the resulting speedup ratios were inflated roughly 2x in kiddo's favour.

The new `multi-core` profile omits the `domain` flag for this reason, and `bench-profile-status expect-multi-core` runs a dispatch canary that proves work is actually spreading rather than trusting the command line.

## Note on `tools/benchmark-profile`

The intent was to delete `tools/benchmark-profile` here, but **it is not on `master`** — it exists only in the local, unpushed commit `0bf7b4d` ("chore: preserve cyclic SIMD research state") on `codex/donnelly-wip-20260801`. There is nothing for this PR to remove. It will need dropping from that branch before it merges, or it will reintroduce a second, now-divergent copy of the tooling.

## Testing

`bash -n` on the changed script and `just --list` both clean; all pre-commit hooks pass. The behavioural changes are to environment gating, which can only be exercised by booting a benchmark profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8SWimtznixdAkNWTyvE1j