### PR TITLE
feat: caller-supplied thread pools and small-batch scheduling hints for batch queries

### DIFF
--- a/.github/workflows/build-msrv.yml
+++ b/.github/workflows/build-msrv.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --features=serde,rkyv_08,test_utils --no-deps
 
+      - name: Install cpp_competitors system dependencies
+        # benches/profile_cpp_competitors.rs is gated behind the cpp_competitors
+        # feature, which cargo-hack's --each-feature sweep below checks in
+        # isolation. Its build script (build_cpp_competitors.rs) vendors and
+        # compiles nanoflann/ALGLIB/Pkd-tree itself, but skd-tree's shim links
+        # against three system packages it deliberately does not vendor.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libboost-dev libarmadillo-dev libensmallen-dev
+
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -65,6 +65,14 @@ jobs:
         if: github.actor == 'dependabot[bot]'
         run: cargo clippy --features fixed,rkyv_08,serde --no-deps
 
+      - name: Install cpp_competitors system dependencies
+        # benches/profile_cpp_competitors.rs is gated behind the cpp_competitors
+        # feature, which cargo-hack's --each-feature sweep below checks in
+        # isolation. Its build script (build_cpp_competitors.rs) vendors and
+        # compiles nanoflann/ALGLIB/Pkd-tree itself, but skd-tree's shim links
+        # against three system packages it deliberately does not vendor.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libboost-dev libarmadillo-dev libensmallen-dev
+
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --features=serde,rkyv_08,test_utils --no-deps
 
+      - name: Install cpp_competitors system dependencies
+        # benches/profile_cpp_competitors.rs is gated behind the cpp_competitors
+        # feature, which cargo-hack's --each-feature sweep below checks in
+        # isolation. Its build script (build_cpp_competitors.rs) vendors and
+        # compiles nanoflann/ALGLIB/Pkd-tree itself, but skd-tree's shim links
+        # against three system packages it deliberately does not vendor.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libboost-dev libarmadillo-dev libensmallen-dev
+
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
 
+      - name: Install cpp_competitors system dependencies
+        # benches/profile_cpp_competitors.rs is gated behind the cpp_competitors
+        # feature, which cargo-hack's --each-feature sweep below checks in
+        # isolation. Its build script (build_cpp_competitors.rs) vendors and
+        # compiles nanoflann/ALGLIB/Pkd-tree itself, but skd-tree's shim links
+        # against three system packages it deliberately does not vendor.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libboost-dev libarmadillo-dev libensmallen-dev
+
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ cargo_asm = ["dep:rand", "dep:rand_chacha"]
 csv = ["dep:csv"]
 default = ["fixed", "multi-threaded"]
 buffered_result_collection = ["dep:smallvec"]
+cpp_competitors = ["dep:cc"]
 huge_pages = ["dep:libc"]
 leaf_view_chunked = []
 leaf_nta_prefetch = []
@@ -132,6 +133,11 @@ version = "0.1"
 
 [build-dependencies]
 yep-cache-line-size = "0.9"
+
+[build-dependencies.cc]
+version = "1"
+optional = true
+features = ["parallel"]
 
 [dev-dependencies]
 assert_float_eq = "1.2"
@@ -322,6 +328,12 @@ name = "profile_external_kd_trees"
 path = "benches/profile_external_kd_trees.rs"
 harness = false
 required-features = ["test_utils"]
+
+[[bench]]
+name = "profile_cpp_competitors"
+path = "benches/profile_cpp_competitors.rs"
+harness = false
+required-features = ["cpp_competitors", "test_utils"]
 
 [[bench]]
 name = "profile_v6_within_radius_projection"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,9 @@ opt-level = 3
 debug = true
 lto = true
 codegen-units = 1
-opt-level = 2
+# Match profile.release: benchmarks that measure hand-written SIMD kernels are
+# not comparable to a release build if they are compiled a level below it.
+opt-level = 3
 
 # Fast iteration profile for test/dev loops that still want near-release perf.
 [profile.fast-tests]
@@ -368,6 +370,11 @@ name = "profile_v6_archived_query_focus"
 path = "benches/profile_v6_archived_query_focus.rs"
 harness = false
 required-features = ["rkyv_08", "huge_pages"]
+
+[[example]]
+name = "batch_overhead_probe"
+path = "examples/batch_overhead_probe.rs"
+required-features = ["test_utils", "multi-threaded"]
 
 [[example]]
 name = "fuzz-case-repro"

--- a/benches/cpp_shims/alglib_shim.cpp
+++ b/benches/cpp_shims/alglib_shim.cpp
@@ -1,0 +1,97 @@
+// Thin extern "C" shim over ALGLIB's free C++ edition kd-tree
+// (alglib::kdtree in alglibmisc). ALGLIB's "real" type is hard-coded to
+// double throughout, so this competitor is f64-only, like ANN was.
+//
+// ALGLIB's own distances are in "corresponding norm" units (norm type 2 =
+// Euclidean, i.e. NOT squared), so this shim squares them before returning
+// to match every other competitor's squared-distance convention. Point
+// indices come back via kdtreebuildtagged's tags (0..n-1), since a plain
+// untagged build has no way to recover which original point a result
+// corresponds to.
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "alglibmisc.h"
+
+namespace {
+
+struct Handle {
+    alglib::kdtree kdt;
+};
+
+}  // namespace
+
+extern "C" {
+
+void* alglib_build_f64(const double* points, uint64_t n, uint32_t dim) {
+    auto* h = new Handle();
+    alglib::real_2d_array xy;
+    xy.setcontent(static_cast<alglib::ae_int_t>(n), static_cast<alglib::ae_int_t>(dim), points);
+
+    std::vector<alglib::ae_int_t> tag_buf(n);
+    for (uint64_t i = 0; i < n; ++i) {
+        tag_buf[i] = static_cast<alglib::ae_int_t>(i);
+    }
+    alglib::integer_1d_array tags;
+    tags.setcontent(static_cast<alglib::ae_int_t>(n), tag_buf.data());
+
+    alglib::kdtreebuildtagged(xy, tags, static_cast<alglib::ae_int_t>(n), static_cast<alglib::ae_int_t>(dim), 0, 2, h->kdt);
+    return h;
+}
+
+void alglib_free_f64(void* handle) { delete static_cast<Handle*>(handle); }
+
+void alglib_nearest_one_f64(void* handle, const double* q, uint64_t* out_idx, double* out_dist2) {
+    auto* h = static_cast<Handle*>(handle);
+    alglib::real_1d_array x;
+    x.attach_to_ptr(3, const_cast<double*>(q));
+    alglib::kdtreequeryknn(h->kdt, x, 1, false);
+
+    alglib::real_1d_array r;
+    alglib::integer_1d_array result_tags;
+    alglib::kdtreequeryresultsdistances(h->kdt, r);
+    alglib::kdtreequeryresultstags(h->kdt, result_tags);
+    *out_idx = static_cast<uint64_t>(result_tags[0]);
+    *out_dist2 = r[0] * r[0];
+}
+
+uint64_t alglib_nearest_n_f64(void* handle, const double* q, uint64_t k, uint64_t* out_idx, double* out_dist2) {
+    auto* h = static_cast<Handle*>(handle);
+    alglib::real_1d_array x;
+    x.attach_to_ptr(3, const_cast<double*>(q));
+    const alglib::ae_int_t found = alglib::kdtreequeryknn(h->kdt, x, static_cast<alglib::ae_int_t>(k), false);
+
+    alglib::real_1d_array r;
+    alglib::integer_1d_array result_tags;
+    alglib::kdtreequeryresultsdistances(h->kdt, r);
+    alglib::kdtreequeryresultstags(h->kdt, result_tags);
+    for (alglib::ae_int_t i = 0; i < found; ++i) {
+        out_idx[i] = static_cast<uint64_t>(result_tags[i]);
+        out_dist2[i] = r[i] * r[i];
+    }
+    return static_cast<uint64_t>(found);
+}
+
+uint64_t alglib_within_radius_f64(
+    void* handle, const double* q, double radius2, uint64_t* out_idx, double* out_dist2, uint64_t cap) {
+    auto* h = static_cast<Handle*>(handle);
+    alglib::real_1d_array x;
+    x.attach_to_ptr(3, const_cast<double*>(q));
+    const double radius = std::sqrt(radius2);
+    const alglib::ae_int_t found = alglib::kdtreequeryrnn(h->kdt, x, radius, false);
+
+    alglib::real_1d_array r;
+    alglib::integer_1d_array result_tags;
+    alglib::kdtreequeryresultsdistances(h->kdt, r);
+    alglib::kdtreequeryresultstags(h->kdt, result_tags);
+    const uint64_t copy_n = static_cast<uint64_t>(found) < cap ? static_cast<uint64_t>(found) : cap;
+    for (uint64_t i = 0; i < copy_n; ++i) {
+        out_idx[i] = static_cast<uint64_t>(result_tags[i]);
+        out_dist2[i] = r[i] * r[i];
+    }
+    return static_cast<uint64_t>(found);
+}
+
+}  // extern "C"

--- a/benches/cpp_shims/nanoflann_shim.cpp
+++ b/benches/cpp_shims/nanoflann_shim.cpp
@@ -1,0 +1,116 @@
+// Thin extern "C" shim over nanoflann's header-only KDTreeSingleIndexAdaptor,
+// so it can be driven from the Rust criterion bench via FFI.
+//
+// Query semantics match kiddo's own conventions: distances are squared
+// Euclidean, radius arguments are squared radii, and within_radius results
+// are written into a caller-provided buffer up to `cap` entries while the
+// true (possibly larger) match count is always returned.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <nanoflann.hpp>
+
+namespace {
+
+template <typename Scalar>
+struct FlatCloud {
+    const Scalar* data;
+    std::size_t n;
+    std::size_t dim;
+
+    inline std::size_t kdtree_get_point_count() const { return n; }
+    inline Scalar kdtree_get_pt(std::size_t idx, std::size_t d) const {
+        return data[idx * dim + d];
+    }
+    template <class BBox>
+    bool kdtree_get_bbox(BBox&) const { return false; }
+};
+
+template <typename Scalar>
+struct Handle {
+    using Cloud = FlatCloud<Scalar>;
+    using Adaptor = nanoflann::L2_Simple_Adaptor<Scalar, Cloud, Scalar, uint64_t>;
+    using Index = nanoflann::KDTreeSingleIndexAdaptor<Adaptor, Cloud, 3, uint64_t>;
+
+    Cloud cloud;
+    Index index;
+
+    Handle(const Scalar* points, uint64_t n, uint32_t dim)
+        : cloud{points, static_cast<std::size_t>(n), static_cast<std::size_t>(dim)},
+          index(dim, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(32)) {
+        index.buildIndex();
+    }
+};
+
+template <typename Scalar>
+void* build(const Scalar* points, uint64_t n, uint32_t dim) {
+    return new Handle<Scalar>(points, n, dim);
+}
+
+template <typename Scalar>
+void free_handle(void* h) {
+    delete static_cast<Handle<Scalar>*>(h);
+}
+
+template <typename Scalar>
+void nearest_one(void* h, const Scalar* q, uint64_t* out_idx, Scalar* out_dist2) {
+    auto* handle = static_cast<Handle<Scalar>*>(h);
+    handle->index.knnSearch(q, 1, out_idx, out_dist2);
+}
+
+template <typename Scalar>
+uint64_t nearest_n(void* h, const Scalar* q, uint64_t k, uint64_t* out_idx, Scalar* out_dist2) {
+    auto* handle = static_cast<Handle<Scalar>*>(h);
+    return static_cast<uint64_t>(handle->index.knnSearch(q, static_cast<std::size_t>(k), out_idx, out_dist2));
+}
+
+template <typename Scalar>
+uint64_t within_radius(
+    void* h, const Scalar* q, Scalar radius2, uint64_t* out_idx, Scalar* out_dist2, uint64_t cap) {
+    auto* handle = static_cast<Handle<Scalar>*>(h);
+    std::vector<nanoflann::ResultItem<uint64_t, Scalar>> matches;
+    const uint64_t total = static_cast<uint64_t>(handle->index.radiusSearch(q, radius2, matches));
+    const uint64_t copy_n = total < cap ? total : cap;
+    for (uint64_t i = 0; i < copy_n; ++i) {
+        out_idx[i] = matches[i].first;
+        out_dist2[i] = matches[i].second;
+    }
+    return total;
+}
+
+}  // namespace
+
+extern "C" {
+
+void* nanoflann_build_f32(const float* points, uint64_t n, uint32_t dim) { return build<float>(points, n, dim); }
+void* nanoflann_build_f64(const double* points, uint64_t n, uint32_t dim) { return build<double>(points, n, dim); }
+
+void nanoflann_free_f32(void* h) { free_handle<float>(h); }
+void nanoflann_free_f64(void* h) { free_handle<double>(h); }
+
+void nanoflann_nearest_one_f32(void* h, const float* q, uint64_t* out_idx, float* out_dist2) {
+    nearest_one<float>(h, q, out_idx, out_dist2);
+}
+void nanoflann_nearest_one_f64(void* h, const double* q, uint64_t* out_idx, double* out_dist2) {
+    nearest_one<double>(h, q, out_idx, out_dist2);
+}
+
+uint64_t nanoflann_nearest_n_f32(void* h, const float* q, uint64_t k, uint64_t* out_idx, float* out_dist2) {
+    return nearest_n<float>(h, q, k, out_idx, out_dist2);
+}
+uint64_t nanoflann_nearest_n_f64(void* h, const double* q, uint64_t k, uint64_t* out_idx, double* out_dist2) {
+    return nearest_n<double>(h, q, k, out_idx, out_dist2);
+}
+
+uint64_t nanoflann_within_radius_f32(
+    void* h, const float* q, float radius2, uint64_t* out_idx, float* out_dist2, uint64_t cap) {
+    return within_radius<float>(h, q, radius2, out_idx, out_dist2, cap);
+}
+uint64_t nanoflann_within_radius_f64(
+    void* h, const double* q, double radius2, uint64_t* out_idx, double* out_dist2, uint64_t cap) {
+    return within_radius<double>(h, q, radius2, out_idx, out_dist2, cap);
+}
+
+}  // extern "C"

--- a/benches/cpp_shims/pkdtree_shim.cpp
+++ b/benches/cpp_shims/pkdtree_shim.cpp
@@ -1,0 +1,142 @@
+// Thin extern "C" shim over ucrparlay/Pkd-tree (SIGMOD'25), a parallel
+// k-d tree built on ParlayLib fork-join parallelism.
+//
+// Pkd-tree has no clean top-level "kNN(point, k)" API; real usage (mirrored
+// from their own tests/testFramework.h) means grabbing the raw root node
+// and bounding box, and composing a kBoundedQueue per query yourself. Two
+// query modes are exposed here:
+//   - *_single_*: one FFI call per query, matching every other competitor's
+//     benchmark methodology (sequential, no parallel_for). This is the
+//     number that belongs on the same chart as nanoflann/ALGLIB/kiddo.
+//   - *_batch_*: one FFI call covering all queries at once via
+//     parlay::parallel_for across every core, matching Pkd-tree's actual
+//     design intent and its own published benchmark methodology. This is
+//     NOT comparable to the sequential per-query numbers above -- it's a
+//     batch-throughput metric, charted separately.
+//
+// Only nearest_one/nearest_n are implemented; Pkd-tree's range query is
+// another box-composition API of similar complexity to k_nearest, and
+// wasn't worth the added risk for this comparison.
+//
+// Point indices are recovered by pointer arithmetic against the (build()
+// reorders points in place) stored point array, since cpdd::PointType
+// carries no id field of its own.
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <vector>
+
+#include "cpdd/cpdd.h"
+
+namespace {
+
+template <typename Scalar>
+using Point = cpdd::PointType<Scalar, 3>;
+
+template <typename Scalar>
+using Tree = cpdd::ParallelKDtree<Point<Scalar>>;
+
+template <typename Scalar>
+using NNPair = std::pair<std::reference_wrapper<Point<Scalar>>, Scalar>;
+
+template <typename Scalar>
+struct Handle {
+    Tree<Scalar> tree;
+    typename Tree<Scalar>::points wp;
+    typename Tree<Scalar>::node* root = nullptr;
+    typename Tree<Scalar>::box root_box;
+
+    explicit Handle(const Scalar* points, uint64_t n, uint32_t dim)
+        : wp(Tree<Scalar>::points::uninitialized(n)) {
+        for (uint64_t i = 0; i < n; ++i) {
+            wp[i] = Point<Scalar>(const_cast<Scalar*>(points + i * dim));
+        }
+        tree.build(parlay::make_slice(wp), static_cast<uint_fast8_t>(dim));
+        root = tree.get_root();
+        root_box = tree.get_root_box();
+    }
+
+    uint64_t index_of(const Point<Scalar>& p) const {
+        return static_cast<uint64_t>(&p - &wp[0]);
+    }
+};
+
+template <typename Scalar>
+void* build(const Scalar* points, uint64_t n, uint32_t dim) {
+    return new Handle<Scalar>(points, n, dim);
+}
+
+template <typename Scalar>
+void free_handle(void* h) {
+    delete static_cast<Handle<Scalar>*>(h);
+}
+
+// One query, composed exactly as cpdd's own single-query benchmark does.
+template <typename Scalar>
+uint64_t single_query(Handle<Scalar>* h, const Scalar* q, uint64_t k, uint64_t* out_idx, Scalar* out_dist2) {
+    Point<Scalar> query(const_cast<Scalar*>(q));
+    std::vector<NNPair<Scalar>> storage(k, NNPair<Scalar>(std::ref(h->wp[0]), Scalar(0)));
+    cpdd::kBoundedQueue<Point<Scalar>, NNPair<Scalar>> bq(parlay::make_slice(storage.data(), storage.data() + k));
+    size_t visited = 0;
+    h->tree.k_nearest(h->root, query, 3, bq, h->root_box, visited);
+
+    const uint64_t found = static_cast<uint64_t>(bq.m_count);
+    for (uint64_t i = 0; i < found; ++i) {
+        out_idx[i] = h->index_of(storage[i].first.get());
+        out_dist2[i] = storage[i].second;
+    }
+    return found;
+}
+
+// All queries at once, parallel across every core via parlay::parallel_for.
+template <typename Scalar>
+void batch_query(
+    Handle<Scalar>* h, const Scalar* queries_flat, uint64_t num_queries, uint64_t k, uint64_t* out_idx,
+    Scalar* out_dist2) {
+    parlay::parallel_for(0, num_queries, [&](size_t qi) {
+        Point<Scalar> query(const_cast<Scalar*>(queries_flat + qi * 3));
+        std::vector<NNPair<Scalar>> storage(k, NNPair<Scalar>(std::ref(h->wp[0]), Scalar(0)));
+        cpdd::kBoundedQueue<Point<Scalar>, NNPair<Scalar>> bq(parlay::make_slice(storage.data(), storage.data() + k));
+        size_t visited = 0;
+        h->tree.k_nearest(h->root, query, 3, bq, h->root_box, visited);
+
+        const uint64_t found = static_cast<uint64_t>(bq.m_count);
+        for (uint64_t i = 0; i < found; ++i) {
+            out_idx[qi * k + i] = h->index_of(storage[i].first.get());
+            out_dist2[qi * k + i] = storage[i].second;
+        }
+        for (uint64_t i = found; i < k; ++i) {
+            out_idx[qi * k + i] = 0;
+            out_dist2[qi * k + i] = Scalar(0);
+        }
+    });
+}
+
+}  // namespace
+
+extern "C" {
+
+void* pkdtree_build_f32(const float* points, uint64_t n, uint32_t dim) { return build<float>(points, n, dim); }
+void* pkdtree_build_f64(const double* points, uint64_t n, uint32_t dim) { return build<double>(points, n, dim); }
+
+void pkdtree_free_f32(void* h) { free_handle<float>(h); }
+void pkdtree_free_f64(void* h) { free_handle<double>(h); }
+
+uint64_t pkdtree_single_query_f32(void* h, const float* q, uint64_t k, uint64_t* out_idx, float* out_dist2) {
+    return single_query<float>(static_cast<Handle<float>*>(h), q, k, out_idx, out_dist2);
+}
+uint64_t pkdtree_single_query_f64(void* h, const double* q, uint64_t k, uint64_t* out_idx, double* out_dist2) {
+    return single_query<double>(static_cast<Handle<double>*>(h), q, k, out_idx, out_dist2);
+}
+
+void pkdtree_batch_query_f32(
+    void* h, const float* queries_flat, uint64_t num_queries, uint64_t k, uint64_t* out_idx, float* out_dist2) {
+    batch_query<float>(static_cast<Handle<float>*>(h), queries_flat, num_queries, k, out_idx, out_dist2);
+}
+void pkdtree_batch_query_f64(
+    void* h, const double* queries_flat, uint64_t num_queries, uint64_t k, uint64_t* out_idx, double* out_dist2) {
+    batch_query<double>(static_cast<Handle<double>*>(h), queries_flat, num_queries, k, out_idx, out_dist2);
+}
+
+}  // extern "C"

--- a/benches/cpp_shims/skdtree_shim.cpp
+++ b/benches/cpp_shims/skdtree_shim.cpp
@@ -1,0 +1,163 @@
+// skd-tree (achmichalop/skd-tree_2027, MIT) shim.
+//
+// Needs three system packages that upstream's README lists and this build
+// script cannot vendor: Boost, Armadillo and ensmallen. A dead
+// `<tpie/tpie.h>` include is satisfied by an empty stub; see
+// build_cpp_competitors.rs.
+//
+// Four properties of the upstream code shape this shim, and each one is a
+// place where a naive integration would produce a misleading number.
+//
+// 1. `SKDTREE::knn_query` wraps the actual search in two
+//    `std::chrono::steady_clock::now()` calls and accumulates a counter:
+//
+//        inline Points knn_query(Point& q, unsigned int k) {
+//            auto start = std::chrono::steady_clock::now();
+//            results = knnQuery<Dim>[treeType](q, k);
+//            auto end = std::chrono::steady_clock::now();
+//            knn_count++; knn_time += ...;
+//        }
+//
+//    Two clock reads is roughly 40-50ns on this platform, which is more than
+//    kiddo's entire marginal per-query cost. Benchmarking through that
+//    wrapper would measure their instrumentation, not their index, so this
+//    shim calls the dispatch table `knnQuery<Dim>[treeType]` directly. The
+//    constructor still runs, because it is what populates the globals the
+//    table reads.
+//
+// 2. The tree lives in globals -- `inline void *root;` and
+//    `inline TreeSelection treeType;` in tree_core.hpp -- not in the object.
+//    Only one skd-tree can exist process-wide, and building a second one
+//    silently invalidates the first. The handle below is therefore a token
+//    for "the global tree", and `skdtree_build_f64` refuses to build while
+//    another handle is live rather than corrupting it.
+//
+// 3. Coordinates are quantised: queries compute
+//    `(uint64_t)(query[i] * CONVERSION_FACTOR)` with
+//    `CONVERSION_FACTOR = (ULONG_MAX - 1) >> 1`, i.e. ~2^63, and separators
+//    are bit-prefix masks of that value. Negative coordinates cast to
+//    uint64_t are undefined, and coordinates >= 2 overflow the scale. The
+//    benchmark's uniform [0,1) points are fine, but this shim range-checks
+//    rather than trusting the caller, because the failure would otherwise be
+//    silent wrong answers rather than a crash.
+//
+// 4. `knn_query` returns `std::vector<point_t<Dim>>` -- the coordinates of
+//    the neighbours, not indices or distances. Distances are therefore
+//    computed here, which is work the other shims do not do. It is the only
+//    way to validate the results at all, but it is a handicap and must be
+//    reported as one.
+//
+// Dim is a compile-time template parameter, so 3D is instantiated
+// explicitly; a 4D cell would need a second instantiation here.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+#include "indices/nonlearned/skdtree/skdtree.hpp"
+#include "utils/type.hpp"
+
+namespace {
+
+constexpr std::size_t kDim = 3;
+
+// SKDTREE lives in bench::index; the query dispatch table and the tree
+// globals it reads are at namespace scope in evaluation.hpp / tree_core.hpp.
+using SkdTree = bench::index::SKDTREE<kDim>;
+using Point = point_t<kDim>;
+using Points = std::vector<Point>;
+
+// Owns the point vector, because SKDTREE holds `Points& points` by reference
+// and would dangle if the caller's vector went away.
+struct Handle {
+    Points points;
+    std::vector<Point> results_scratch;
+    // Constructed for its side effects on the globals; the queries below go
+    // to the dispatch table directly. See note 1.
+    SkdTree* index = nullptr;
+
+    ~Handle() { delete index; }
+};
+
+// Note 2: the upstream globals permit exactly one live tree.
+bool global_tree_in_use = false;
+
+}  // namespace
+
+extern "C" {
+
+// Returns nullptr if a tree already exists (note 2) or if any coordinate is
+// outside the quantisable range (note 3).
+void* skdtree_build_f64(const double* points, uint64_t n, uint32_t dim) {
+    if (dim != kDim || global_tree_in_use) {
+        return nullptr;
+    }
+
+    auto* handle = new Handle();
+    handle->points.resize(static_cast<std::size_t>(n));
+    for (std::size_t i = 0; i < static_cast<std::size_t>(n); ++i) {
+        for (std::size_t d = 0; d < kDim; ++d) {
+            const double coordinate = points[i * kDim + d];
+            // Guard the quantisation rather than let it wrap silently.
+            if (!(coordinate >= 0.0) || coordinate >= 2.0) {
+                delete handle;
+                return nullptr;
+            }
+            handle->points[i][d] = coordinate;
+        }
+    }
+
+    handle->index = new SkdTree(handle->points);
+    global_tree_in_use = true;
+    return handle;
+}
+
+void skdtree_free_f64(void* raw_handle) {
+    if (raw_handle == nullptr) {
+        return;
+    }
+    delete static_cast<Handle*>(raw_handle);
+    global_tree_in_use = false;
+}
+
+// Writes squared Euclidean distances for the k nearest neighbours, ascending,
+// and returns how many were produced. Distances are computed here because
+// upstream returns coordinates (note 4).
+uint64_t skdtree_nearest_n_f64(void* raw_handle, const double* q, uint64_t k,
+                               double* out_dist2) {
+    auto* handle = static_cast<Handle*>(raw_handle);
+
+    Point query;
+    for (std::size_t d = 0; d < kDim; ++d) {
+        query[d] = q[d];
+    }
+
+    // Note 1: bypass SKDTREE::knn_query's clock instrumentation.
+    Points results = knnQuery<kDim>[treeType](query, static_cast<uint32_t>(k));
+
+    const std::size_t produced = std::min<std::size_t>(results.size(), static_cast<std::size_t>(k));
+    for (std::size_t i = 0; i < produced; ++i) {
+        double sum = 0.0;
+        for (std::size_t d = 0; d < kDim; ++d) {
+            const double delta = results[i][d] - query[d];
+            sum += delta * delta;
+        }
+        out_dist2[i] = sum;
+    }
+    // Best-first search returns in order, but the contract the other shims
+    // present is "ascending", so do not rely on it.
+    std::sort(out_dist2, out_dist2 + produced);
+    return produced;
+}
+
+void skdtree_nearest_one_f64(void* raw_handle, const double* q, double* out_dist2) {
+    double best = std::numeric_limits<double>::infinity();
+    if (skdtree_nearest_n_f64(raw_handle, q, 1, &best) == 0) {
+        best = std::numeric_limits<double>::infinity();
+    }
+    *out_dist2 = best;
+}
+
+}  // extern "C"

--- a/benches/profile_cpp_competitors.rs
+++ b/benches/profile_cpp_competitors.rs
@@ -1,0 +1,1848 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! Query-only comparison against non-Rust k-d tree / nearest-neighbour
+//! libraries, mirroring `profile_external_kd_trees.rs`'s methodology for the
+//! Rust competitors: the same seeded, uniformly distributed 3D `f32`/`f64`
+//! points and queries, tree construction outside Criterion's timed regions,
+//! and each library's own exact-query API (eps=0 wherever a library exposes
+//! an error-bound knob).
+//!
+//! - **nanoflann**: full coverage (nearest_one, nearest_n, within_radius,
+//!   f32 + f64). ANN, libkdtree++, and FASTANN were tried and dropped: ANN
+//!   and libkdtree++ were both substantially slower than nanoflann with no
+//!   offsetting advantage, and FASTANN's "exact" mode turned out to be an
+//!   O(N) brute-force linear scan rather than a tree, making it a poor
+//!   comparison point.
+//! - **ALGLIB** (free C++ edition, GPL 2+, vendored source-only for local
+//!   benchmarking): full coverage but f64-only, since ALGLIB's `real` type
+//!   is hard-coded to `double` throughout, same limitation as ANN had.
+//! - **Pkd-tree** (ucrparlay/Pkd-tree, SIGMOD'25, ParlayLib fork-join
+//!   parallelism): nearest_one/nearest_n only, f32 + f64. No within_radius
+//!   -- its range query is another raw box-composition API of similar
+//!   complexity to k_nearest, not worth the added risk here. Benchmarked in
+//!   two genuinely different, non-comparable ways: a single-threaded
+//!   sequential per-query mode (`pkdtree_*` in the main
+//!   `profile_cpp_competitors` groups, comparable to every other
+//!   competitor's numbers) and a batch-parallel mode that submits every
+//!   query at once via `parlay::parallel_for` across all cores (in the
+//!   separate `profile_pkdtree_batch` groups) -- the latter is Pkd-tree's
+//!   actual design intent, but is a batch-throughput metric, not a
+//!   per-query latency one, so it gets its own chart rather than a line on
+//!   the shared one.
+//!
+//! `profile_pkdtree_batch` also carries kiddo's own native
+//! `kiddo::batch::Executor::serial()`/`parallel()` numbers (via
+//! `KdTree::query_batch`, no FFI needed) alongside Pkd-tree's batch mode, so
+//! the two genuinely parallel-capable structures land on the same
+//! batch-throughput chart.
+//!
+//! `kiddo_vs_pkdtree_single` (`profile_kiddo_vs_pkdtree` groups) is a
+//! dedicated two-library, single-threaded per-query comparison, kept
+//! separate from `profile_cpp_competitors` so it can be run at larger tree
+//! sizes without nanoflann/ALGLIB also having to build and hold a tree that
+//! size in memory at the same time. It reads its own
+//! `KIDDO_LARGE_MIN/MAX_LOG2_POINTS` for that reason. 2^24 f64 peaks at
+//! around 2 GB resident; sizes beyond that were what exhausted memory
+//! previously, so raise the range deliberately rather than by default.
+//!
+//! Vendored C++ sources are fetched at build time behind the
+//! `cpp_competitors` feature; see `build_cpp_competitors.rs`.
+//!
+//! # Selecting work
+//!
+//! Every `criterion_group!` function body runs on every invocation:
+//! Criterion's `--` filter only decides which `bench_function` results get
+//! recorded, not which surrounding Rust setup code executes. Selecting with
+//! that filter alone therefore still generates every point cloud and builds
+//! every tree, which is what made full-range runs exhaust memory. Selection
+//! is done up front here instead, before anything is allocated:
+//!
+//! - `KIDDO_CPP_SUITES`: `cpp_competitors`, `pkdtree_batch`,
+//!   `kiddo_vs_pkdtree`, `pkdtree_probe`. The probe is a temporary
+//!   diagnostic and is opt-in; the other three are the default.
+//! - `KIDDO_CPP_LIBRARIES`: `nanoflann`, `alglib`, `pkdtree`, `kiddo`. A
+//!   library name covers all of its modes, so `pkdtree` selects both the
+//!   sequential and the batch-parallel Pkd-tree benchmarks.
+//! - `KIDDO_CPP_SCALARS`: `f32`, `f64`.
+//!
+//! Each is a comma-separated list, unset means "all of the defaults", and an
+//! unrecognised name is an error rather than a silently empty run. A point
+//! cloud is generated, and a tree built, only once something still selected
+//! actually needs it.
+
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use kiddo::batch::Executor;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::{DonnellyCyclicSimdDescent, DonnellyUnrolled, Eytzinger};
+use kiddo::SquaredEuclidean;
+use kiddo::StemStrategy;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::ffi::c_void;
+use std::hint::black_box;
+use std::num::NonZeroUsize;
+
+const K: usize = 3;
+const DEFAULT_QUERY_COUNT: usize = 1_000;
+const DEFAULT_MIN_LOG2_POINTS: u32 = 16;
+const DEFAULT_MAX_LOG2_POINTS: u32 = 24;
+const DEFAULT_RADIUS: f64 = 0.05;
+// Match the focused Kiddo suites and profile_external_kd_trees so all
+// separately collected results are comparable.
+const POINT_SEED: u64 = 0x5eed_0000_0000_0001;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0002;
+const MAX_QTYS: [usize; 3] = [5, 20, 50];
+// Pkd-tree has no dedicated single-nearest entry point, so its nearest_one
+// series is its k-nearest batch call with k=1. kiddo's is the real
+// nearest_one, whose flat one-result-per-query collection is the whole reason
+// it exists as a separate query.
+const NEAREST_ONE_K: usize = 1;
+// Generous cap on how many within_radius matches are copied out through FFI;
+// the true match count is always returned even if it exceeds this.
+const RADIUS_CAP: usize = 4096;
+
+const SUITE_CPP_COMPETITORS: &str = "cpp_competitors";
+const SUITE_PKDTREE_BATCH: &str = "pkdtree_batch";
+const SUITE_KIDDO_VS_PKDTREE: &str = "kiddo_vs_pkdtree";
+const SUITE_PKDTREE_PROBE: &str = "pkdtree_probe";
+const ALL_SUITES: [&str; 4] = [
+    SUITE_CPP_COMPETITORS,
+    SUITE_PKDTREE_BATCH,
+    SUITE_KIDDO_VS_PKDTREE,
+    SUITE_PKDTREE_PROBE,
+];
+// The probe is a temporary diagnostic, so it is opt-in rather than part of an
+// unqualified run.
+const DEFAULT_SUITES: [&str; 3] = [
+    SUITE_CPP_COMPETITORS,
+    SUITE_PKDTREE_BATCH,
+    SUITE_KIDDO_VS_PKDTREE,
+];
+const NANOFLANN: &str = "nanoflann";
+const ALGLIB: &str = "alglib";
+const PKDTREE: &str = "pkdtree";
+const KIDDO: &str = "kiddo";
+const SKDTREE: &str = "skdtree";
+const ALL_LIBRARIES: [&str; 5] = [NANOFLANN, ALGLIB, PKDTREE, KIDDO, SKDTREE];
+const F32: &str = "f32";
+const F64: &str = "f64";
+const ALL_SCALARS: [&str; 2] = [F32, F64];
+
+// Pkd-tree's build_recursive has a box-containment assertion that fails for
+// f32 from 2^22 points upward: 2^21 builds, 2^22 and 2^23 abort, and f64 is
+// unaffected at least through 2^24. The assertion aborts the process rather
+// than returning an error, which would take every later benchmark in the same
+// run down with it, so oversized f32 Pkd-tree cells are skipped up front.
+const PKDTREE_MAX_LOG2_POINTS_F32: u32 = 21;
+
+/// Asserts that the experimental Donnelly cyclic SIMD descent answers exactly
+/// as the Eytzinger baseline does on this tree, so a throughput win can never
+/// be a wrong-answer win. Checked once per run, at the smallest size.
+fn validate_kiddo_strategies_f64(points: &[PointF64], queries: &[PointF64]) {
+    let eytzinger: KiddoF64 = KdTree::new_from_slice(points).unwrap();
+    let donnelly: KiddoF64<DonnellyCyclicSimdDescent<3>> = KdTree::new_from_slice(points).unwrap();
+    let max_qty = NonZeroUsize::new(*MAX_QTYS.last().unwrap()).unwrap();
+
+    for (index, query) in queries.iter().enumerate() {
+        let expected = eytzinger
+            .query(query)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        let actual = donnelly
+            .query(query)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        assert_eq!(
+            (actual.item, actual.distance),
+            (expected.item, expected.distance),
+            "Donnelly cyclic SIMD nearest_one disagrees with Eytzinger at query {index}"
+        );
+
+        let expected = eytzinger
+            .query(query)
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .execute();
+        let actual = donnelly
+            .query(query)
+            .nearest_n::<SquaredEuclidean<f64>>(max_qty)
+            .execute();
+        let expected: Vec<_> = expected.iter().map(|r| (r.item, r.distance)).collect();
+        let actual: Vec<_> = actual.iter().map(|r| (r.item, r.distance)).collect();
+        assert_eq!(
+            actual, expected,
+            "Donnelly cyclic SIMD nearest_n disagrees with Eytzinger at query {index}"
+        );
+    }
+}
+
+/// The executors charted side by side in the batch-throughput suite.
+fn kiddo_batch_executors() -> [(&'static str, Executor); 3] {
+    [
+        ("serial", Executor::serial()),
+        ("parallel", Executor::parallel()),
+        // What a caller who has read the tuning guidance would actually
+        // configure, and therefore the number kiddo should be judged on.
+        // `parallel` stays in as the untuned control.
+        (
+            "tuned",
+            Executor::parallel()
+                .with_default_static_chunking()
+                .with_serial_fallback(),
+        ),
+    ]
+}
+
+fn pkdtree_supports_f32(point_count: usize) -> bool {
+    point_count <= 1usize << PKDTREE_MAX_LOG2_POINTS_F32
+}
+
+/// Whether Pkd-tree should be benchmarked for this f32 cell, warning once per
+/// skipped size so an absent series is never mistaken for a missing run.
+fn pkdtree_f32_selected(libraries: &Selection, point_count: usize) -> bool {
+    if !libraries.contains(PKDTREE) {
+        return false;
+    }
+    if !pkdtree_supports_f32(point_count) {
+        eprintln!(
+            "skipping Pkd-tree f32 at {point_count} points: upstream build assertion fails above 2^{PKDTREE_MAX_LOG2_POINTS_F32}"
+        );
+        return false;
+    }
+    true
+}
+
+type PointF32 = [f32; K];
+type PointF64 = [f64; K];
+const B: usize = 32;
+type KiddoF32<S = Eytzinger> = KdTree<f32, u32, S, FlatVec<f32, u32, K, B>, K, B>;
+type KiddoF64<S = Eytzinger> = KdTree<f64, u32, S, FlatVec<f64, u32, K, B>, K, B>;
+// DonnellyCyclicSimdDescent's AVX-512 path asserts BH == K, and is implemented
+// only for f64/3D/BH3 and f32/4D/BH4. These benchmarks are 3D for every
+// library, so f64 gets the SIMD descent and f32 (K=3) cannot have it at all.
+
+mod ffi {
+    use std::ffi::c_void;
+
+    #[allow(clippy::duplicated_attributes)]
+    #[link(name = "nanoflann_shim", kind = "static")]
+    #[link(name = "alglib_shim", kind = "static")]
+    #[link(name = "pkdtree_shim", kind = "static")]
+    #[link(name = "skdtree_shim", kind = "static")]
+    #[link(name = "stdc++")]
+    #[link(name = "pthread")]
+    extern "C" {
+        pub fn nanoflann_build_f32(points: *const f32, n: u64, dim: u32) -> *mut c_void;
+        pub fn nanoflann_build_f64(points: *const f64, n: u64, dim: u32) -> *mut c_void;
+        pub fn nanoflann_free_f32(handle: *mut c_void);
+        pub fn nanoflann_free_f64(handle: *mut c_void);
+        pub fn nanoflann_nearest_one_f32(
+            handle: *mut c_void,
+            q: *const f32,
+            out_idx: *mut u64,
+            out_dist2: *mut f32,
+        );
+        pub fn nanoflann_nearest_one_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+        );
+        pub fn nanoflann_nearest_n_f32(
+            handle: *mut c_void,
+            q: *const f32,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f32,
+        ) -> u64;
+        pub fn nanoflann_nearest_n_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+        ) -> u64;
+        pub fn nanoflann_within_radius_f32(
+            handle: *mut c_void,
+            q: *const f32,
+            radius2: f32,
+            out_idx: *mut u64,
+            out_dist2: *mut f32,
+            cap: u64,
+        ) -> u64;
+        pub fn nanoflann_within_radius_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            radius2: f64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+            cap: u64,
+        ) -> u64;
+
+        pub fn alglib_build_f64(points: *const f64, n: u64, dim: u32) -> *mut c_void;
+        pub fn alglib_free_f64(handle: *mut c_void);
+        pub fn alglib_nearest_one_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+        );
+        pub fn alglib_nearest_n_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+        ) -> u64;
+        pub fn alglib_within_radius_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            radius2: f64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+            cap: u64,
+        ) -> u64;
+
+        pub fn skdtree_build_f64(points: *const f64, n: u64, dim: u32) -> *mut c_void;
+        pub fn skdtree_free_f64(handle: *mut c_void);
+        pub fn skdtree_nearest_n_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            k: u64,
+            out_dist2: *mut f64,
+        ) -> u64;
+        pub fn pkdtree_build_f32(points: *const f32, n: u64, dim: u32) -> *mut c_void;
+        pub fn pkdtree_build_f64(points: *const f64, n: u64, dim: u32) -> *mut c_void;
+        pub fn pkdtree_free_f32(handle: *mut c_void);
+        pub fn pkdtree_free_f64(handle: *mut c_void);
+        pub fn pkdtree_single_query_f32(
+            handle: *mut c_void,
+            q: *const f32,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f32,
+        ) -> u64;
+        pub fn pkdtree_single_query_f64(
+            handle: *mut c_void,
+            q: *const f64,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+        ) -> u64;
+        pub fn pkdtree_batch_query_f32(
+            handle: *mut c_void,
+            queries_flat: *const f32,
+            num_queries: u64,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f32,
+        );
+        pub fn pkdtree_batch_query_f64(
+            handle: *mut c_void,
+            queries_flat: *const f64,
+            num_queries: u64,
+            k: u64,
+            out_idx: *mut u64,
+            out_dist2: *mut f64,
+        );
+    }
+}
+
+macro_rules! raii_handle {
+    ($name:ident, $free:path) => {
+        struct $name(*mut c_void);
+        impl Drop for $name {
+            fn drop(&mut self) {
+                unsafe { $free(self.0) }
+            }
+        }
+    };
+}
+
+raii_handle!(NanoflannF32, ffi::nanoflann_free_f32);
+raii_handle!(NanoflannF64, ffi::nanoflann_free_f64);
+raii_handle!(AlglibF64, ffi::alglib_free_f64);
+raii_handle!(PkdtreeF32, ffi::pkdtree_free_f32);
+raii_handle!(PkdtreeF64, ffi::pkdtree_free_f64);
+raii_handle!(SkdtreeF64, ffi::skdtree_free_f64);
+
+fn read_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_u32_env(var: &str, default: u32) -> u32 {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .unwrap_or_else(|_| panic!("{var} must be a positive integer"))
+        })
+        .unwrap_or(default)
+}
+
+fn read_f64_env(var: &str, default: f64) -> f64 {
+    std::env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .parse::<f64>()
+                .unwrap_or_else(|_| panic!("{var} must be a finite positive number"))
+        })
+        .unwrap_or(default)
+}
+
+/// A comma-separated up-front selection read from an environment variable.
+///
+/// Consulted before any point cloud is generated or any tree is built, so
+/// that deselected work costs nothing instead of being built, benchmarked and
+/// then dropped from the exported results.
+struct Selection {
+    names: Vec<String>,
+}
+
+impl Selection {
+    fn from_env(var: &str, valid: &[&str], default: &[&str]) -> Self {
+        let names: Vec<String> = std::env::var(var)
+            .unwrap_or_default()
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .collect();
+
+        if names.is_empty() {
+            return Self {
+                names: default.iter().map(|name| (*name).to_owned()).collect(),
+            };
+        }
+
+        for name in &names {
+            assert!(
+                valid.contains(&name.as_str()),
+                "{var} contains unknown entry {name:?}; valid entries are {valid:?}"
+            );
+        }
+
+        Self { names }
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.names.iter().any(|selected| selected == name)
+    }
+
+    /// True when at least one of `names` is selected, i.e. when the enclosing
+    /// point cloud is still worth generating.
+    fn any(&self, names: &[&str]) -> bool {
+        names.iter().any(|name| self.contains(name))
+    }
+
+    fn list(&self) -> String {
+        self.names.join(",")
+    }
+}
+
+fn suite_selection() -> Selection {
+    Selection::from_env("KIDDO_CPP_SUITES", &ALL_SUITES, &DEFAULT_SUITES)
+}
+
+fn library_selection() -> Selection {
+    Selection::from_env("KIDDO_CPP_LIBRARIES", &ALL_LIBRARIES, &ALL_LIBRARIES)
+}
+
+fn scalar_selection() -> Selection {
+    Selection::from_env("KIDDO_CPP_SCALARS", &ALL_SCALARS, &ALL_SCALARS)
+}
+
+fn build_points_f32(point_count: usize) -> Vec<PointF32> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries_f32(query_count: usize) -> Vec<PointF32> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn build_points_f64(point_count: usize) -> Vec<PointF64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
+    (0..point_count).map(|_| rng.random()).collect()
+}
+
+fn build_queries_f64(query_count: usize) -> Vec<PointF64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(QUERY_SEED);
+    (0..query_count).map(|_| rng.random()).collect()
+}
+
+fn id(library: &str, query: &str, point_count: usize) -> BenchmarkId {
+    BenchmarkId::new(format!("{library}_{query}"), point_count)
+}
+
+fn expected_nearest_f32(points: &[PointF32], query: &PointF32, max_qty: usize) -> Vec<f32> {
+    let mut expected: Vec<_> = points
+        .iter()
+        .map(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(p, q)| (p - q) * (p - q))
+                .sum::<f32>()
+        })
+        .collect();
+    expected.sort_unstable_by(f32::total_cmp);
+    expected.truncate(max_qty);
+    expected
+}
+
+fn expected_nearest_f64(points: &[PointF64], query: &PointF64, max_qty: usize) -> Vec<f64> {
+    let mut expected: Vec<_> = points
+        .iter()
+        .map(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(p, q)| (p - q) * (p - q))
+                .sum::<f64>()
+        })
+        .collect();
+    expected.sort_unstable_by(f64::total_cmp);
+    expected.truncate(max_qty);
+    expected
+}
+
+fn expected_within_count_f32(points: &[PointF32], query: &PointF32, max_dist2: f32) -> usize {
+    points
+        .iter()
+        .filter(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(p, q)| (p - q) * (p - q))
+                .sum::<f32>()
+                <= max_dist2
+        })
+        .count()
+}
+
+fn expected_within_count_f64(points: &[PointF64], query: &PointF64, max_dist2: f64) -> usize {
+    points
+        .iter()
+        .filter(|point| {
+            point
+                .iter()
+                .zip(query)
+                .map(|(p, q)| (p - q) * (p - q))
+                .sum::<f64>()
+                <= max_dist2
+        })
+        .count()
+}
+
+fn assert_distances_match_f32(label: &str, mut actual: Vec<f32>, expected: &[f32]) {
+    actual.sort_unstable_by(f32::total_cmp);
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label} returned the wrong number of neighbours"
+    );
+    for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+        let tolerance = 1.0e-5 * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "{label} distance mismatch at result {index}: actual={actual} expected={expected}"
+        );
+    }
+}
+
+fn assert_distances_match_f64(label: &str, mut actual: Vec<f64>, expected: &[f64]) {
+    actual.sort_unstable_by(f64::total_cmp);
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label} returned the wrong number of neighbours"
+    );
+    for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+        let tolerance = 1.0e-12 * expected.abs().max(1.0);
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "{label} distance mismatch at result {index}: actual={actual} expected={expected}"
+        );
+    }
+}
+
+const VALIDATED_F32: [&str; 2] = [NANOFLANN, PKDTREE];
+
+fn validate_implementations_f32(
+    points: &[PointF32],
+    query: &PointF32,
+    radius: f32,
+    libraries: &Selection,
+) {
+    if !libraries.any(&VALIDATED_F32) {
+        return;
+    }
+
+    let max_qty = *MAX_QTYS.last().unwrap();
+    let radius2 = radius * radius;
+    let expected = expected_nearest_f32(points, query, max_qty);
+    let mut idx = vec![0u64; max_qty];
+    let mut dist2 = vec![0f32; max_qty];
+
+    unsafe {
+        if libraries.contains(NANOFLANN) {
+            let expected_within = expected_within_count_f32(points, query, radius2);
+            let handle = NanoflannF32(ffi::nanoflann_build_f32(
+                points.as_ptr().cast(),
+                points.len() as u64,
+                K as u32,
+            ));
+            let n = ffi::nanoflann_nearest_n_f32(
+                handle.0,
+                query.as_ptr(),
+                max_qty as u64,
+                idx.as_mut_ptr(),
+                dist2.as_mut_ptr(),
+            );
+            assert_distances_match_f32("nanoflann", dist2[..n as usize].to_vec(), &expected);
+            let mut ridx = vec![0u64; RADIUS_CAP];
+            let mut rdist2 = vec![0f32; RADIUS_CAP];
+            let total = ffi::nanoflann_within_radius_f32(
+                handle.0,
+                query.as_ptr(),
+                radius2,
+                ridx.as_mut_ptr(),
+                rdist2.as_mut_ptr(),
+                RADIUS_CAP as u64,
+            );
+            assert_eq!(
+                total as usize, expected_within,
+                "nanoflann returned the wrong within-radius count"
+            );
+        }
+
+        if libraries.contains(PKDTREE) && pkdtree_supports_f32(points.len()) {
+            let handle = PkdtreeF32(ffi::pkdtree_build_f32(
+                points.as_ptr().cast(),
+                points.len() as u64,
+                K as u32,
+            ));
+            let n = ffi::pkdtree_single_query_f32(
+                handle.0,
+                query.as_ptr(),
+                max_qty as u64,
+                idx.as_mut_ptr(),
+                dist2.as_mut_ptr(),
+            );
+            assert_distances_match_f32("Pkd-tree", dist2[..n as usize].to_vec(), &expected);
+        }
+    }
+}
+
+const VALIDATED_F64: [&str; 4] = [NANOFLANN, ALGLIB, PKDTREE, SKDTREE];
+
+fn validate_implementations_f64(
+    points: &[PointF64],
+    query: &PointF64,
+    radius: f64,
+    libraries: &Selection,
+) {
+    if !libraries.any(&VALIDATED_F64) {
+        return;
+    }
+
+    let max_qty = *MAX_QTYS.last().unwrap();
+    let radius2 = radius * radius;
+    let expected = expected_nearest_f64(points, query, max_qty);
+    let mut idx = vec![0u64; max_qty];
+    let mut dist2 = vec![0f64; max_qty];
+    let mut ridx = vec![0u64; RADIUS_CAP];
+    let mut rdist2 = vec![0f64; RADIUS_CAP];
+    let expected_within = if libraries.any(&[NANOFLANN, ALGLIB]) {
+        expected_within_count_f64(points, query, radius2)
+    } else {
+        0
+    };
+
+    unsafe {
+        if libraries.contains(NANOFLANN) {
+            let handle = NanoflannF64(ffi::nanoflann_build_f64(
+                points.as_ptr().cast(),
+                points.len() as u64,
+                K as u32,
+            ));
+            let n = ffi::nanoflann_nearest_n_f64(
+                handle.0,
+                query.as_ptr(),
+                max_qty as u64,
+                idx.as_mut_ptr(),
+                dist2.as_mut_ptr(),
+            );
+            assert_distances_match_f64("nanoflann", dist2[..n as usize].to_vec(), &expected);
+            let total = ffi::nanoflann_within_radius_f64(
+                handle.0,
+                query.as_ptr(),
+                radius2,
+                ridx.as_mut_ptr(),
+                rdist2.as_mut_ptr(),
+                RADIUS_CAP as u64,
+            );
+            assert_eq!(
+                total as usize, expected_within,
+                "nanoflann returned the wrong within-radius count"
+            );
+        }
+
+        if libraries.contains(ALGLIB) {
+            let handle = AlglibF64(ffi::alglib_build_f64(
+                points.as_ptr().cast(),
+                points.len() as u64,
+                K as u32,
+            ));
+            let n = ffi::alglib_nearest_n_f64(
+                handle.0,
+                query.as_ptr(),
+                max_qty as u64,
+                idx.as_mut_ptr(),
+                dist2.as_mut_ptr(),
+            );
+            assert_distances_match_f64("ALGLIB", dist2[..n as usize].to_vec(), &expected);
+            let total = ffi::alglib_within_radius_f64(
+                handle.0,
+                query.as_ptr(),
+                radius2,
+                ridx.as_mut_ptr(),
+                rdist2.as_mut_ptr(),
+                RADIUS_CAP as u64,
+            );
+            assert_eq!(
+                total as usize, expected_within,
+                "ALGLIB returned the wrong within-radius count"
+            );
+        }
+
+        if libraries.contains(SKDTREE) {
+            // Returns null if the globals are already occupied or a coordinate
+            // is outside the quantisable range; both are silent-wrong-answer
+            // hazards, so treat null as a hard failure rather than a skip.
+            let raw = ffi::skdtree_build_f64(points.as_ptr().cast(), points.len() as u64, K as u32);
+            assert!(
+                !raw.is_null(),
+                "skd-tree refused to build; see skdtree_shim.cpp"
+            );
+            let handle = SkdtreeF64(raw);
+            let n = ffi::skdtree_nearest_n_f64(
+                handle.0,
+                query.as_ptr(),
+                max_qty as u64,
+                dist2.as_mut_ptr(),
+            );
+            assert_distances_match_f64("skd-tree", dist2[..n as usize].to_vec(), &expected);
+        }
+
+        if libraries.contains(PKDTREE) {
+            let handle = PkdtreeF64(ffi::pkdtree_build_f64(
+                points.as_ptr().cast(),
+                points.len() as u64,
+                K as u32,
+            ));
+            let n = ffi::pkdtree_single_query_f64(
+                handle.0,
+                query.as_ptr(),
+                max_qty as u64,
+                idx.as_mut_ptr(),
+                dist2.as_mut_ptr(),
+            );
+            assert_distances_match_f64("Pkd-tree", dist2[..n as usize].to_vec(), &expected);
+        }
+    }
+}
+
+fn bench_nanoflann_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+    radius2: f32,
+    within_radius_id: &str,
+) {
+    let handle = unsafe {
+        NanoflannF32(ffi::nanoflann_build_f32(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+
+    group.bench_function(id("nanoflann", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut item = 0u64;
+            for query in queries {
+                let mut idx = 0u64;
+                let mut dist2 = 0.0f32;
+                unsafe {
+                    ffi::nanoflann_nearest_one_f32(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        &mut idx,
+                        &mut dist2,
+                    );
+                }
+                distance += dist2;
+                item = item.wrapping_add(idx);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let mut idx_buf = vec![0u64; max_qty];
+        let mut dist2_buf = vec![0f32; max_qty];
+        group.bench_function(
+            id("nanoflann", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f32;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let n = unsafe {
+                            ffi::nanoflann_nearest_n_f32(
+                                handle.0,
+                                black_box(query.as_ptr()),
+                                max_qty as u64,
+                                idx_buf.as_mut_ptr(),
+                                dist2_buf.as_mut_ptr(),
+                            )
+                        };
+                        len = len.wrapping_add(n);
+                        distance += dist2_buf[..n as usize].iter().sum::<f32>();
+                        item = idx_buf[..n as usize]
+                            .iter()
+                            .fold(item, |acc, v| acc.wrapping_add(*v));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+
+    let mut idx_buf = vec![0u64; RADIUS_CAP];
+    let mut dist2_buf = vec![0f32; RADIUS_CAP];
+    group.bench_function(id("nanoflann", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0u64;
+            let mut distance = 0.0f32;
+            for query in queries {
+                let total = unsafe {
+                    ffi::nanoflann_within_radius_f32(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        radius2,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                        RADIUS_CAP as u64,
+                    )
+                };
+                let copied = (total as usize).min(RADIUS_CAP);
+                len = len.wrapping_add(total);
+                distance += dist2_buf[..copied].iter().sum::<f32>();
+            }
+            black_box((len, distance))
+        });
+    });
+}
+
+fn bench_nanoflann_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+    radius2: f64,
+    within_radius_id: &str,
+) {
+    let handle = unsafe {
+        NanoflannF64(ffi::nanoflann_build_f64(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+
+    group.bench_function(id("nanoflann", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0u64;
+            for query in queries {
+                let mut idx = 0u64;
+                let mut dist2 = 0.0f64;
+                unsafe {
+                    ffi::nanoflann_nearest_one_f64(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        &mut idx,
+                        &mut dist2,
+                    );
+                }
+                distance += dist2;
+                item = item.wrapping_add(idx);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let mut idx_buf = vec![0u64; max_qty];
+        let mut dist2_buf = vec![0f64; max_qty];
+        group.bench_function(
+            id("nanoflann", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f64;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let n = unsafe {
+                            ffi::nanoflann_nearest_n_f64(
+                                handle.0,
+                                black_box(query.as_ptr()),
+                                max_qty as u64,
+                                idx_buf.as_mut_ptr(),
+                                dist2_buf.as_mut_ptr(),
+                            )
+                        };
+                        len = len.wrapping_add(n);
+                        distance += dist2_buf[..n as usize].iter().sum::<f64>();
+                        item = idx_buf[..n as usize]
+                            .iter()
+                            .fold(item, |acc, v| acc.wrapping_add(*v));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+
+    let mut idx_buf = vec![0u64; RADIUS_CAP];
+    let mut dist2_buf = vec![0f64; RADIUS_CAP];
+    group.bench_function(id("nanoflann", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0u64;
+            let mut distance = 0.0f64;
+            for query in queries {
+                let total = unsafe {
+                    ffi::nanoflann_within_radius_f64(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        radius2,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                        RADIUS_CAP as u64,
+                    )
+                };
+                let copied = (total as usize).min(RADIUS_CAP);
+                len = len.wrapping_add(total);
+                distance += dist2_buf[..copied].iter().sum::<f64>();
+            }
+            black_box((len, distance))
+        });
+    });
+}
+
+fn bench_alglib_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+    radius2: f64,
+    within_radius_id: &str,
+) {
+    let handle = unsafe {
+        AlglibF64(ffi::alglib_build_f64(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+
+    group.bench_function(id("alglib", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0u64;
+            for query in queries {
+                let mut idx = 0u64;
+                let mut dist2 = 0.0f64;
+                unsafe {
+                    ffi::alglib_nearest_one_f64(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        &mut idx,
+                        &mut dist2,
+                    );
+                }
+                distance += dist2;
+                item = item.wrapping_add(idx);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let mut idx_buf = vec![0u64; max_qty];
+        let mut dist2_buf = vec![0f64; max_qty];
+        group.bench_function(
+            id("alglib", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f64;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let n = unsafe {
+                            ffi::alglib_nearest_n_f64(
+                                handle.0,
+                                black_box(query.as_ptr()),
+                                max_qty as u64,
+                                idx_buf.as_mut_ptr(),
+                                dist2_buf.as_mut_ptr(),
+                            )
+                        };
+                        len = len.wrapping_add(n);
+                        distance += dist2_buf[..n as usize].iter().sum::<f64>();
+                        item = idx_buf[..n as usize]
+                            .iter()
+                            .fold(item, |acc, v| acc.wrapping_add(*v));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+
+    let mut idx_buf = vec![0u64; RADIUS_CAP];
+    let mut dist2_buf = vec![0f64; RADIUS_CAP];
+    group.bench_function(id("alglib", within_radius_id, point_count), |b| {
+        b.iter(|| {
+            let mut len = 0u64;
+            let mut distance = 0.0f64;
+            for query in queries {
+                let total = unsafe {
+                    ffi::alglib_within_radius_f64(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        radius2,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                        RADIUS_CAP as u64,
+                    )
+                };
+                let copied = (total as usize).min(RADIUS_CAP);
+                len = len.wrapping_add(total);
+                distance += dist2_buf[..copied].iter().sum::<f64>();
+            }
+            black_box((len, distance))
+        });
+    });
+}
+
+fn bench_pkdtree_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let handle = unsafe {
+        PkdtreeF32(ffi::pkdtree_build_f32(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+
+    group.bench_function(id("pkdtree", "nearest_one", point_count), |b| {
+        let mut idx_buf = [0u64; 1];
+        let mut dist2_buf = [0f32; 1];
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut item = 0u64;
+            for query in queries {
+                unsafe {
+                    ffi::pkdtree_single_query_f32(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        1,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                    );
+                }
+                distance += dist2_buf[0];
+                item = item.wrapping_add(idx_buf[0]);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let mut idx_buf = vec![0u64; max_qty];
+        let mut dist2_buf = vec![0f32; max_qty];
+        group.bench_function(
+            id("pkdtree", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f32;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let n = unsafe {
+                            ffi::pkdtree_single_query_f32(
+                                handle.0,
+                                black_box(query.as_ptr()),
+                                max_qty as u64,
+                                idx_buf.as_mut_ptr(),
+                                dist2_buf.as_mut_ptr(),
+                            )
+                        };
+                        len = len.wrapping_add(n);
+                        distance += dist2_buf[..n as usize].iter().sum::<f32>();
+                        item = idx_buf[..n as usize]
+                            .iter()
+                            .fold(item, |acc, v| acc.wrapping_add(*v));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+/// skd-tree is f64-only and has no batch API, so it appears here in the
+/// per-query suite and not on the batch-throughput chart. It also has no
+/// dedicated single-nearest entry point, so nearest_one is k=1.
+fn bench_skdtree_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let raw =
+        unsafe { ffi::skdtree_build_f64(points.as_ptr().cast(), points.len() as u64, K as u32) };
+    assert!(
+        !raw.is_null(),
+        "skd-tree refused to build at {point_count} points; see skdtree_shim.cpp"
+    );
+    let handle = SkdtreeF64(raw);
+
+    for (query_id, max_qty) in std::iter::once(("nearest_one".to_owned(), NEAREST_ONE_K))
+        .chain(MAX_QTYS.map(|max_qty| (format!("nearest_n_k{max_qty}"), max_qty)))
+    {
+        let mut dist2_buf = vec![0f64; max_qty];
+        group.bench_function(id("skdtree", &query_id, point_count), |b| {
+            b.iter(|| {
+                let mut len = 0u64;
+                let mut distance = 0.0f64;
+                for query in queries {
+                    let n = unsafe {
+                        ffi::skdtree_nearest_n_f64(
+                            handle.0,
+                            black_box(query.as_ptr()),
+                            max_qty as u64,
+                            dist2_buf.as_mut_ptr(),
+                        )
+                    };
+                    len = len.wrapping_add(n);
+                    distance += dist2_buf[..n as usize].iter().sum::<f64>();
+                }
+                black_box((len, distance))
+            });
+        });
+    }
+}
+
+fn bench_pkdtree_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let handle = unsafe {
+        PkdtreeF64(ffi::pkdtree_build_f64(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+
+    group.bench_function(id("pkdtree", "nearest_one", point_count), |b| {
+        let mut idx_buf = [0u64; 1];
+        let mut dist2_buf = [0f64; 1];
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0u64;
+            for query in queries {
+                unsafe {
+                    ffi::pkdtree_single_query_f64(
+                        handle.0,
+                        black_box(query.as_ptr()),
+                        1,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                    );
+                }
+                distance += dist2_buf[0];
+                item = item.wrapping_add(idx_buf[0]);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let mut idx_buf = vec![0u64; max_qty];
+        let mut dist2_buf = vec![0f64; max_qty];
+        group.bench_function(
+            id("pkdtree", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f64;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let n = unsafe {
+                            ffi::pkdtree_single_query_f64(
+                                handle.0,
+                                black_box(query.as_ptr()),
+                                max_qty as u64,
+                                idx_buf.as_mut_ptr(),
+                                dist2_buf.as_mut_ptr(),
+                            )
+                        };
+                        len = len.wrapping_add(n);
+                        distance += dist2_buf[..n as usize].iter().sum::<f64>();
+                        item = idx_buf[..n as usize]
+                            .iter()
+                            .fold(item, |acc, v| acc.wrapping_add(*v));
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn bench_kiddo_single_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let tree: KiddoF32 = KdTree::new_from_slice(points).unwrap();
+
+    group.bench_function(id("kiddo", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f32;
+            let mut item = 0u64;
+            for query in queries {
+                let result = tree
+                    .query(black_box(query))
+                    .nearest_one::<SquaredEuclidean<f32>>()
+                    .execute();
+                distance += result.distance;
+                item = item.wrapping_add(result.item as u64);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let k = NonZeroUsize::new(max_qty).unwrap();
+        group.bench_function(
+            id("kiddo", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f32;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let results = tree
+                            .query(black_box(query))
+                            .nearest_n::<SquaredEuclidean<f32>>(k)
+                            .execute();
+                        len = len.wrapping_add(results.len() as u64);
+                        for result in results.iter() {
+                            distance += result.distance;
+                            item = item.wrapping_add(result.item as u64);
+                        }
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn bench_kiddo_single_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let tree: KiddoF64 = KdTree::new_from_slice(points).unwrap();
+
+    group.bench_function(id("kiddo", "nearest_one", point_count), |b| {
+        b.iter(|| {
+            let mut distance = 0.0f64;
+            let mut item = 0u64;
+            for query in queries {
+                let result = tree
+                    .query(black_box(query))
+                    .nearest_one::<SquaredEuclidean<f64>>()
+                    .execute();
+                distance += result.distance;
+                item = item.wrapping_add(result.item as u64);
+            }
+            black_box((distance, item))
+        });
+    });
+
+    for max_qty in MAX_QTYS {
+        let k = NonZeroUsize::new(max_qty).unwrap();
+        group.bench_function(
+            id("kiddo", &format!("nearest_n_k{max_qty}"), point_count),
+            |b| {
+                b.iter(|| {
+                    let mut len = 0u64;
+                    let mut distance = 0.0f64;
+                    let mut item = 0u64;
+                    for query in queries {
+                        let results = tree
+                            .query(black_box(query))
+                            .nearest_n::<SquaredEuclidean<f64>>(k)
+                            .execute();
+                        len = len.wrapping_add(results.len() as u64);
+                        for result in results.iter() {
+                            distance += result.distance;
+                            item = item.wrapping_add(result.item as u64);
+                        }
+                    }
+                    black_box((len, distance, item))
+                });
+            },
+        );
+    }
+}
+
+fn kiddo_vs_pkdtree_single(c: &mut Criterion) {
+    let suites = suite_selection();
+    if !suites.contains(SUITE_KIDDO_VS_PKDTREE) {
+        return;
+    }
+    let libraries = library_selection();
+    let scalars = scalar_selection();
+    if !libraries.any(&[KIDDO, PKDTREE]) {
+        return;
+    }
+
+    // Deliberately distinct env vars from KIDDO_PROFILE_MIN/MAX_LOG2_POINTS,
+    // so that one invocation can sweep the competitor suite over its usual
+    // range while the large-tree suites use a different, coarser one.
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let min_log2_points = read_u32_env("KIDDO_LARGE_MIN_LOG2_POINTS", DEFAULT_MIN_LOG2_POINTS);
+    let max_log2_points = read_u32_env("KIDDO_LARGE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+
+    eprintln!(
+        "benchmarking kiddo vs Pkd-tree only, single-threaded per-query: scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count}",
+        scalars.list(),
+        libraries.list()
+    );
+
+    if scalars.contains(F32) {
+        let queries_f32 = build_queries_f32(query_count);
+        let mut group = c.benchmark_group("profile_kiddo_vs_pkdtree/f32");
+        group.throughput(Throughput::Elements(query_count as u64));
+        for log2_points in min_log2_points..=max_log2_points {
+            let point_count = 1usize << log2_points;
+            let points = build_points_f32(point_count);
+            if libraries.contains(KIDDO) {
+                bench_kiddo_single_f32(&mut group, point_count, &points, &queries_f32);
+            }
+            if pkdtree_f32_selected(&libraries, point_count) {
+                bench_pkdtree_f32(&mut group, point_count, &points, &queries_f32);
+            }
+        }
+        group.finish();
+    }
+
+    if scalars.contains(F64) {
+        let queries_f64 = build_queries_f64(query_count);
+        let mut group = c.benchmark_group("profile_kiddo_vs_pkdtree/f64");
+        group.throughput(Throughput::Elements(query_count as u64));
+        for log2_points in min_log2_points..=max_log2_points {
+            let point_count = 1usize << log2_points;
+            let points = build_points_f64(point_count);
+            if libraries.contains(KIDDO) {
+                bench_kiddo_single_f64(&mut group, point_count, &points, &queries_f64);
+            }
+            if libraries.contains(PKDTREE) {
+                bench_pkdtree_f64(&mut group, point_count, &points, &queries_f64);
+            }
+            if libraries.contains(SKDTREE) {
+                bench_skdtree_f64(&mut group, point_count, &points, &queries_f64);
+            }
+        }
+        group.finish();
+    }
+}
+
+fn bench_pkdtree_batch_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let handle = unsafe {
+        PkdtreeF32(ffi::pkdtree_build_f32(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+    let flat_queries: Vec<f32> = queries.iter().flatten().copied().collect();
+    let num_queries = queries.len() as u64;
+
+    for (query_id, max_qty) in std::iter::once(("nearest_one".to_owned(), NEAREST_ONE_K))
+        .chain(MAX_QTYS.map(|max_qty| (format!("nearest_n_k{max_qty}"), max_qty)))
+    {
+        let mut idx_buf = vec![0u64; queries.len() * max_qty];
+        let mut dist2_buf = vec![0f32; queries.len() * max_qty];
+        group.bench_function(id("pkdtree_batch", &query_id, point_count), |b| {
+            b.iter(|| {
+                unsafe {
+                    ffi::pkdtree_batch_query_f32(
+                        handle.0,
+                        black_box(flat_queries.as_ptr()),
+                        num_queries,
+                        max_qty as u64,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                    );
+                }
+                black_box((dist2_buf.iter().sum::<f32>(), idx_buf.iter().sum::<u64>()))
+            });
+        });
+    }
+}
+
+fn bench_pkdtree_batch_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let handle = unsafe {
+        PkdtreeF64(ffi::pkdtree_build_f64(
+            points.as_ptr().cast(),
+            points.len() as u64,
+            K as u32,
+        ))
+    };
+    let flat_queries: Vec<f64> = queries.iter().flatten().copied().collect();
+    let num_queries = queries.len() as u64;
+
+    for (query_id, max_qty) in std::iter::once(("nearest_one".to_owned(), NEAREST_ONE_K))
+        .chain(MAX_QTYS.map(|max_qty| (format!("nearest_n_k{max_qty}"), max_qty)))
+    {
+        let mut idx_buf = vec![0u64; queries.len() * max_qty];
+        let mut dist2_buf = vec![0f64; queries.len() * max_qty];
+        group.bench_function(id("pkdtree_batch", &query_id, point_count), |b| {
+            b.iter(|| {
+                unsafe {
+                    ffi::pkdtree_batch_query_f64(
+                        handle.0,
+                        black_box(flat_queries.as_ptr()),
+                        num_queries,
+                        max_qty as u64,
+                        idx_buf.as_mut_ptr(),
+                        dist2_buf.as_mut_ptr(),
+                    );
+                }
+                black_box((dist2_buf.iter().sum::<f64>(), idx_buf.iter().sum::<u64>()))
+            });
+        });
+    }
+}
+
+fn bench_kiddo_batch_f32<S: StemStrategy>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let tree: KiddoF32<S> = KdTree::new_from_slice(points).unwrap();
+
+    // nearest_one, not nearest_n(1): it collects one result per query into a
+    // flat Vec instead of a Vec per query, which is the point of having a
+    // separate entry point at all.
+    for (executor_name, executor) in kiddo_batch_executors() {
+        group.bench_function(
+            id(
+                &format!("{label}_{executor_name}"),
+                "nearest_one",
+                point_count,
+            ),
+            |b| {
+                b.iter(|| {
+                    let batch = tree
+                        .query_batch(black_box(queries))
+                        .with_executor(&executor)
+                        .nearest_one::<SquaredEuclidean<f32>>()
+                        .execute();
+                    black_box(batch.len())
+                });
+            },
+        );
+    }
+
+    for max_qty in MAX_QTYS {
+        let k = NonZeroUsize::new(max_qty).unwrap();
+        for (executor_name, executor) in kiddo_batch_executors() {
+            group.bench_function(
+                id(
+                    &format!("{label}_{executor_name}"),
+                    &format!("nearest_n_k{max_qty}"),
+                    point_count,
+                ),
+                |b| {
+                    b.iter(|| {
+                        let batch = tree
+                            .query_batch(black_box(queries))
+                            .with_executor(&executor)
+                            .nearest_n::<SquaredEuclidean<f32>>(k)
+                            .execute();
+                        black_box(batch.total_len())
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn bench_kiddo_batch_f64<S: StemStrategy>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let tree: KiddoF64<S> = KdTree::new_from_slice(points).unwrap();
+
+    for (executor_name, executor) in kiddo_batch_executors() {
+        group.bench_function(
+            id(
+                &format!("{label}_{executor_name}"),
+                "nearest_one",
+                point_count,
+            ),
+            |b| {
+                b.iter(|| {
+                    let batch = tree
+                        .query_batch(black_box(queries))
+                        .with_executor(&executor)
+                        .nearest_one::<SquaredEuclidean<f64>>()
+                        .execute();
+                    black_box(batch.len())
+                });
+            },
+        );
+    }
+
+    for max_qty in MAX_QTYS {
+        let k = NonZeroUsize::new(max_qty).unwrap();
+        for (executor_name, executor) in kiddo_batch_executors() {
+            group.bench_function(
+                id(
+                    &format!("{label}_{executor_name}"),
+                    &format!("nearest_n_k{max_qty}"),
+                    point_count,
+                ),
+                |b| {
+                    b.iter(|| {
+                        let batch = tree
+                            .query_batch(black_box(queries))
+                            .with_executor(&executor)
+                            .nearest_n::<SquaredEuclidean<f64>>(k)
+                            .execute();
+                        black_box(batch.total_len())
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn pkdtree_batch(c: &mut Criterion) {
+    let suites = suite_selection();
+    if !suites.contains(SUITE_PKDTREE_BATCH) {
+        return;
+    }
+    let libraries = library_selection();
+    let scalars = scalar_selection();
+    if !libraries.any(&[KIDDO, PKDTREE]) {
+        return;
+    }
+
+    // See kiddo_vs_pkdtree_single's comment: deliberately distinct env vars
+    // from cpp_competitors' KIDDO_PROFILE_MIN/MAX_LOG2_POINTS.
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let min_log2_points = read_u32_env("KIDDO_LARGE_MIN_LOG2_POINTS", DEFAULT_MIN_LOG2_POINTS);
+    let max_log2_points = read_u32_env("KIDDO_LARGE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+
+    eprintln!(
+        "benchmarking batch-parallel throughput (kiddo serial+parallel executors, Pkd-tree parallel_for): scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} (all submitted at once)",
+        scalars.list(),
+        libraries.list()
+    );
+
+    if scalars.contains(F32) {
+        let queries_f32 = build_queries_f32(query_count);
+        let mut group = c.benchmark_group("profile_pkdtree_batch/f32");
+        group.throughput(Throughput::Elements(query_count as u64));
+        for log2_points in min_log2_points..=max_log2_points {
+            let point_count = 1usize << log2_points;
+            let points = build_points_f32(point_count);
+            if libraries.contains(KIDDO) {
+                bench_kiddo_batch_f32::<Eytzinger>(
+                    &mut group,
+                    "kiddo_batch",
+                    point_count,
+                    &points,
+                    &queries_f32,
+                );
+                // f32/3D cannot use DonnellyCyclicSimdDescent, whose AVX-512
+                // path requires BH == K == 4. DonnellyUnrolled has no such
+                // constraint, so f32 still gets the Donnelly memory layout,
+                // just with scalar rather than block-at-once descent.
+                bench_kiddo_batch_f32::<DonnellyUnrolled<4>>(
+                    &mut group,
+                    "kiddo_donnelly_batch",
+                    point_count,
+                    &points,
+                    &queries_f32,
+                );
+            }
+            if pkdtree_f32_selected(&libraries, point_count) {
+                bench_pkdtree_batch_f32(&mut group, point_count, &points, &queries_f32);
+            }
+        }
+        group.finish();
+    }
+
+    if scalars.contains(F64) {
+        let queries_f64 = build_queries_f64(query_count);
+        let mut group = c.benchmark_group("profile_pkdtree_batch/f64");
+        group.throughput(Throughput::Elements(query_count as u64));
+        for log2_points in min_log2_points..=max_log2_points {
+            let point_count = 1usize << log2_points;
+            let points = build_points_f64(point_count);
+            if libraries.contains(KIDDO) {
+                if log2_points == min_log2_points {
+                    validate_kiddo_strategies_f64(
+                        &points,
+                        &queries_f64[..queries_f64.len().min(64)],
+                    );
+                }
+                bench_kiddo_batch_f64::<Eytzinger>(
+                    &mut group,
+                    "kiddo_batch",
+                    point_count,
+                    &points,
+                    &queries_f64,
+                );
+                // Each strategy builds and drops its own tree in turn, so only
+                // one is resident at a time.
+                bench_kiddo_batch_f64::<DonnellyCyclicSimdDescent<3>>(
+                    &mut group,
+                    "kiddo_donnelly_batch",
+                    point_count,
+                    &points,
+                    &queries_f64,
+                );
+            }
+            if libraries.contains(PKDTREE) {
+                bench_pkdtree_batch_f64(&mut group, point_count, &points, &queries_f64);
+            }
+        }
+        group.finish();
+    }
+}
+
+fn cpp_competitors(c: &mut Criterion) {
+    let suites = suite_selection();
+    if !suites.contains(SUITE_CPP_COMPETITORS) {
+        return;
+    }
+    let libraries = library_selection();
+    let scalars = scalar_selection();
+
+    let query_count = read_usize_env("KIDDO_PROFILE_QUERIES", DEFAULT_QUERY_COUNT);
+    let min_log2_points = read_u32_env("KIDDO_PROFILE_MIN_LOG2_POINTS", DEFAULT_MIN_LOG2_POINTS);
+    let max_log2_points = read_u32_env("KIDDO_PROFILE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
+    let radius_f64 = read_f64_env("KIDDO_PROFILE_RADIUS", DEFAULT_RADIUS);
+    let radius_f32 = radius_f64 as f32;
+    let within_radius_id = format!("within_radius_r{radius_f64}");
+
+    assert!(query_count > 0, "KIDDO_PROFILE_QUERIES must be positive");
+    assert!(
+        min_log2_points <= max_log2_points,
+        "KIDDO_PROFILE_MIN_LOG2_POINTS must not exceed KIDDO_PROFILE_MAX_LOG2_POINTS"
+    );
+    assert!(
+        max_log2_points <= 31,
+        "KIDDO_PROFILE_MAX_LOG2_POINTS must fit u32 item indices"
+    );
+    assert!(
+        radius_f64.is_finite() && radius_f64 > 0.0 && radius_f32.is_finite() && radius_f32 > 0.0,
+        "KIDDO_PROFILE_RADIUS must be a finite positive number"
+    );
+
+    eprintln!(
+        "benchmarking C++ k-d trees: dims={K} scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} nearest_n={MAX_QTYS:?} radius={radius_f64} point_seed={POINT_SEED} query_seed={QUERY_SEED}",
+        scalars.list(),
+        libraries.list()
+    );
+
+    // ALGLIB's `real` is hard-coded to `double`, so it has no f32 half.
+    if scalars.contains(F32) && libraries.any(&[NANOFLANN, PKDTREE]) {
+        let queries_f32 = build_queries_f32(query_count);
+        let mut group = c.benchmark_group("profile_cpp_competitors/f32");
+        group.throughput(Throughput::Elements(query_count as u64));
+
+        for log2_points in min_log2_points..=max_log2_points {
+            let point_count = 1usize << log2_points;
+            let points = build_points_f32(point_count);
+            if log2_points == min_log2_points {
+                validate_implementations_f32(&points, &queries_f32[0], radius_f32, &libraries);
+            }
+
+            if libraries.contains(NANOFLANN) {
+                bench_nanoflann_f32(
+                    &mut group,
+                    point_count,
+                    &points,
+                    &queries_f32,
+                    radius_f32 * radius_f32,
+                    &within_radius_id,
+                );
+            }
+            if pkdtree_f32_selected(&libraries, point_count) {
+                bench_pkdtree_f32(&mut group, point_count, &points, &queries_f32);
+            }
+        }
+
+        group.finish();
+    }
+
+    if scalars.contains(F64) && libraries.any(&VALIDATED_F64) {
+        let queries_f64 = build_queries_f64(query_count);
+        let mut group = c.benchmark_group("profile_cpp_competitors/f64");
+        group.throughput(Throughput::Elements(query_count as u64));
+
+        for log2_points in min_log2_points..=max_log2_points {
+            let point_count = 1usize << log2_points;
+            let points = build_points_f64(point_count);
+            if log2_points == min_log2_points {
+                validate_implementations_f64(&points, &queries_f64[0], radius_f64, &libraries);
+            }
+
+            if libraries.contains(NANOFLANN) {
+                bench_nanoflann_f64(
+                    &mut group,
+                    point_count,
+                    &points,
+                    &queries_f64,
+                    radius_f64 * radius_f64,
+                    &within_radius_id,
+                );
+            }
+            if libraries.contains(ALGLIB) {
+                bench_alglib_f64(
+                    &mut group,
+                    point_count,
+                    &points,
+                    &queries_f64,
+                    radius_f64 * radius_f64,
+                    &within_radius_id,
+                );
+            }
+            if libraries.contains(PKDTREE) {
+                bench_pkdtree_f64(&mut group, point_count, &points, &queries_f64);
+            }
+            if libraries.contains(SKDTREE) {
+                bench_skdtree_f64(&mut group, point_count, &points, &queries_f64);
+            }
+        }
+
+        group.finish();
+    }
+}
+
+// Temporary diagnostic: is Pkd-tree's build_recursive assertion failure
+// (observed with f32 at 2^22+ points) f32-precision-specific, or does f64
+// hit it too? f64-only, registered before anything that touches f32, so it
+// can't be preempted by an f32 abort. Opt-in via KIDDO_CPP_SUITES, since it
+// otherwise builds a large tree on every unrelated run. Remove once answered.
+fn pkdtree_f64_probe(c: &mut Criterion) {
+    if !suite_selection().contains(SUITE_PKDTREE_PROBE) {
+        return;
+    }
+    let min_log2_points = read_u32_env("KIDDO_LARGE_MIN_LOG2_POINTS", 22);
+    let max_log2_points = read_u32_env("KIDDO_LARGE_MAX_LOG2_POINTS", 22);
+    for log2n in min_log2_points..=max_log2_points {
+        let n = 1usize << log2n;
+        eprintln!("pkdtree_f64_probe: building at n={n} (2^{log2n})...");
+        let points = build_points_f64(n);
+        let handle = unsafe {
+            PkdtreeF64(ffi::pkdtree_build_f64(
+                points.as_ptr().cast(),
+                points.len() as u64,
+                K as u32,
+            ))
+        };
+        let query = build_queries_f64(1);
+        let mut idx = [0u64; 1];
+        let mut dist2 = [0f64; 1];
+        unsafe {
+            ffi::pkdtree_single_query_f64(
+                handle.0,
+                query[0].as_ptr(),
+                1,
+                idx.as_mut_ptr(),
+                dist2.as_mut_ptr(),
+            );
+        }
+        eprintln!(
+            "pkdtree_f64_probe: OK at n={n}, idx={} dist2={}",
+            idx[0], dist2[0]
+        );
+    }
+    let _ = c;
+}
+
+criterion_group!(
+    benches,
+    pkdtree_f64_probe,
+    cpp_competitors,
+    pkdtree_batch,
+    kiddo_vs_pkdtree_single
+);
+criterion_main!(benches);

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,14 @@
 #[cfg(target_arch = "x86_64")]
 mod ultimate_f64_avx512_nearest_one_sq_euc_kernel;
 
+#[cfg(feature = "cpp_competitors")]
+#[path = "build_cpp_competitors.rs"]
+mod cpp_competitors;
+
 fn main() {
+    #[cfg(feature = "cpp_competitors")]
+    cpp_competitors::build();
+
     // Register the custom cfg to avoid warnings
     println!("cargo::rustc-check-cfg=cfg(cache_line_128)");
     println!("cargo::rustc-check-cfg=cfg(kiddo_nightly)");

--- a/build_cpp_competitors.rs
+++ b/build_cpp_competitors.rs
@@ -1,0 +1,298 @@
+//! Fetches and compiles the C++ competitor libraries used by
+//! `benches/profile_cpp_competitors.rs`.
+//!
+//! Entirely gated behind the `cpp_competitors` feature (see root
+//! `build.rs`), so a normal `cargo build`/`cargo test`/CI run never touches
+//! the network or requires a C++ toolchain. This is local, throwaway
+//! evaluation tooling: sources are fetched into `OUT_DIR` (never committed)
+//! and pinned to exact revisions/URLs for reproducibility.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const NANOFLANN_REPO: &str = "https://github.com/jlblancoc/nanoflann.git";
+const NANOFLANN_REV: &str = "936c485fbde748595cda842dec5bea0eaae9a409"; // tag 1.11.0
+                                                                        // ALGLIB free C++ edition, GPL 2+. Vendored source-only, never distributed;
+                                                                        // local benchmarking only (GPL obligations trigger on distribution).
+const ALGLIB_URL: &str = "https://www.alglib.net/translator/re/alglib-4.08.0.cpp.gpl.tgz";
+const ALGLIB_DIR_NAME: &str = "alglib-cpp";
+const PKDTREE_REPO: &str = "https://github.com/ucrparlay/Pkd-tree.git";
+const PKDTREE_REV: &str = "9ea6fb51c3bc6e7e99fdbaec98f35315e59ad307";
+// skd-tree (MIT). Artifact repo for an unpublished paper, so the revision pin
+// matters more than usual: there are no tags and history may be rewritten.
+const SKDTREE_REPO: &str = "https://github.com/achmichalop/skd-tree_2027.git";
+const SKDTREE_REV: &str = "1c21f8a3f5b9af9f3e3adb8d51f76dc1c13a4149";
+
+pub fn build() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is set by cargo"));
+    let vendor_dir = out_dir.join("cpp-competitors-vendor");
+    fs::create_dir_all(&vendor_dir).expect("create vendor dir");
+
+    let nanoflann_dir = fetch_git(&vendor_dir, "nanoflann", NANOFLANN_REPO, NANOFLANN_REV);
+    let alglib_dir = fetch_tarball(&vendor_dir, "alglib", ALGLIB_URL, ALGLIB_DIR_NAME);
+    let pkdtree_dir = fetch_git_with_submodules(&vendor_dir, "pkdtree", PKDTREE_REPO, PKDTREE_REV);
+    let skdtree_dir = fetch_git(&vendor_dir, "skdtree", SKDTREE_REPO, SKDTREE_REV);
+
+    build_nanoflann(&nanoflann_dir);
+    build_alglib(&alglib_dir);
+    build_pkdtree(&pkdtree_dir);
+    build_skdtree(&skdtree_dir, &out_dir);
+
+    println!("cargo:rerun-if-changed=build_cpp_competitors.rs");
+    println!("cargo:rerun-if-changed=benches/cpp_shims/nanoflann_shim.cpp");
+    println!("cargo:rerun-if-changed=benches/cpp_shims/alglib_shim.cpp");
+    println!("cargo:rerun-if-changed=benches/cpp_shims/pkdtree_shim.cpp");
+    println!("cargo:rerun-if-changed=benches/cpp_shims/skdtree_shim.cpp");
+}
+
+/// Unlike the other competitors, skd-tree needs two libraries this build
+/// script does not vendor, both system packages. Probing for them here turns a
+/// wall of C++ template errors into one actionable line.
+///
+/// - Boost (`utils/type.hpp` includes `boost/geometry.hpp`), header-only here.
+/// - Armadillo (`dimRanking.hpp` uses `arma::mat` and friends to score split
+///   dimensions), which must also be linked, and pulls in BLAS/LAPACK.
+fn require_system_header(relative: &str, env_var: &str, package_hint: &str) -> Option<String> {
+    const PREFIXES: [&str; 3] = [
+        "/usr/include",
+        "/usr/local/include",
+        "/opt/homebrew/include",
+    ];
+    if let Ok(prefix) = env::var(env_var) {
+        if Path::new(&prefix).join(relative).exists() {
+            return Some(prefix);
+        }
+        panic!("cpp_competitors: {env_var}={prefix} does not contain {relative}");
+    }
+    if PREFIXES
+        .iter()
+        .any(|prefix| Path::new(prefix).join(relative).exists())
+    {
+        return None;
+    }
+    panic!(
+        "cpp_competitors: skd-tree needs {relative}, which is not vendored because it is a \
+         system package. Install it ({package_hint}) or set {env_var} to its include \
+         directory."
+    );
+}
+
+/// `utils/datautils.hpp` includes `<tpie/tpie.h>`, but nothing in the
+/// repository references a single `tpie::` symbol -- it is a dead include, and
+/// TPIE is not packaged on most distributions. Satisfying it with an empty
+/// header is less invasive than patching vendored source: their code is
+/// compiled exactly as written, and an unused include that resolves to nothing
+/// is equivalent to the include not being there.
+fn write_tpie_stub(out_dir: &Path) -> PathBuf {
+    let stub_dir = out_dir.join("skdtree-stubs");
+    let tpie_dir = stub_dir.join("tpie");
+    fs::create_dir_all(&tpie_dir).expect("create tpie stub dir");
+    fs::write(
+        tpie_dir.join("tpie.h"),
+        "// Deliberately empty. See write_tpie_stub in build_cpp_competitors.rs:\n         // skd-tree includes <tpie/tpie.h> but never uses a tpie symbol.\n         #pragma once\n",
+    )
+    .expect("write tpie stub");
+    stub_dir
+}
+
+fn build_skdtree(skdtree_dir: &Path, out_dir: &Path) {
+    let boost_prefix = require_system_header(
+        "boost/geometry.hpp",
+        "BOOST_INCLUDE_DIR",
+        "Arch: `pacman -S boost`, Debian/Ubuntu: `apt install libboost-dev`, macOS: `brew install boost`",
+    );
+    let armadillo_prefix = require_system_header(
+        "armadillo",
+        "ARMADILLO_INCLUDE_DIR",
+        "Arch: `pacman -S armadillo`, Debian/Ubuntu: `apt install libarmadillo-dev`, macOS: `brew install armadillo`",
+    );
+    let ensmallen_prefix = require_system_header(
+        "ensmallen.hpp",
+        "ENSMALLEN_INCLUDE_DIR",
+        "Arch: `paru -S ensmallen` (AUR), Debian/Ubuntu: `apt install libensmallen-dev`, macOS: `brew install ensmallen`",
+    );
+    let stub_dir = write_tpie_stub(out_dir);
+
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .std("c++20")
+        .flag_if_supported("-march=native")
+        // skd-tree searches nodes with AVX-512 intrinsics unconditionally, so
+        // there is no scalar fallback to fall back to.
+        .flag_if_supported("-mavx512f")
+        .flag_if_supported("-mavx512bw")
+        // Its own headers are included as "indices/..." and "utils/..."
+        // relative to the repository root.
+        .include(skdtree_dir)
+        .include(&stub_dir)
+        .file("benches/cpp_shims/skdtree_shim.cpp")
+        .warnings(false);
+    for prefix in [boost_prefix, armadillo_prefix, ensmallen_prefix]
+        .into_iter()
+        .flatten()
+    {
+        build.include(prefix);
+    }
+    build.compile("skdtree_shim");
+    // Armadillo's matrix routines are not header-only; dimRanking pulls in
+    // BLAS/LAPACK through them.
+    println!("cargo:rustc-link-lib=armadillo");
+}
+
+fn run(cmd: &mut Command, what: &str) {
+    let status = cmd
+        .status()
+        .unwrap_or_else(|e| panic!("cpp_competitors: failed to spawn {what}: {e}"));
+    if !status.success() {
+        panic!("cpp_competitors: {what} failed with {status}");
+    }
+}
+
+fn fetch_git(vendor_dir: &Path, name: &str, repo: &str, rev: &str) -> PathBuf {
+    let dest = vendor_dir.join(name);
+    let marker = dest.join(".fetched-rev");
+    if let Ok(fetched) = fs::read_to_string(&marker) {
+        if fetched.trim() == rev {
+            return dest;
+        }
+    }
+    if dest.exists() {
+        fs::remove_dir_all(&dest).expect("remove stale vendor checkout");
+    }
+    println!("cargo:warning=cpp_competitors: cloning {name} from {repo}@{rev}");
+    run(
+        Command::new("git")
+            .args(["clone", "--quiet", repo])
+            .arg(&dest),
+        &format!("git clone {name}"),
+    );
+    run(
+        Command::new("git")
+            .arg("-C")
+            .arg(&dest)
+            .args(["checkout", "--quiet", rev]),
+        &format!("git checkout {name}@{rev}"),
+    );
+    fs::write(&marker, rev).expect("write fetch marker");
+    dest
+}
+
+fn fetch_git_with_submodules(vendor_dir: &Path, name: &str, repo: &str, rev: &str) -> PathBuf {
+    let dest = vendor_dir.join(name);
+    let marker = dest.join(".fetched-rev");
+    if let Ok(fetched) = fs::read_to_string(&marker) {
+        if fetched.trim() == rev {
+            return dest;
+        }
+    }
+    if dest.exists() {
+        fs::remove_dir_all(&dest).expect("remove stale vendor checkout");
+    }
+    println!("cargo:warning=cpp_competitors: cloning {name} from {repo}@{rev} (with submodules)");
+    run(
+        Command::new("git")
+            .args(["clone", "--quiet", repo])
+            .arg(&dest),
+        &format!("git clone {name}"),
+    );
+    run(
+        Command::new("git")
+            .arg("-C")
+            .arg(&dest)
+            .args(["checkout", "--quiet", rev]),
+        &format!("git checkout {name}@{rev}"),
+    );
+    run(
+        Command::new("git").arg("-C").arg(&dest).args([
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ]),
+        &format!("git submodule update {name}"),
+    );
+    fs::write(&marker, rev).expect("write fetch marker");
+    dest
+}
+
+fn fetch_tarball(vendor_dir: &Path, name: &str, url: &str, extracted_name: &str) -> PathBuf {
+    let dest = vendor_dir.join(name);
+    if dest.exists() {
+        return dest;
+    }
+    let tarball = vendor_dir.join(format!("{name}.tar.gz"));
+    println!("cargo:warning=cpp_competitors: downloading {name} from {url}");
+    run(
+        Command::new("curl")
+            .args(["-sSfL", "--retry", "3", "-o"])
+            .arg(&tarball)
+            .arg(url),
+        &format!("downloading {name}"),
+    );
+    run(
+        Command::new("tar")
+            .arg("xzf")
+            .arg(&tarball)
+            .arg("-C")
+            .arg(vendor_dir),
+        &format!("extracting {name}"),
+    );
+    let _ = fs::remove_file(&tarball);
+    let extracted = vendor_dir.join(extracted_name);
+    fs::rename(&extracted, &dest).unwrap_or_else(|e| {
+        panic!("cpp_competitors: expected {name} tarball to extract to {extracted_name}: {e}")
+    });
+    dest
+}
+
+fn build_nanoflann(nanoflann_dir: &Path) {
+    cc::Build::new()
+        .cpp(true)
+        .std("c++14")
+        .include(nanoflann_dir.join("include"))
+        .file("benches/cpp_shims/nanoflann_shim.cpp")
+        .warnings(false)
+        .compile("nanoflann_shim");
+}
+
+fn build_alglib(alglib_dir: &Path) {
+    let src = alglib_dir.join("src");
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .std("c++17")
+        .include(&src)
+        .file("benches/cpp_shims/alglib_shim.cpp")
+        .warnings(false);
+    for entry in fs::read_dir(&src).expect("read alglib src dir") {
+        let path = entry.expect("read alglib src entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("cpp") {
+            continue;
+        }
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        // ARM/RISC-V specific SIMD kernels; irrelevant and non-portable on x86_64.
+        if name.contains("kernels_neon") || name.contains("kernels_rvv10") {
+            continue;
+        }
+        build.file(path);
+    }
+    build.compile("alglib_shim");
+}
+
+fn build_pkdtree(pkdtree_dir: &Path) {
+    cc::Build::new()
+        .cpp(true)
+        .std("c++20")
+        .flag_if_supported("-pthread")
+        .flag_if_supported("-mcx16")
+        .flag_if_supported("-march=native")
+        .include(pkdtree_dir.join("include"))
+        .include(pkdtree_dir.join("parlaylib/include"))
+        .file("benches/cpp_shims/pkdtree_shim.cpp")
+        .warnings(false)
+        .compile("pkdtree_shim");
+    println!("cargo:rustc-link-lib=pthread");
+}

--- a/build_cpp_competitors.rs
+++ b/build_cpp_competitors.rs
@@ -2,8 +2,11 @@
 //! `benches/profile_cpp_competitors.rs`.
 //!
 //! Entirely gated behind the `cpp_competitors` feature (see root
-//! `build.rs`), so a normal `cargo build`/`cargo test`/CI run never touches
-//! the network or requires a C++ toolchain. This is local, throwaway
+//! `build.rs`), so a normal `cargo build`/`cargo test` never touches the
+//! network or requires a C++ toolchain. CI's `cargo hack --each-feature`
+//! sweeps do check this feature in isolation, though, and provision the
+//! three system packages skd-tree needs (see `require_system_header` below)
+//! in a dedicated step before that check runs. This is local, throwaway
 //! evaluation tooling: sources are fetched into `OUT_DIR` (never committed)
 //! and pinned to exact revisions/URLs for reproducibility.
 

--- a/examples/batch_overhead_probe.rs
+++ b/examples/batch_overhead_probe.rs
@@ -1,0 +1,128 @@
+//! Where does kiddo's parallel batch mode lose throughput at small batch
+//! sizes? Isolates two candidate costs against the same tree and executor:
+//!
+//! - `nearest_one` produces one `QueryResultItem` per query and collects into
+//!   a flat `Vec`, while `nearest_n` produces a `Vec` per query and collects
+//!   into `Vec<Vec<_>>`. Comparing `nearest_one` with `nearest_n(k=1)` prices
+//!   the per-query heap allocation at equal query work.
+//! - static chunking and the serial fallback change how, and whether, the
+//!   batch is dispatched to the pool at all.
+//!
+//! Run: cargo run --release --example batch_overhead_probe
+
+use kiddo::batch::Executor;
+use kiddo::dist::SquaredEuclidean;
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::stem_strategy::Eytzinger;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+use std::num::NonZeroUsize;
+use std::time::Instant;
+
+const K: usize = 3;
+const B: usize = 32;
+const LOG2_POINTS: u32 = 21;
+const QUERY_COUNTS: [usize; 8] = [500, 1_000, 4_000, 16_000, 50_000, 100_000, 200_000, 400_000];
+const REPEATS: usize = 40;
+
+type Tree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, K, B>, K, B>;
+
+fn points(count: usize, seed: u64) -> Vec<[f32; K]> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    (0..count).map(|_| rng.random()).collect()
+}
+
+/// Best-of-`REPEATS` throughput in queries/sec, after a warm-up pass that also
+/// leaves the rayon pool awake.
+fn throughput(queries: usize, mut run: impl FnMut() -> usize) -> f64 {
+    for _ in 0..3 {
+        black_box(run());
+    }
+    let mut best = f64::INFINITY;
+    for _ in 0..REPEATS {
+        let started = Instant::now();
+        black_box(run());
+        let elapsed = started.elapsed().as_secs_f64();
+        best = best.min(elapsed);
+    }
+    queries as f64 / best
+}
+
+fn main() {
+    let point_count = 1usize << LOG2_POINTS;
+    let tree: Tree = KdTree::new_from_slice(&points(point_count, 1)).unwrap();
+    let all_queries = points(*QUERY_COUNTS.last().unwrap(), 2);
+    let parallel = Executor::parallel();
+    let k20 = NonZeroUsize::new(20).unwrap();
+
+    println!("tree=2^{LOG2_POINTS} f32 {K}D, throughput in Melem/s, best of {REPEATS}\n");
+    println!(
+        "{:>8}  {:>12}  {:>12}  {:>7}  {:>12}  {:>12}  {:>12}",
+        "queries",
+        "one adaptive",
+        "one chunked",
+        "chunk%",
+        "one fallback",
+        "k20 adaptive",
+        "k20 chunked"
+    );
+
+    for count in QUERY_COUNTS {
+        let queries = &all_queries[..count];
+
+        let chunked = Executor::parallel().with_default_static_chunking();
+        let fallback = Executor::parallel()
+            .with_default_static_chunking()
+            .with_serial_fallback();
+
+        let one_adaptive = throughput(count, || {
+            tree.query_batch(queries)
+                .with_executor(&parallel)
+                .nearest_one::<SquaredEuclidean<f32>>()
+                .execute()
+                .len()
+        });
+        let one_chunked = throughput(count, || {
+            tree.query_batch(queries)
+                .with_executor(&chunked)
+                .nearest_one::<SquaredEuclidean<f32>>()
+                .execute()
+                .len()
+        });
+        let one_fallback = throughput(count, || {
+            tree.query_batch(queries)
+                .with_executor(&fallback)
+                .nearest_one::<SquaredEuclidean<f32>>()
+                .execute()
+                .len()
+        });
+
+        let k20_adaptive = throughput(count, || {
+            tree.query_batch(queries)
+                .with_executor(&parallel)
+                .nearest_n::<SquaredEuclidean<f32>>(k20)
+                .execute()
+                .total_len()
+        });
+        let k20_chunked = throughput(count, || {
+            tree.query_batch(queries)
+                .with_executor(&chunked)
+                .nearest_n::<SquaredEuclidean<f32>>(k20)
+                .execute()
+                .total_len()
+        });
+
+        println!(
+            "{:>8}  {:>12.2}  {:>12.2}  {:>+6.0}%  {:>12.2}  {:>12.2}  {:>12.2}",
+            count,
+            one_adaptive / 1.0e6,
+            one_chunked / 1.0e6,
+            100.0 * (one_chunked - one_adaptive) / one_adaptive,
+            one_fallback / 1.0e6,
+            k20_adaptive / 1.0e6,
+            k20_chunked / 1.0e6,
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -365,6 +365,157 @@ bench-external-kd-trees RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES=
         "$output_dir/bench_result-external-kd-trees-${result_key}.json" \
         profile_external_kd_trees
 
+bench-cpp-competitors RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='cpp_competitors,test_utils,logging_off' QUERIES=profile_queries MIN_LOG2_POINTS=profile_min_log2_points MAX_LOG2_POINTS=profile_max_log2_points RADIUS='0.05' LIBRARIES='nanoflann,alglib,pkdtree,kiddo' SCALARS='f32,f64':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_CPP_SUITES='cpp_competitors,pkdtree_batch' \
+        KIDDO_CPP_LIBRARIES={{quote(LIBRARIES)}} \
+        KIDDO_CPP_SCALARS={{quote(SCALARS)}} \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        KIDDO_PROFILE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_PROFILE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        KIDDO_PROFILE_RADIUS={{quote(RADIUS)}} \
+        KIDDO_LARGE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_LARGE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_cpp_competitors \
+            --features {{quote(FEATURES)}}
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-cpp-competitors-${result_key}.json" \
+        profile_cpp_competitors
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-pkdtree-batch-${result_key}.json" \
+        profile_pkdtree_batch
+
+# kiddo vs Pkd-tree alone at large tree sizes (KIDDO_CPP_SUITES keeps the other suites from allocating: Criterion's `--` filter selects results, not setup)
+bench-kiddo-vs-pkdtree RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='cpp_competitors,test_utils,logging_off' QUERIES=profile_queries MIN_LOG2_POINTS='24' MAX_LOG2_POINTS='24' LIBRARIES='kiddo,pkdtree' SCALARS='f32,f64':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_CPP_SUITES='kiddo_vs_pkdtree' \
+        KIDDO_CPP_LIBRARIES={{quote(LIBRARIES)}} \
+        KIDDO_CPP_SCALARS={{quote(SCALARS)}} \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        KIDDO_LARGE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_LARGE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_cpp_competitors \
+            --features {{quote(FEATURES)}} \
+            -- profile_kiddo_vs_pkdtree
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-kiddo-vs-pkdtree-${result_key}.json" \
+        profile_kiddo_vs_pkdtree
+
+# kiddo (serial + parallel executors) vs Pkd-tree, batch-throughput mode only; one scalar per invocation so each can use the tree-size range it supports
+bench-kiddo-vs-pkdtree-batch RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' FEATURES='cpp_competitors,test_utils,logging_off,simd' QUERIES=profile_queries MIN_LOG2_POINTS='24' MAX_LOG2_POINTS='27' SCALARS='f64' LIBRARIES='kiddo,pkdtree':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    RUSTC_WRAPPER= \
+        KIDDO_CPP_SUITES='pkdtree_batch' \
+        KIDDO_CPP_LIBRARIES={{quote(LIBRARIES)}} \
+        KIDDO_CPP_SCALARS={{quote(SCALARS)}} \
+        KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        KIDDO_LARGE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_LARGE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        RUSTFLAGS='-C target-cpu=native' \
+        cargo criterion \
+            --bench profile_cpp_competitors \
+            --features {{quote(FEATURES)}} \
+            -- profile_pkdtree_batch
+    cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+        target/criterion \
+        "$output_dir/bench_result-pkdtree-batch-${result_key}.json" \
+        profile_pkdtree_batch
+
+chart-kiddo-vs-pkdtree-results RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_kiddo_vs_pkdtree_results.py charts \
+        --result {{quote(RESULTS_DIR)}}/bench_result-kiddo-vs-pkdtree-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}}
+
+html-kiddo-vs-pkdtree-results RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' HTML_NAME='kiddo-vs-pkdtree.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_kiddo_vs_pkdtree_results.py all \
+        --result {{quote(RESULTS_DIR)}}/bench_result-kiddo-vs-pkdtree-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}}
+
+bench-nearestneighborsjl RESULT_KEY=benchmark_result_key OUTPUT_DIR='.' QUERIES=profile_queries MIN_LOG2_POINTS=profile_min_log2_points MAX_LOG2_POINTS=profile_max_log2_points RADIUS='0.05' JULIA='julia':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    result_key={{quote(RESULT_KEY)}}
+    output_dir={{quote(OUTPUT_DIR)}}
+    if [[ ! "$result_key" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]]; then
+        echo "RESULT_KEY must contain only letters, digits, '.', '_', '+', ':', or '-'" >&2
+        exit 2
+    fi
+    mkdir -p "$output_dir"
+    KIDDO_PROFILE_QUERIES={{quote(QUERIES)}} \
+        KIDDO_PROFILE_MIN_LOG2_POINTS={{quote(MIN_LOG2_POINTS)}} \
+        KIDDO_PROFILE_MAX_LOG2_POINTS={{quote(MAX_LOG2_POINTS)}} \
+        KIDDO_PROFILE_RADIUS={{quote(RADIUS)}} \
+        {{quote(JULIA)}} scripts/bench_nearestneighbors_jl.jl \
+        "$output_dir/bench_result-nearestneighborsjl-${result_key}.json"
+
+chart-cpp-competitor-results CPP_RESULT_KEY KIDDO_RESULT_KEY=CPP_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_cpp_competitor_results.py charts \
+        --cpp {{quote(RESULTS_DIR)}}/bench_result-cpp-competitors-{{quote(CPP_RESULT_KEY)}}.json \
+        --kiddo-nearest-one {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_one-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-nearest-n {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_n-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-query-family {{quote(RESULTS_DIR)}}/bench_result-v6-query-family-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --result-label {{quote(CPP_RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}}
+
+html-cpp-competitor-results CPP_RESULT_KEY KIDDO_RESULT_KEY=CPP_RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' HTML_NAME='cpp-competitor-benchmarks.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_cpp_competitor_results.py all \
+        --cpp {{quote(RESULTS_DIR)}}/bench_result-cpp-competitors-{{quote(CPP_RESULT_KEY)}}.json \
+        --kiddo-nearest-one {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_one-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-nearest-n {{quote(RESULTS_DIR)}}/bench_result-v6-nearest_n-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --kiddo-query-family {{quote(RESULTS_DIR)}}/bench_result-v6-query-family-eytzinger-{{quote(KIDDO_RESULT_KEY)}}.json \
+        --result-label {{quote(CPP_RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}}
+
+chart-pkdtree-batch-results RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_pkdtree_batch_results.py charts \
+        --result {{quote(RESULTS_DIR)}}/bench_result-pkdtree-batch-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}}
+
+html-pkdtree-batch-results RESULT_KEY RESULTS_DIR='.' OUTPUT_DIR='.' HTML_NAME='pkdtree-batch-throughput.html' PYTHON='python3':
+    {{quote(PYTHON)}} scripts/chart_pkdtree_batch_results.py all \
+        --result {{quote(RESULTS_DIR)}}/bench_result-pkdtree-batch-{{quote(RESULT_KEY)}}.json \
+        --result-label {{quote(RESULT_KEY)}} \
+        --output-dir {{quote(OUTPUT_DIR)}} \
+        --html-name {{quote(HTML_NAME)}}
+
 bench-v6-within-radius-projection RESULT_KEY=benchmark_result_key OUTPUT_DIR='./focused-results' FEATURES='simd,test_utils,logging_off' QUERIES='1000' MIN_LOG2_POINTS='16' MAX_LOG2_POINTS='27' RADIUS='0.05':
     #!/usr/bin/env bash
     set -euo pipefail

--- a/scripts/bench_nearestneighbors_jl.jl
+++ b/scripts/bench_nearestneighbors_jl.jl
@@ -1,0 +1,188 @@
+#!/usr/bin/env julia
+# Standalone benchmark for Julia's NearestNeighbors.jl KDTree, run as its own
+# process (there is no practical way to embed a Julia runtime into the Rust
+# criterion harness the way the C++ competitors are FFI'd in). Output is a
+# JSON file in the same schema tools/criterion-export produces, using the
+# same group/function naming convention as profile_cpp_competitors.rs, so
+# chart_cpp_competitor_results.py can merge it in as just another library
+# series (prefix "nearestneighborsjl_").
+#
+# Usage: julia bench_nearestneighbors_jl.jl <output.json>
+# Env vars (same names/semantics as the Rust benches):
+#   KIDDO_PROFILE_QUERIES, KIDDO_PROFILE_MIN_LOG2_POINTS,
+#   KIDDO_PROFILE_MAX_LOG2_POINTS, KIDDO_PROFILE_RADIUS
+
+using NearestNeighbors
+using Random
+using JSON
+using Statistics
+
+const K = 3
+const MAX_QTYS = [5, 20, 50]
+const SAMPLES = 30
+const WARMUP = 3
+
+query_count = parse(Int, get(ENV, "KIDDO_PROFILE_QUERIES", "1000"))
+min_log2 = parse(Int, get(ENV, "KIDDO_PROFILE_MIN_LOG2_POINTS", "16"))
+max_log2 = parse(Int, get(ENV, "KIDDO_PROFILE_MAX_LOG2_POINTS", "19"))
+radius = parse(Float64, get(ENV, "KIDDO_PROFILE_RADIUS", "0.05"))
+out_path = length(ARGS) >= 1 ? ARGS[1] : "bench_result-nearestneighborsjl.json"
+
+@assert query_count > 0
+@assert min_log2 <= max_log2
+
+function build_points(::Type{T}, n::Int, seed::UInt64) where {T}
+    rng = MersenneTwister(seed)
+    rand(rng, T, K, n)
+end
+
+function build_queries(::Type{T}, n::Int, seed::UInt64) where {T}
+    rng = MersenneTwister(seed)
+    [rand(rng, T, K) for _ in 1:n]
+end
+
+function expected_nearest(points::Matrix{T}, q::Vector{T}, max_qty::Int) where {T}
+    n = size(points, 2)
+    d2 = Vector{T}(undef, n)
+    @inbounds for i in 1:n
+        s = zero(T)
+        for k in 1:K
+            diff = points[k, i] - q[k]
+            s += diff * diff
+        end
+        d2[i] = s
+    end
+    sort(d2)[1:min(max_qty, n)]
+end
+
+function expected_within_count(points::Matrix{T}, q::Vector{T}, radius2::T) where {T}
+    n = size(points, 2)
+    count = 0
+    @inbounds for i in 1:n
+        s = zero(T)
+        for k in 1:K
+            diff = points[k, i] - q[k]
+            s += diff * diff
+        end
+        if s <= radius2
+            count += 1
+        end
+    end
+    count
+end
+
+function validate(points::Matrix{T}, tree, q::Vector{T}, radius::T) where {T}
+    max_qty = MAX_QTYS[end]
+    expected = expected_nearest(points, q, max_qty)
+    _, dists = knn(tree, q, max_qty, true)
+    actual2 = sort([d * d for d in dists])
+    tol = T === Float32 ? T(1.0e-4) : T(1.0e-10)
+    for (a, e) in zip(actual2, expected)
+        @assert abs(a - e) <= tol * max(abs(e), one(T)) "distance mismatch: actual=$a expected=$e"
+    end
+    expected_within = expected_within_count(points, q, radius * radius)
+    actual_within = length(inrange(tree, q, radius, false))
+    @assert actual_within == expected_within "within-radius count mismatch: actual=$actual_within expected=$expected_within"
+    println("Testing nearestneighborsjl ($T) at n=$(size(points, 2)): OK")
+end
+
+function timed_trials(f::Function)
+    for _ in 1:WARMUP
+        f()
+    end
+    times_ns = Vector{Float64}(undef, SAMPLES)
+    for i in 1:SAMPLES
+        t0 = time_ns()
+        f()
+        times_ns[i] = Float64(time_ns() - t0)
+    end
+    times_ns
+end
+
+function estimate(times_ns::Vector{Float64})
+    m = mean(times_ns)
+    s = std(times_ns)
+    n = length(times_ns)
+    se = s / sqrt(n)
+    # Durations can't be negative; a wide relative spread on fast/noisy
+    # samples can otherwise push mean - 1.96*se below zero.
+    lower = max(m - 1.96 * se, m * 0.01)
+    (mean = m, lower = lower, upper = m + 1.96 * se)
+end
+
+function make_result(group_id::String, function_id::String, tree_size::Int, query_count::Int, times_ns::Vector{Float64})
+    est = estimate(times_ns)
+    Dict(
+        "benchmark" => "$group_id/$function_id/$tree_size",
+        "metadata" => Dict(
+            "group_id" => group_id,
+            "function_id" => function_id,
+            "value_str" => string(tree_size),
+            "throughput" => Dict("Elements" => query_count),
+        ),
+        "estimates" => Dict(
+            "mean" => Dict(
+                "point_estimate" => est.mean,
+                "confidence_interval" => Dict(
+                    "lower_bound" => est.lower,
+                    "upper_bound" => est.upper,
+                ),
+            ),
+        ),
+    )
+end
+
+function bench_scalar(::Type{T}, results::Vector{Any}) where {T}
+    scalar = T === Float32 ? "f32" : "f64"
+    group_id = "profile_cpp_competitors/$scalar"
+    queries = build_queries(T, query_count, UInt64(0x5eed_0000_0000_0002))
+
+    for log2n in min_log2:max_log2
+        n = 1 << log2n
+        points = build_points(T, n, UInt64(0x5eed_0000_0000_0001))
+        tree = KDTree(points)
+
+        if log2n == min_log2
+            validate(points, tree, queries[1], T(radius))
+        end
+
+        push!(results, make_result(group_id, "nearestneighborsjl_nearest_one", n, query_count, timed_trials(() -> begin
+            for q in queries
+                knn(tree, q, 1, false)
+            end
+        end)))
+
+        for max_qty in MAX_QTYS
+            push!(results, make_result(group_id, "nearestneighborsjl_nearest_n_k$max_qty", n, query_count, timed_trials(() -> begin
+                for q in queries
+                    knn(tree, q, max_qty, false)
+                end
+            end)))
+        end
+
+        radius_id = "nearestneighborsjl_within_radius_r$radius"
+        push!(results, make_result(group_id, radius_id, n, query_count, timed_trials(() -> begin
+            for q in queries
+                inrange(tree, q, radius, false)
+            end
+        end)))
+
+        println(stderr, "nearestneighborsjl $scalar n=$n done")
+    end
+end
+
+results = Any[]
+bench_scalar(Float32, results)
+bench_scalar(Float64, results)
+
+open(out_path, "w") do io
+    JSON.print(io, Dict(
+        "schema_version" => 1,
+        "criterion_root" => "julia",
+        "collected_at_unix_ms" => round(Int, time() * 1000),
+        "filters" => String[],
+        "results" => results,
+    ))
+end
+
+println("wrote $out_path")

--- a/scripts/chart_cpp_competitor_results.py
+++ b/scripts/chart_cpp_competitor_results.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Chart non-Rust k-d tree/NN library results against separately benchmarked Kiddo results.
+
+Mirrors chart_external_kd_tree_results.py's approach for the Rust
+competitors. Accepts one or more --cpp result files sharing the
+profile_cpp_competitors/{f32,f64} group schema: the FFI-driven Rust bench
+export (nanoflann, ALGLIB, Pkd-tree single-query mode; see
+benches/profile_cpp_competitors.rs's module doc comment for what was tried
+and dropped) and the standalone Julia NearestNeighbors.jl export
+(scripts/bench_nearestneighbors_jl.jl), which write the same schema from a
+separate process since there's no practical way to embed a Julia runtime in
+the Rust criterion harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CPP_GROUP = "profile_cpp_competitors"
+KIDDO_GROUPS = {
+    "nearest_one": "profile_v6_nearest_one_eytzinger",
+    "nearest_n": "profile_v6_nearest_n_eytzinger",
+    "within_radius": "profile_v6_query_family_eytzinger",
+}
+LIBRARY_PREFIXES = (
+    ("nanoflann_", "nanoflann"),
+    ("alglib_", "ALGLIB"),
+    ("pkdtree_", "Pkd-tree"),
+    ("nearestneighborsjl_", "NearestNeighbors.jl"),
+)
+LIBRARY_ORDER = ("kiddo", "nanoflann", "ALGLIB", "Pkd-tree", "NearestNeighbors.jl")
+COLORS = {
+    "kiddo": "#3264a8",
+    "nanoflann": "#d35400",
+    "ALGLIB": "#1f8f3a",
+    "Pkd-tree": "#8e44ad",
+    "NearestNeighbors.jl": "#c2185b",
+}
+SCALARS = ("f32", "f64")
+DEFAULT_RADIUS = 0.05
+SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+
+
+@dataclass(frozen=True)
+class Point:
+    tree_size: int
+    duration_ns: float
+    lower_ns: float
+    upper_ns: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare C++ k-d tree/NN library Criterion exports with Kiddo's "
+            "separately collected 3D Eytzinger benchmarks."
+        )
+    )
+    parser.add_argument("mode", choices=("charts", "all"))
+    parser.add_argument(
+        "--cpp",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="one or more result exports sharing the profile_cpp_competitors schema",
+    )
+    parser.add_argument("--kiddo-nearest-one", type=Path, required=True)
+    parser.add_argument("--kiddo-nearest-n", type=Path, required=True)
+    parser.add_argument("--kiddo-query-family", type=Path, required=True)
+    parser.add_argument("--result-label", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--html-name", default="cpp-competitor-benchmarks.html")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"could not read {path}: {error}") from error
+    if not isinstance(value, dict) or not isinstance(value.get("results"), list):
+        raise RuntimeError(f"{path} is not a Criterion result export")
+    return value
+
+
+def finite_positive(value: Any, description: str, path: Path) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}") from error
+    if not math.isfinite(number) or number <= 0:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}")
+    return number
+
+
+def read_series(path: Path, expected_group: str) -> dict[tuple[str, str], list[Point]]:
+    series: dict[tuple[str, str], list[Point]] = {}
+    for result in load_json(path)["results"]:
+        metadata = result.get("metadata")
+        estimates = result.get("estimates")
+        if not isinstance(metadata, dict) or not isinstance(estimates, dict):
+            raise RuntimeError(f"{path} contains incomplete benchmark data")
+
+        group_id = metadata.get("group_id")
+        function_id = metadata.get("function_id")
+        if not isinstance(group_id, str) or not isinstance(function_id, str):
+            raise RuntimeError(f"{path} contains an invalid benchmark identity")
+        if group_id.rsplit("/", 1)[0] != expected_group:
+            raise RuntimeError(
+                f"{path} contains group {group_id!r}, expected {expected_group!r}"
+            )
+        scalar = group_id.rsplit("/", 1)[-1]
+        if scalar not in SCALARS:
+            raise RuntimeError(
+                f"{path} contains unsupported scalar/dimensional group {group_id!r}; "
+                "this comparison is strictly 3D f32/f64"
+            )
+
+        tree_size_value = finite_positive(metadata.get("value_str"), "tree size", path)
+        tree_size = int(tree_size_value)
+        if tree_size != tree_size_value or tree_size & (tree_size - 1):
+            raise RuntimeError(f"tree size is not a power of two in {path}: {tree_size_value}")
+
+        throughput = metadata.get("throughput")
+        query_count = throughput.get("Elements") if isinstance(throughput, dict) else None
+        query_count = finite_positive(query_count, "Elements throughput", path)
+        mean = estimates.get("mean")
+        interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
+        if not isinstance(mean, dict) or not isinstance(interval, dict):
+            raise RuntimeError(f"{path} contains no mean confidence interval")
+
+        point = Point(
+            tree_size,
+            finite_positive(mean.get("point_estimate"), "mean duration", path) / query_count,
+            finite_positive(interval.get("lower_bound"), "lower duration bound", path)
+            / query_count,
+            finite_positive(interval.get("upper_bound"), "upper duration bound", path)
+            / query_count,
+        )
+        series.setdefault((scalar, function_id), []).append(point)
+
+    for key, points in series.items():
+        points.sort(key=lambda point: point.tree_size)
+        sizes = [point.tree_size for point in points]
+        if len(sizes) != len(set(sizes)):
+            raise RuntimeError(f"duplicate tree sizes for {key!r} in {path}")
+    return series
+
+
+def cpp_identity(function_id: str) -> tuple[str, str]:
+    for prefix, library in LIBRARY_PREFIXES:
+        if function_id.startswith(prefix):
+            query = function_id[len(prefix) :]
+            if (
+                query == "nearest_one"
+                or re.fullmatch(r"nearest_n_k(?:5|20|50)", query)
+                or re.fullmatch(r"within_radius_r[0-9.eE+-]+", query)
+            ):
+                return library, query
+            raise RuntimeError(f"unsupported C++ competitor query identity: {function_id}")
+    raise RuntimeError(
+        f"unexpected library in C++ competitor benchmark identity {function_id!r}; "
+        "Kiddo must come from its focused benchmark exports"
+    )
+
+
+def kiddo_points(
+    scalar: str,
+    query: str,
+    nearest_one: dict[tuple[str, str], list[Point]],
+    nearest_n: dict[tuple[str, str], list[Point]],
+    query_family: dict[tuple[str, str], list[Point]],
+) -> list[Point]:
+    if query == "nearest_one":
+        source = nearest_one
+        function_id = query
+    elif query.startswith("nearest_n_k"):
+        source = nearest_n
+        function_id = query
+    else:
+        radius_match = re.fullmatch(r"within_radius_r([0-9.eE+-]+)", query)
+        if radius_match is None:
+            raise RuntimeError(f"unsupported query {query!r}")
+        radius = float(radius_match.group(1))
+        if not math.isclose(radius, DEFAULT_RADIUS, rel_tol=0.0, abs_tol=1.0e-12):
+            raise RuntimeError(
+                f"C++ competitor radius {radius:g} has no equivalent focused Kiddo result; "
+                f"profile_v6_query_family_eytzinger uses radius {DEFAULT_RADIUS:g}"
+            )
+        source = query_family
+        function_id = "within_unsorted"
+
+    try:
+        return source[(scalar, function_id)]
+    except KeyError as error:
+        raise RuntimeError(
+            f"missing Kiddo {scalar}/{function_id} results required for {query}"
+        ) from error
+
+
+def collect_charts(
+    cpp_paths: list[Path],
+    nearest_one_path: Path,
+    nearest_n_path: Path,
+    query_family_path: Path,
+) -> dict[tuple[str, str], dict[str, list[Point]]]:
+    cpp: dict[tuple[str, str], list[Point]] = {}
+    for cpp_path in cpp_paths:
+        for key, points in read_series(cpp_path, CPP_GROUP).items():
+            if key in cpp:
+                raise RuntimeError(
+                    f"duplicate {key!r} series across --cpp inputs (last from {cpp_path})"
+                )
+            cpp[key] = points
+    nearest_one = read_series(nearest_one_path, KIDDO_GROUPS["nearest_one"])
+    nearest_n = read_series(nearest_n_path, KIDDO_GROUPS["nearest_n"])
+    query_family = read_series(
+        query_family_path, KIDDO_GROUPS["within_radius"]
+    )
+
+    charts: dict[tuple[str, str], dict[str, list[Point]]] = {}
+    for (scalar, function_id), points in cpp.items():
+        library, query = cpp_identity(function_id)
+        chart = charts.setdefault((scalar, query), {})
+        if library in chart:
+            raise RuntimeError(f"duplicate {library} series for {scalar}/{query}")
+        chart[library] = points
+
+    # Library coverage is intentionally uneven (see module docstring), so
+    # unlike a uniform matrix we only require that *some* competitor
+    # reported each scalar/query combination, not that every library did.
+    expected_queries = {
+        "nearest_one",
+        "nearest_n_k5",
+        "nearest_n_k20",
+        "nearest_n_k50",
+        f"within_radius_r{DEFAULT_RADIUS}",
+    }
+    expected_keys = {(scalar, query) for scalar in SCALARS for query in expected_queries}
+    missing = expected_keys - charts.keys()
+    extra = charts.keys() - expected_keys
+    if missing or extra:
+        raise RuntimeError(
+            "C++ competitor result matrix does not match the expected 3D query matrix; "
+            f"missing={sorted(missing)!r}, extra={sorted(extra)!r}"
+        )
+
+    # Series are ragged rather than truncated to their shared tree sizes: a
+    # library that cannot reach the largest sizes (Pkd-tree's f32 build
+    # asserts above 2^21) would otherwise drag every other library's curve
+    # down to its own ceiling, discarding data that was measured. Each
+    # library is plotted over exactly the range it covers, and render_charts
+    # marks any partial range in the legend so a short line is never mistaken
+    # for a missing measurement.
+    for (scalar, query), chart in charts.items():
+        chart["kiddo"] = kiddo_points(
+            scalar, query, nearest_one, nearest_n, query_family
+        )
+        for library, points in chart.items():
+            if not points:
+                raise RuntimeError(f"empty {library} series for {scalar}/{query}")
+            chart[library] = sorted(points, key=lambda point: point.tree_size)
+    return charts
+
+
+def coverage_label(library: str, points: list[Point], full_sizes: list[int]) -> str:
+    """Legend label, annotated with the tree-size range when it is partial."""
+    sizes = {point.tree_size for point in points}
+    if sizes == set(full_sizes):
+        return library
+    low = min(sizes).bit_length() - 1
+    high = max(sizes).bit_length() - 1
+    span = f"2^{low}" if low == high else f"2^{low}–2^{high}"
+    return f"{library} ({span})"
+
+
+def query_sort_key(query: str) -> tuple[int, int | float]:
+    if query == "nearest_one":
+        return (0, 0)
+    nearest_n_match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    if nearest_n_match:
+        return (1, int(nearest_n_match.group(1)))
+    radius_match = re.fullmatch(r"within_radius_r(.+)", query)
+    return (2, float(radius_match.group(1)) if radius_match else 0)
+
+
+def query_title(query: str) -> str:
+    if query == "nearest_one":
+        return "nearest_one"
+    nearest_n_match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    if nearest_n_match:
+        return f"nearest_n (n={nearest_n_match.group(1)})"
+    radius = query.removeprefix("within_radius_r")
+    return f"within_radius (radius={radius})"
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]+", "-", value).strip("-_") or "benchmark"
+
+
+def render_charts(
+    charts: dict[tuple[str, str], dict[str, list[Point]]],
+    output_dir: Path,
+    result_label: str,
+) -> list[tuple[str, Path]]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as error:
+        raise RuntimeError("matplotlib is required to generate benchmark charts") from error
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[tuple[str, Path]] = []
+    ordered = sorted(
+        charts.items(),
+        key=lambda item: (SCALARS.index(item[0][0]), query_sort_key(item[0][1])),
+    )
+    for (scalar, query), series in ordered:
+        title = f"3D {query_title(query)} — {scalar}"
+        figure, axis = plt.subplots(figsize=(10.5, 6.2))
+        sizes = sorted(
+            {point.tree_size for points in series.values() for point in points}
+        )
+        for library in LIBRARY_ORDER:
+            points = series.get(library)
+            if points is None:
+                continue
+            axis.errorbar(
+                [point.tree_size for point in points],
+                [point.duration_ns for point in points],
+                yerr=[
+                    [point.duration_ns - point.lower_ns for point in points],
+                    [point.upper_ns - point.duration_ns for point in points],
+                ],
+                marker="o",
+                markersize=4,
+                linewidth=1.8,
+                capsize=2,
+                color=COLORS[library],
+                label=coverage_label(library, points, sizes),
+            )
+
+        axis.set_xscale("log", base=2)
+        axis.set_yscale("log", base=10)
+        axis.set_xticks(sizes)
+        axis.set_xticklabels([f"2^{size.bit_length() - 1}" for size in sizes])
+        axis.set_xlabel("Tree size (log₂ scale)")
+        axis.set_ylabel("Mean query duration (ns/query, log₁₀ scale)")
+        axis.set_title(title)
+        axis.grid(True, which="both", alpha=0.25)
+        axis.legend(title="Library")
+        figure.tight_layout()
+
+        path = output_dir / (
+            f"bench_result-cpp-competitors-{slug(result_label)}-"
+            f"{scalar}-{slug(query)}.png"
+        )
+        figure.savefig(path, dpi=160)
+        plt.close(figure)
+        rendered.append((title, path))
+    return rendered
+
+
+def write_html(
+    path: Path,
+    charts: list[tuple[str, Path]],
+    result_label: str,
+    sources: list[Path],
+) -> None:
+    sections = "\n".join(
+        (
+            f"<section><h2>{html.escape(title)}</h2>"
+            f'<img src="{html.escape(chart.name, quote=True)}" '
+            f'alt="{html.escape(title, quote=True)}"></section>'
+        )
+        for title, chart in charts
+    )
+    source_items = "".join(f"<li><code>{html.escape(str(source))}</code></li>" for source in sources)
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Non-Rust competitor k-d tree benchmarks</title>
+  <style>
+    body {{ font: 16px/1.45 system-ui, sans-serif; max-width: 1180px; margin: 0 auto; padding: 2rem; color: #18212b; }}
+    section {{ margin: 2.5rem 0; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #d8dee4; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>Non-Rust competitor k-d tree benchmarks</h1>
+  <p>Result label: <code>{html.escape(result_label)}</code>. All benchmarks are 3D. Each chart uses a base-2 logarithmic tree-size axis and a base-10 logarithmic per-query duration axis. Library coverage is uneven by design: ALGLIB is f64-only, Pkd-tree (single-query mode shown here) has no within_radius series and its f32 build asserts above 2^21 points, and NearestNeighbors.jl comes from a separate Julia process rather than the Rust criterion harness. Series are therefore ragged: each library is drawn over exactly the tree sizes it covers, and a legend entry carrying a range such as <code>2^16–2^21</code> marks a library that does not span the whole axis. Pkd-tree's batch-parallel throughput is a different metric and is charted separately.</p>
+  <details><summary>Source result exports</summary><ul>{source_items}</ul></details>
+  {sections}
+</body>
+</html>
+"""
+    path.write_text(document, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    if not SAFE_LABEL.fullmatch(args.result_label):
+        raise RuntimeError(
+            "result label must contain only letters, digits, '.', '_', '+', ':', or '-'"
+        )
+    kiddo_sources = [args.kiddo_nearest_one, args.kiddo_nearest_n, args.kiddo_query_family]
+    charts = collect_charts(args.cpp, *kiddo_sources)
+    rendered = render_charts(charts, args.output_dir, args.result_label)
+    if args.mode == "all":
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        write_html(args.output_dir / args.html_name, rendered, args.result_label, args.cpp + kiddo_sources)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chart_kiddo_vs_pkdtree_results.py
+++ b/scripts/chart_kiddo_vs_pkdtree_results.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Chart the dedicated kiddo-vs-Pkd-tree single-query comparison (profile_kiddo_vs_pkdtree group).
+
+Unlike chart_cpp_competitor_results.py, this needs no separate kiddo
+baseline file: kiddo_vs_pkdtree_single in profile_cpp_competitors.rs
+benchmarks both libraries directly (kiddo via its native API, no FFI) in one
+pass, so a single result export already has both series. This exists
+separately so it can be run at much larger tree sizes without nanoflann/
+ALGLIB also needing to build and hold a tree that size in memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+GROUP = "profile_kiddo_vs_pkdtree"
+SCALARS = ("f32", "f64")
+SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+LIBRARY_PREFIXES = (
+    ("kiddo_", "kiddo"),
+    ("pkdtree_", "Pkd-tree"),
+)
+LIBRARY_ORDER = ("kiddo", "Pkd-tree")
+COLORS = {"kiddo": "#3264a8", "Pkd-tree": "#8e44ad"}
+
+
+@dataclass(frozen=True)
+class Point:
+    tree_size: int
+    duration_ns: float
+    lower_ns: float
+    upper_ns: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Chart kiddo vs Pkd-tree, single-query, possibly at large N.")
+    parser.add_argument("mode", choices=("charts", "all"))
+    parser.add_argument("--result", type=Path, nargs="+", required=True)
+    parser.add_argument("--result-label", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--html-name", default="kiddo-vs-pkdtree.html")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"could not read {path}: {error}") from error
+    if not isinstance(value, dict) or not isinstance(value.get("results"), list):
+        raise RuntimeError(f"{path} is not a Criterion result export")
+    return value
+
+
+def finite_positive(value: Any, description: str, path: Path) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}") from error
+    if not math.isfinite(number) or number <= 0:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}")
+    return number
+
+
+def identity(function_id: str) -> tuple[str, str]:
+    for prefix, library in LIBRARY_PREFIXES:
+        if function_id.startswith(prefix):
+            query = function_id[len(prefix) :]
+            if query == "nearest_one" or re.fullmatch(r"nearest_n_k\d+", query):
+                return library, query
+            raise RuntimeError(f"unsupported query identity: {function_id}")
+    raise RuntimeError(f"unexpected library in benchmark identity {function_id!r}")
+
+
+def read_series(path: Path) -> dict[tuple[str, str], dict[str, list[Point]]]:
+    charts: dict[tuple[str, str], dict[str, list[Point]]] = {}
+    for result in load_json(path)["results"]:
+        metadata = result.get("metadata")
+        estimates = result.get("estimates")
+        if not isinstance(metadata, dict) or not isinstance(estimates, dict):
+            raise RuntimeError(f"{path} contains incomplete benchmark data")
+
+        group_id = metadata.get("group_id")
+        function_id = metadata.get("function_id")
+        if not isinstance(group_id, str) or not isinstance(function_id, str):
+            raise RuntimeError(f"{path} contains an invalid benchmark identity")
+        if group_id.rsplit("/", 1)[0] != GROUP:
+            raise RuntimeError(f"{path} contains group {group_id!r}, expected {GROUP!r}")
+        scalar = group_id.rsplit("/", 1)[-1]
+        if scalar not in SCALARS:
+            raise RuntimeError(f"{path} contains unsupported scalar group {group_id!r}")
+
+        library, query = identity(function_id)
+
+        tree_size_value = finite_positive(metadata.get("value_str"), "tree size", path)
+        tree_size = int(tree_size_value)
+        if tree_size != tree_size_value or tree_size & (tree_size - 1):
+            raise RuntimeError(f"tree size is not a power of two in {path}: {tree_size_value}")
+
+        throughput = metadata.get("throughput")
+        query_count = throughput.get("Elements") if isinstance(throughput, dict) else None
+        query_count = finite_positive(query_count, "Elements throughput", path)
+        mean = estimates.get("mean")
+        interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
+        if not isinstance(mean, dict) or not isinstance(interval, dict):
+            raise RuntimeError(f"{path} contains no mean confidence interval")
+
+        point = Point(
+            tree_size,
+            finite_positive(mean.get("point_estimate"), "mean duration", path) / query_count,
+            finite_positive(interval.get("lower_bound"), "lower duration bound", path) / query_count,
+            finite_positive(interval.get("upper_bound"), "upper duration bound", path) / query_count,
+        )
+        chart = charts.setdefault((scalar, query), {})
+        chart.setdefault(library, []).append(point)
+
+    for chart in charts.values():
+        for library, points in chart.items():
+            points.sort(key=lambda point: point.tree_size)
+            sizes = [point.tree_size for point in points]
+            if len(sizes) != len(set(sizes)):
+                raise RuntimeError(f"duplicate tree sizes for {library!r} in {path}")
+    return charts
+
+
+def merge_charts(paths: list[Path]) -> dict[tuple[str, str], dict[str, list[Point]]]:
+    merged: dict[tuple[str, str], dict[str, list[Point]]] = {}
+    for path in paths:
+        for key, libraries in read_series(path).items():
+            chart = merged.setdefault(key, {})
+            for library, points in libraries.items():
+                existing = chart.setdefault(library, [])
+                existing_sizes = {point.tree_size for point in existing}
+                for point in points:
+                    if point.tree_size in existing_sizes:
+                        raise RuntimeError(
+                            f"duplicate tree size {point.tree_size} for {library!r}/{key!r} across --result inputs"
+                        )
+                existing.extend(points)
+    return merged
+
+
+def query_sort_key(query: str) -> tuple[int, int]:
+    if query == "nearest_one":
+        return (0, 0)
+    match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    return (1, int(match.group(1))) if match else (2, 0)
+
+
+def query_title(query: str) -> str:
+    if query == "nearest_one":
+        return "nearest_one"
+    match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    return f"nearest_n (n={match.group(1)})" if match else query
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]+", "-", value).strip("-_") or "benchmark"
+
+
+def render_charts(
+    charts: dict[tuple[str, str], dict[str, list[Point]]], output_dir: Path, result_label: str
+) -> list[tuple[str, Path]]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as error:
+        raise RuntimeError("matplotlib is required to generate benchmark charts") from error
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[tuple[str, Path]] = []
+    ordered = sorted(charts.items(), key=lambda item: (SCALARS.index(item[0][0]), query_sort_key(item[0][1])))
+    for (scalar, query), series in ordered:
+        title = f"3D {query_title(query)} — kiddo vs Pkd-tree — {scalar}"
+        figure, axis = plt.subplots(figsize=(10.5, 6.2))
+        for library in LIBRARY_ORDER:
+            points = series.get(library)
+            if points is None:
+                continue
+            axis.errorbar(
+                [point.tree_size for point in points],
+                [point.duration_ns for point in points],
+                yerr=[
+                    [point.duration_ns - point.lower_ns for point in points],
+                    [point.upper_ns - point.duration_ns for point in points],
+                ],
+                marker="o",
+                markersize=4,
+                linewidth=1.8,
+                capsize=2,
+                color=COLORS.get(library, "#555555"),
+                label=library,
+            )
+        sizes = sorted({point.tree_size for points in series.values() for point in points})
+        axis.set_xscale("log", base=2)
+        axis.set_yscale("log", base=10)
+        axis.set_xticks(sizes)
+        axis.set_xticklabels([f"2^{size.bit_length() - 1}" for size in sizes])
+        axis.set_xlabel("Tree size (log₂ scale)")
+        axis.set_ylabel("Mean query duration (ns/query, log₁₀ scale)")
+        axis.set_title(title)
+        axis.grid(True, which="both", alpha=0.25)
+        axis.legend(title="Library")
+        figure.tight_layout()
+
+        path = output_dir / f"bench_result-kiddo-vs-pkdtree-{slug(result_label)}-{scalar}-{slug(query)}.png"
+        figure.savefig(path, dpi=160)
+        plt.close(figure)
+        rendered.append((title, path))
+    return rendered
+
+
+def write_html(path: Path, charts: list[tuple[str, Path]], result_label: str, sources: list[Path]) -> None:
+    sections = "\n".join(
+        (
+            f"<section><h2>{html.escape(title)}</h2>"
+            f'<img src="{html.escape(chart.name, quote=True)}" '
+            f'alt="{html.escape(title, quote=True)}"></section>'
+        )
+        for title, chart in charts
+    )
+    source_items = "".join(f"<li><code>{html.escape(str(source))}</code></li>" for source in sources)
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kiddo vs Pkd-tree (single-query)</title>
+  <style>
+    body {{ font: 16px/1.45 system-ui, sans-serif; max-width: 1180px; margin: 0 auto; padding: 2rem; color: #18212b; }}
+    section {{ margin: 2.5rem 0; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #d8dee4; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>kiddo vs Pkd-tree (single-query)</h1>
+  <p>Result label: <code>{html.escape(result_label)}</code>. All benchmarks are 3D, single-threaded, sequential per-query.</p>
+  <details><summary>Source result exports</summary><ul>{source_items}</ul></details>
+  {sections}
+</body>
+</html>
+"""
+    path.write_text(document, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    if not SAFE_LABEL.fullmatch(args.result_label):
+        raise RuntimeError("result label must contain only letters, digits, '.', '_', '+', ':', or '-'")
+    charts = merge_charts(args.result)
+    rendered = render_charts(charts, args.output_dir, args.result_label)
+    if args.mode == "all":
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        write_html(args.output_dir / args.html_name, rendered, args.result_label, args.result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chart_pkdtree_batch_results.py
+++ b/scripts/chart_pkdtree_batch_results.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Chart batch-parallel throughput (profile_pkdtree_batch group).
+
+This is deliberately a standalone chart, not a line on the
+chart_cpp_competitor_results.py charts: batch-parallel (submit every query
+at once, either via kiddo::batch::Executor::parallel() or Pkd-tree's
+parlay::parallel_for, both across all cores) is a throughput metric, not a
+per-query latency one, and isn't comparable to any of the sequential
+single-query numbers charted elsewhere. Kiddo's serial executor is included
+too, as the fairest same-API baseline for the parallel numbers. See
+benches/profile_cpp_competitors.rs's module doc comment for the full
+rationale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+GROUP = "profile_pkdtree_batch"
+SCALARS = ("f32", "f64")
+# Donnelly prefixes must precede the Eytzinger ones: "kiddo_batch_" is a
+# prefix of nothing else, but matching is first-wins, and a future rename
+# could easily make one stem's prefix shadow another's.
+LIBRARY_PREFIXES = (
+    ("kiddo_donnelly_batch_tuned_", "kiddo Donnelly (tuned)"),
+    ("kiddo_donnelly_batch_parallel_", "kiddo Donnelly (parallel)"),
+    ("kiddo_donnelly_batch_serial_", "kiddo Donnelly (serial)"),
+    ("kiddo_batch_tuned_", "kiddo Eytzinger (tuned)"),
+    ("kiddo_batch_parallel_", "kiddo Eytzinger (parallel)"),
+    ("kiddo_batch_serial_", "kiddo Eytzinger (serial)"),
+    ("pkdtree_batch_", "Pkd-tree"),
+)
+LIBRARY_ORDER = (
+    "kiddo Donnelly (tuned)",
+    "kiddo Donnelly (parallel)",
+    "kiddo Eytzinger (tuned)",
+    "kiddo Eytzinger (parallel)",
+    "kiddo Donnelly (serial)",
+    "kiddo Eytzinger (serial)",
+    "Pkd-tree",
+)
+COLORS = {
+    "kiddo Donnelly (tuned)": "#0f6b48",
+    "kiddo Donnelly (parallel)": "#1a7f5a",
+    "kiddo Eytzinger (tuned)": "#1f4e8c",
+    "kiddo Eytzinger (parallel)": "#3264a8",
+    "kiddo Donnelly (serial)": "#7fc4a8",
+    "kiddo Eytzinger (serial)": "#7fa8d9",
+    "Pkd-tree": "#8e44ad",
+}
+SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+
+
+@dataclass(frozen=True)
+class Point:
+    tree_size: int
+    elements_per_sec: float
+    lower: float
+    upper: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Chart batch-parallel throughput.")
+    parser.add_argument("mode", choices=("charts", "all"))
+    parser.add_argument("--result", type=Path, nargs="+", required=True)
+    parser.add_argument("--result-label", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--html-name", default="pkdtree-batch-throughput.html")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"could not read {path}: {error}") from error
+    if not isinstance(value, dict) or not isinstance(value.get("results"), list):
+        raise RuntimeError(f"{path} is not a Criterion result export")
+    return value
+
+
+def finite_positive(value: Any, description: str, path: Path) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}") from error
+    if not math.isfinite(number) or number <= 0:
+        raise RuntimeError(f"invalid {description} in {path}: {value!r}")
+    return number
+
+
+def identity(function_id: str) -> tuple[str, str]:
+    for prefix, library in LIBRARY_PREFIXES:
+        if function_id.startswith(prefix):
+            query = function_id[len(prefix) :]
+            if query == "nearest_one" or re.fullmatch(r"nearest_n_k\d+", query):
+                return library, query
+            raise RuntimeError(f"unsupported batch query identity: {function_id}")
+    raise RuntimeError(f"unexpected library in batch benchmark identity {function_id!r}")
+
+
+def read_series(path: Path) -> dict[tuple[str, str], dict[str, list[Point]]]:
+    charts: dict[tuple[str, str], dict[str, list[Point]]] = {}
+    for result in load_json(path)["results"]:
+        metadata = result.get("metadata")
+        estimates = result.get("estimates")
+        if not isinstance(metadata, dict) or not isinstance(estimates, dict):
+            raise RuntimeError(f"{path} contains incomplete benchmark data")
+
+        group_id = metadata.get("group_id")
+        function_id = metadata.get("function_id")
+        if not isinstance(group_id, str) or not isinstance(function_id, str):
+            raise RuntimeError(f"{path} contains an invalid benchmark identity")
+        if group_id.rsplit("/", 1)[0] != GROUP:
+            raise RuntimeError(f"{path} contains group {group_id!r}, expected {GROUP!r}")
+        scalar = group_id.rsplit("/", 1)[-1]
+        if scalar not in SCALARS:
+            raise RuntimeError(f"{path} contains unsupported scalar group {group_id!r}")
+
+        library, query = identity(function_id)
+
+        tree_size_value = finite_positive(metadata.get("value_str"), "tree size", path)
+        tree_size = int(tree_size_value)
+        if tree_size != tree_size_value or tree_size & (tree_size - 1):
+            raise RuntimeError(f"tree size is not a power of two in {path}: {tree_size_value}")
+
+        throughput = metadata.get("throughput")
+        query_count = throughput.get("Elements") if isinstance(throughput, dict) else None
+        query_count = finite_positive(query_count, "Elements throughput", path)
+        mean = estimates.get("mean")
+        interval = mean.get("confidence_interval") if isinstance(mean, dict) else None
+        if not isinstance(mean, dict) or not isinstance(interval, dict):
+            raise RuntimeError(f"{path} contains no mean confidence interval")
+
+        duration_s = finite_positive(mean.get("point_estimate"), "mean duration", path) / 1.0e9
+        lower_s = finite_positive(interval.get("lower_bound"), "lower duration bound", path) / 1.0e9
+        upper_s = finite_positive(interval.get("upper_bound"), "upper duration bound", path) / 1.0e9
+
+        point = Point(
+            tree_size,
+            query_count / duration_s,
+            query_count / upper_s,
+            query_count / lower_s,
+        )
+        chart = charts.setdefault((scalar, query), {})
+        chart.setdefault(library, []).append(point)
+
+    for chart in charts.values():
+        for library, points in chart.items():
+            points.sort(key=lambda point: point.tree_size)
+            sizes = [point.tree_size for point in points]
+            if len(sizes) != len(set(sizes)):
+                raise RuntimeError(f"duplicate tree sizes for {library!r} in {path}")
+    return charts
+
+
+def merge_charts(
+    paths: list[Path],
+) -> dict[tuple[str, str], dict[str, list[Point]]]:
+    merged: dict[tuple[str, str], dict[str, list[Point]]] = {}
+    for path in paths:
+        for key, libraries in read_series(path).items():
+            chart = merged.setdefault(key, {})
+            for library, points in libraries.items():
+                if library in chart:
+                    raise RuntimeError(f"duplicate {library} series for {key!r} across --result inputs")
+                chart[library] = points
+    return merged
+
+
+def query_sort_key(query: str) -> int:
+    """nearest_one sorts first; nearest_n sorts by k."""
+    if query == "nearest_one":
+        return 1
+    match = re.fullmatch(r"nearest_n_k(\d+)", query)
+    return int(match.group(1)) if match else 0
+
+
+def query_title(query: str) -> str:
+    """Pkd-tree has no single-nearest entry point, so its nearest_one series
+    is its k-nearest call with k=1; kiddo's is the real nearest_one."""
+    if query == "nearest_one":
+        return "nearest_one (Pkd-tree: k=1)"
+    return f"nearest_n (k={query_sort_key(query)})"
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]+", "-", value).strip("-_") or "benchmark"
+
+
+def render_charts(
+    charts: dict[tuple[str, str], dict[str, list[Point]]], output_dir: Path, result_label: str
+) -> list[tuple[str, Path]]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as error:
+        raise RuntimeError("matplotlib is required to generate benchmark charts") from error
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[tuple[str, Path]] = []
+    ordered = sorted(charts.items(), key=lambda item: (SCALARS.index(item[0][0]), query_sort_key(item[0][1])))
+    for (scalar, query), series in ordered:
+        title = f"Batch-parallel {query_title(query)} throughput — {scalar}"
+        figure, axis = plt.subplots(figsize=(10.5, 6.2))
+        for library in LIBRARY_ORDER:
+            points = series.get(library)
+            if points is None:
+                continue
+            axis.errorbar(
+                [point.tree_size for point in points],
+                [point.elements_per_sec for point in points],
+                yerr=[
+                    [point.elements_per_sec - point.lower for point in points],
+                    [point.upper - point.elements_per_sec for point in points],
+                ],
+                marker="o",
+                markersize=4,
+                linewidth=1.8,
+                capsize=2,
+                color=COLORS.get(library, "#555555"),
+                label=library,
+            )
+        sizes = sorted({point.tree_size for points in series.values() for point in points})
+        axis.set_xscale("log", base=2)
+        axis.set_yscale("log", base=10)
+        axis.set_xticks(sizes)
+        axis.set_xticklabels([f"2^{size.bit_length() - 1}" for size in sizes])
+        axis.set_xlabel("Tree size (log₂ scale)")
+        axis.set_ylabel("Queries/sec, all cores (log₁₀ scale)")
+        axis.set_title(title)
+        axis.grid(True, which="both", alpha=0.25)
+        axis.legend(title="Library")
+        figure.tight_layout()
+
+        path = output_dir / f"bench_result-pkdtree-batch-{slug(result_label)}-{scalar}-{slug(query)}.png"
+        figure.savefig(path, dpi=160)
+        plt.close(figure)
+        rendered.append((title, path))
+    return rendered
+
+
+def write_html(path: Path, charts: list[tuple[str, Path]], result_label: str, sources: list[Path]) -> None:
+    sections = "\n".join(
+        (
+            f"<section><h2>{html.escape(title)}</h2>"
+            f'<img src="{html.escape(chart.name, quote=True)}" '
+            f'alt="{html.escape(title, quote=True)}"></section>'
+        )
+        for title, chart in charts
+    )
+    source_items = "".join(f"<li><code>{html.escape(str(source))}</code></li>" for source in sources)
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Batch-parallel throughput: kiddo vs Pkd-tree</title>
+  <style>
+    body {{ font: 16px/1.45 system-ui, sans-serif; max-width: 1180px; margin: 0 auto; padding: 2rem; color: #18212b; }}
+    section {{ margin: 2.5rem 0; }}
+    img {{ display: block; width: 100%; height: auto; border: 1px solid #d8dee4; }}
+    code {{ overflow-wrap: anywhere; }}
+  </style>
+</head>
+<body>
+  <h1>Batch-parallel throughput: kiddo vs Pkd-tree</h1>
+  <p>Result label: <code>{html.escape(result_label)}</code>. All queries submitted at once across every core (kiddo::batch::Executor::parallel() / Pkd-tree's parlay::parallel_for). kiddo's serial executor is included as the fairest same-API baseline. Not comparable to the sequential per-query charts.</p>
+  <details><summary>Source result exports</summary><ul>{source_items}</ul></details>
+  {sections}
+</body>
+</html>
+"""
+    path.write_text(document, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    if not SAFE_LABEL.fullmatch(args.result_label):
+        raise RuntimeError("result label must contain only letters, digits, '.', '_', '+', ':', or '-'")
+    charts = merge_charts(args.result)
+    rendered = render_charts(charts, args.output_dir, args.result_label)
+    if args.mode == "all":
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        write_html(args.output_dir / args.html_name, rendered, args.result_label, args.result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_bench_profile_matrix.sh
+++ b/scripts/run_bench_profile_matrix.sh
@@ -1,0 +1,803 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Competitor matrix for the bench-profile boot profiles.
+#
+# ONE PHASE PER INVOCATION, because each phase needs a different boot profile
+# and the machine can only be in one at a time. The phase is derived from the
+# booted profile by default; the run is gated on `bench-profile-status
+# expect-<profile>` so a phase can never silently execute in the wrong CPU
+# state. That gate exists because it already happened once: a full parallel
+# matrix was collected under isolcpus=domain, which disables load balancing, so
+# every thread pool ran on a single core and the numbers were meaningless.
+#
+#   PHASE single      (boot: benchmark single-core)
+#     Per-query latency: nanoflann and Pkd-tree's sequential mode, plus kiddo's
+#     own serial benches. Inherently single-threaded, so it pins to ONE
+#     isolated core -- the maximum-isolation case, matching the methodology of
+#     the existing single-core query-pool runs. Both runtimes are forced to one
+#     worker: ParlayLib starts its global scheduler on first use whether or not
+#     parallel_for is called, so without PARLAY_NUM_THREADS=1 it would put a
+#     worker per hardware thread onto that single core.
+#
+#   PHASE parallel    (boot: benchmark multi-core)
+#     Parallel throughput, controlled: kiddo (serial, parallel and tuned
+#     executors, Eytzinger and Donnelly stems) against Pkd-tree's parallel_for,
+#     across one whole core complex. Each CCD has its own L3 and its own path
+#     to the memory controller, so confining the run to one CCD removes
+#     cross-complex traffic and keeps housekeeping's cache footprint entirely
+#     on the other complex. Boost is off in this profile, so cells measured
+#     minutes apart stay comparable. This is the "does A beat B" phase.
+#
+#   PHASE unlimited   (boot: benchmark unlimited)
+#     No holds barred: every thread, SMT on, boost on, no pinning and no
+#     isolation. kiddo against Pkd-tree only -- this phase exists to settle who
+#     holds the crown for maximum parallel query rate on this machine, not to
+#     compare implementation details. Isolation and IRQ gates relax to
+#     warnings, because with every core in use they cannot hold by
+#     construction. Numbers here are NOT comparable with the parallel phase's.
+#
+# Every phase pins both runtimes to the same worker count. This is not a
+# nicety: ParlayLib falls back to `std::thread::hardware_concurrency()`, which
+# ignores the affinity mask, while rayon uses `available_parallelism()`, which
+# honours it. Left alone under taskset, Pkd-tree would oversubscribe the
+# benchmark cores while kiddo did not, and the comparison would be meaningless.
+#
+# This deliberately does NOT use bench-profile-run: that wrapper pins to the
+# profile's whole benchmark set, which is right for the parallel phase but
+# wrong for the single phase's per-cell IRQ accounting and retry logic, which
+# is implemented here instead.
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+# auto -> derive the phase from the booted profile. Override only to force a
+# phase in an unusual environment; the profile gate still applies.
+PHASE=${PHASE:-auto}
+SINGLE_LIBRARIES=${SINGLE_LIBRARIES:-nanoflann,pkdtree}
+SINGLE_F64_HEIGHTS=${SINGLE_F64_HEIGHTS:-16,18,20,22,24}
+SINGLE_F32_HEIGHTS=${SINGLE_F32_HEIGHTS:-16,18,20,21}
+SINGLE_QUERY_COUNT=${SINGLE_QUERY_COUNT:-1000}
+SINGLE_RADIUS=${SINGLE_RADIUS:-0.05}
+BENCH_CPUS=${BENCH_CPUS:-}
+F64_HEIGHTS=${F64_HEIGHTS:-24,25,26,27}
+F32_HEIGHTS=${F32_HEIGHTS:-21}
+QUERY_COUNTS=${QUERY_COUNTS:-1000,4096,16384,100000}
+SCALARS=${SCALARS:-f64,f32}
+BATCH_LIBRARIES=${BATCH_LIBRARIES:-kiddo,pkdtree}
+# The unlimited phase is a head-to-head for the maximum-parallel-QPS crown, so
+# it is deliberately limited to the two contenders and to the largest cells.
+UNLIMITED_LIBRARIES=${UNLIMITED_LIBRARIES:-kiddo,pkdtree}
+UNLIMITED_F64_HEIGHTS=${UNLIMITED_F64_HEIGHTS:-24,27}
+UNLIMITED_F32_HEIGHTS=${UNLIMITED_F32_HEIGHTS:-21}
+UNLIMITED_QUERY_COUNTS=${UNLIMITED_QUERY_COUNTS:-100000}
+CRITERION_WARMUP=${CRITERION_WARMUP:-3}
+CRITERION_MEASUREMENT=${CRITERION_MEASUREMENT:-8}
+CRITERION_SAMPLE_SIZE=${CRITERION_SAMPLE_SIZE:-30}
+IRQ_RETRIES=${IRQ_RETRIES:-2}
+FEATURES=${FEATURES:-cpp_competitors,test_utils,logging_off,simd}
+OUTPUT_BASE=${OUTPUT_BASE:-$REPO_DIR/cpp-competitor-results}
+CHART_BASE=${CHART_BASE:-$REPO_DIR/cpp-competitor-charts}
+SUITE_LABEL=${SUITE_LABEL:-batch-parallel-matrix-$(date -u +%Y%m%dT%H%M%SZ)}
+
+readonly RUN_DIR="$OUTPUT_BASE/$SUITE_LABEL"
+readonly CHART_DIR="$CHART_BASE/$SUITE_LABEL"
+readonly LOG_FILE="$RUN_DIR/run.log"
+
+for command_name in cargo jq mktemp python3 rustc taskset; do
+    command -v "$command_name" >/dev/null || {
+        echo "Required command is unavailable: $command_name" >&2
+        exit 2
+    }
+done
+[[ "$SUITE_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]] || {
+    echo "SUITE_LABEL contains unsupported characters: $SUITE_LABEL" >&2
+    exit 2
+}
+[[ ! -e "$RUN_DIR" && ! -e "$CHART_DIR" ]] || {
+    echo "Refusing to overwrite existing suite $SUITE_LABEL" >&2
+    exit 2
+}
+
+# --- phase and boot profile -------------------------------------------------
+
+# The bench-profile boot entries carry their identity on the kernel cmdline.
+booted_profile() {
+    local token
+    for token in $(< /proc/cmdline); do
+        case "$token" in
+            systemd.setenv=BENCH_PROFILE=*)
+                printf '%s\n' "${token#systemd.setenv=BENCH_PROFILE=}"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+BOOT_PROFILE=$(booted_profile || true)
+
+if [[ "$PHASE" == auto ]]; then
+    case "$BOOT_PROFILE" in
+        single-core) PHASE=single ;;
+        multi-core)  PHASE=parallel ;;
+        unlimited)   PHASE=unlimited ;;
+        *)
+            cat >&2 <<'EOF'
+Not booted into a bench-profile benchmark profile, so no phase can be derived.
+
+Each phase needs a different CPU state, and the machine can only be in one at a
+time. Reboot into the entry for the phase you want:
+
+  ... benchmark single-core   -> PHASE=single     nanoflann + Pkd-tree, one core
+  ... benchmark multi-core    -> PHASE=parallel   kiddo vs Pkd-tree, one CCD
+  ... benchmark unlimited     -> PHASE=unlimited  kiddo vs Pkd-tree, whole machine
+
+Install the profiles from https://github.com/sdd/bench-profile if they are not
+in the boot menu. Set PHASE= explicitly only to override this deliberately.
+EOF
+            exit 2
+            ;;
+    esac
+fi
+
+case "$PHASE" in
+    single)   REQUIRED_PROFILE=single-core; EXPECT_VERB=expect-single-core ;;
+    parallel) REQUIRED_PROFILE=multi-core;  EXPECT_VERB=expect-multi-core ;;
+    unlimited)
+        REQUIRED_PROFILE=unlimited
+        EXPECT_VERB=expect-unrestricted
+        # The crown run is a head-to-head at the largest sizes only, so it
+        # replaces the matrix dimensions before they are parsed below.
+        BATCH_LIBRARIES="$UNLIMITED_LIBRARIES"
+        F64_HEIGHTS="$UNLIMITED_F64_HEIGHTS"
+        F32_HEIGHTS="$UNLIMITED_F32_HEIGHTS"
+        QUERY_COUNTS="$UNLIMITED_QUERY_COUNTS"
+        ;;
+    *)
+        echo "PHASE must be single, parallel or unlimited: $PHASE" >&2
+        exit 2
+        ;;
+esac
+readonly PHASE REQUIRED_PROFILE EXPECT_VERB
+
+if [[ -n "$BOOT_PROFILE" && "$BOOT_PROFILE" != "$REQUIRED_PROFILE" ]]; then
+    echo "PHASE=$PHASE needs the '$REQUIRED_PROFILE' boot profile, but this machine" >&2
+    echo "is booted into '$BOOT_PROFILE'. Reboot, or accept that the result is not" >&2
+    echo "comparable with the rest of the series." >&2
+    exit 2
+fi
+
+IFS=',' read -r -a f64_heights <<<"$F64_HEIGHTS"
+IFS=',' read -r -a f32_heights <<<"$F32_HEIGHTS"
+IFS=',' read -r -a query_counts <<<"$QUERY_COUNTS"
+IFS=',' read -r -a scalars <<<"$SCALARS"
+
+contains() {
+    local needle=$1
+    shift
+    local value
+    for value in "$@"; do
+        [[ "$value" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+validate_unique_positive_list() {
+    local label=$1
+    shift
+    local -a values=("$@")
+    local i j value
+    (( ${#values[@]} > 0 )) || {
+        echo "$label must not be empty" >&2
+        exit 2
+    }
+    for value in "${values[@]}"; do
+        [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
+            echo "$label contains an invalid positive integer: $value" >&2
+            exit 2
+        }
+    done
+    for ((i = 0; i < ${#values[@]}; i++)); do
+        for ((j = i + 1; j < ${#values[@]}; j++)); do
+            [[ "${values[i]}" != "${values[j]}" ]] || {
+                echo "$label contains a duplicate: ${values[i]}" >&2
+                exit 2
+            }
+        done
+    done
+}
+
+validate_unique_positive_list QUERY_COUNTS "${query_counts[@]}"
+(( ${#scalars[@]} > 0 )) || { echo "SCALARS must not be empty" >&2; exit 2; }
+for scalar in "${scalars[@]}"; do
+    case "$scalar" in
+        f32|f64) ;;
+        *) echo "SCALARS entries must be f32 or f64: $scalar" >&2; exit 2 ;;
+    esac
+done
+contains f64 "${scalars[@]}" && validate_unique_positive_list F64_HEIGHTS "${f64_heights[@]}"
+contains f32 "${scalars[@]}" && validate_unique_positive_list F32_HEIGHTS "${f32_heights[@]}"
+
+for value_name in CRITERION_WARMUP CRITERION_MEASUREMENT; do
+    value=${!value_name}
+    [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] || {
+        echo "$value_name must be a non-negative number: $value" >&2
+        exit 2
+    }
+done
+[[ "$CRITERION_SAMPLE_SIZE" =~ ^[1-9][0-9]*$ ]] && (( CRITERION_SAMPLE_SIZE >= 10 )) || {
+    echo "CRITERION_SAMPLE_SIZE must be an integer of at least 10" >&2
+    exit 2
+}
+[[ "$IRQ_RETRIES" =~ ^[0-9]+$ ]] || {
+    echo "IRQ_RETRIES must be a non-negative integer" >&2
+    exit 2
+}
+
+# Pkd-tree's f32 build asserts above 2^21 points, aborting the process.
+if contains f32 "${scalars[@]}" && [[ "$BATCH_LIBRARIES" == *pkdtree* ]]; then
+    for height in "${f32_heights[@]}"; do
+        (( height <= 21 )) || {
+            echo "F32_HEIGHTS entry $height exceeds Pkd-tree's f32 build limit of 2^21" >&2
+            exit 2
+        }
+    done
+fi
+
+IFS=',' read -r -a single_f64_heights <<<"$SINGLE_F64_HEIGHTS"
+IFS=',' read -r -a single_f32_heights <<<"$SINGLE_F32_HEIGHTS"
+if [[ "$PHASE" == single ]]; then
+    contains f64 "${scalars[@]}" && validate_unique_positive_list SINGLE_F64_HEIGHTS "${single_f64_heights[@]}"
+    contains f32 "${scalars[@]}" && validate_unique_positive_list SINGLE_F32_HEIGHTS "${single_f32_heights[@]}"
+    validate_unique_positive_list SINGLE_QUERY_COUNT "$SINGLE_QUERY_COUNT"
+    # Pkd-tree's f32 build asserts above 2^21 in the single-query suite too.
+    if [[ "$SINGLE_LIBRARIES" == *pkdtree* ]] && contains f32 "${scalars[@]}"; then
+        for height in "${single_f32_heights[@]}"; do
+            (( height <= 21 )) || {
+                echo "SINGLE_F32_HEIGHTS entry $height exceeds Pkd-tree's f32 build limit of 2^21" >&2
+                exit 2
+            }
+        done
+    fi
+fi
+
+expand_cpu_list() {
+    local spec=$1 segment start end cpu
+    local -a segments
+    IFS=',' read -r -a segments <<<"$spec"
+    for segment in "${segments[@]}"; do
+        if [[ "$segment" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+            start=${BASH_REMATCH[1]}
+            end=${BASH_REMATCH[2]}
+            (( start <= end )) || return 1
+            for ((cpu = start; cpu <= end; cpu++)); do printf '%s\n' "$cpu"; done
+        elif [[ "$segment" =~ ^[0-9]+$ ]]; then
+            printf '%s\n' "$segment"
+        else
+            return 1
+        fi
+    done
+}
+
+online_cpu_list() {
+    local candidate cpu online
+    for candidate in /sys/devices/system/cpu/cpu[0-9]*; do
+        cpu=${candidate##*/cpu}
+        [[ "$cpu" =~ ^[0-9]+$ ]] || continue
+        online=1
+        [[ -r "$candidate/online" ]] && online=$(<"$candidate/online")
+        (( online == 1 )) && printf '%s\n' "$cpu"
+    done | sort -n
+}
+
+# --- benchmark CPU set ------------------------------------------------------
+
+case "$PHASE" in
+    single)
+        # Sequential latency: one isolated core is the maximum-isolation case,
+        # and adding cores could not make a sequential query faster.
+        BENCH_CPUS=${BENCH_CPUS:-8}
+        readonly STRICT_ISOLATION=1
+        ;;
+    parallel)
+        # One isolated core complex: its own L3, its own path to the memory
+        # controller, housekeeping confined to the other complex.
+        BENCH_CPUS=${BENCH_CPUS:-8-15}
+        readonly STRICT_ISOLATION=1
+        ;;
+    unlimited)
+        # Every online CPU, SMT included. Isolation cannot hold by
+        # construction, so the environment gates downgrade to warnings and IRQs
+        # stop invalidating cells; otherwise every cell would be discarded.
+        if [[ -z "$BENCH_CPUS" ]]; then
+            BENCH_CPUS=$(online_cpu_list | paste -sd, -)
+        fi
+        readonly STRICT_ISOLATION=0
+        ;;
+esac
+
+
+if [[ -n "$BOOT_PROFILE" && "$BOOT_PROFILE" != "$REQUIRED_PROFILE" ]]; then
+    echo "PHASE=$PHASE needs the '$REQUIRED_PROFILE' boot profile, but this machine" >&2
+    echo "is booted into '$BOOT_PROFILE'. Reboot, or accept that the result is not" >&2
+    echo "comparable with the rest of the series." >&2
+    exit 2
+fi
+
+mapfile -t bench_cpus < <(expand_cpu_list "$BENCH_CPUS") || {
+    echo "BENCH_CPUS is not a valid CPU list: $BENCH_CPUS" >&2
+    exit 2
+}
+if [[ "$PHASE" == single ]]; then
+    (( ${#bench_cpus[@]} == 1 )) || {
+        echo "The single phase measures sequential latency; BENCH_CPUS must name one CPU" >&2
+        exit 2
+    }
+else
+    (( ${#bench_cpus[@]} > 1 )) || {
+        echo "PHASE=$PHASE measures parallel throughput; BENCH_CPUS must name more than one CPU" >&2
+        exit 2
+    }
+fi
+readonly WORKER_COUNT=${#bench_cpus[@]}
+
+if (( STRICT_ISOLATION == 1 )); then
+    pin_command=(taskset --cpu-list "$BENCH_CPUS")
+else
+    pin_command=(env)
+fi
+readonly pin_command
+
+mkdir -p -- "$RUN_DIR" "$CHART_DIR"
+
+log() {
+    printf '%s\n' "$*" | tee -a "$LOG_FILE"
+}
+
+# --- environment validation -------------------------------------------------
+
+validate_environment() {
+    local status_file=$1
+    local failures=0 cpu isolated online governor siblings sibling
+    local -a isolated_cpus
+
+    # In machine mode nothing below can hold: the point is to use every core.
+    local verdict=FAIL
+    (( STRICT_ISOLATION == 1 )) || verdict=WARN
+
+    {
+        echo "phase: $PHASE (boot profile: ${BOOT_PROFILE:-none})"
+        echo "benchmark CPUs: $BENCH_CPUS ($WORKER_COUNT workers)"
+        echo "kernel cmdline: $(cat /proc/cmdline)"
+    } >"$status_file"
+
+    isolated=$(cat /sys/devices/system/cpu/isolated 2>/dev/null || true)
+    mapfile -t isolated_cpus < <(expand_cpu_list "${isolated:-}" 2>/dev/null || true)
+
+    for cpu in "${bench_cpus[@]}"; do
+        online=1
+        if [[ -r "/sys/devices/system/cpu/cpu$cpu/online" ]]; then
+            online=$(<"/sys/devices/system/cpu/cpu$cpu/online")
+        fi
+        if (( online != 1 )); then
+            echo "FAIL: cpu$cpu is offline" >>"$status_file"
+            failures=$((failures + 1))
+            continue
+        fi
+
+        if contains "$cpu" "${isolated_cpus[@]}"; then
+            echo "PASS: cpu$cpu isolated" >>"$status_file"
+        else
+            echo "$verdict: cpu$cpu is not in isolcpus (${isolated:-none})" >>"$status_file"
+            (( STRICT_ISOLATION == 1 )) && failures=$((failures + 1))
+        fi
+
+        governor=$(cat "/sys/devices/system/cpu/cpu$cpu/cpufreq/scaling_governor" 2>/dev/null || echo unknown)
+        if [[ "$governor" == performance ]]; then
+            echo "PASS: cpu$cpu governor performance" >>"$status_file"
+        else
+            # bench-profile-status only checks the single BENCHMARK_CPU, so a
+            # profile provisioned for single-core work routinely leaves the
+            # rest of the isolated set on powersave. Say how to fix it.
+            echo "FAIL: cpu$cpu governor is $governor (fix: sudo cpupower -c $BENCH_CPUS frequency-set -g performance)" >>"$status_file"
+            failures=$((failures + 1))
+        fi
+
+        # An online SMT sibling outside the set would let unrelated work share
+        # the core's execution resources, which shows up as throughput noise.
+        siblings=$(cat "/sys/devices/system/cpu/cpu$cpu/topology/thread_siblings_list" 2>/dev/null || echo "$cpu")
+        while read -r sibling; do
+            [[ -n "$sibling" && "$sibling" != "$cpu" ]] || continue
+            online=1
+            if [[ -r "/sys/devices/system/cpu/cpu$sibling/online" ]]; then
+                online=$(<"/sys/devices/system/cpu/cpu$sibling/online")
+            fi
+            if (( online == 1 )) && ! contains "$sibling" "${bench_cpus[@]}"; then
+                echo "$verdict: cpu$cpu has online SMT sibling cpu$sibling outside BENCH_CPUS" >>"$status_file"
+                (( STRICT_ISOLATION == 1 )) && failures=$((failures + 1))
+            fi
+        done < <(expand_cpu_list "$siblings" 2>/dev/null || true)
+    done
+
+    # Something has to service interrupts and run kernel threads.
+    local housekeeping=0 candidate
+    for candidate in /sys/devices/system/cpu/cpu[0-9]*; do
+        cpu=${candidate##*/cpu}
+        [[ "$cpu" =~ ^[0-9]+$ ]] || continue
+        online=1
+        if [[ -r "$candidate/online" ]]; then
+            online=$(<"$candidate/online")
+        fi
+        (( online == 1 )) || continue
+        contains "$cpu" "${bench_cpus[@]}" || housekeeping=$((housekeeping + 1))
+    done
+    if (( housekeeping > 0 )); then
+        echo "PASS: $housekeeping online housekeeping CPUs outside BENCH_CPUS" >>"$status_file"
+    else
+        echo "$verdict: no online CPU outside BENCH_CPUS to take IRQs" >>"$status_file"
+        (( STRICT_ISOLATION == 1 )) && failures=$((failures + 1))
+    fi
+
+    # bench-profile-status is the authority when installed: it asserts this
+    # phase's whole desired CPU state, and -- for the parallel phases -- runs
+    # the parallel-dispatch canary, the only check that would have caught the
+    # isolcpus=domain collapse that silently invalidated the 2026-08-02 matrix.
+    # The inline checks above remain the fallback for machines without it.
+    if command -v bench-profile-status >/dev/null; then
+        echo "--- bench-profile-status $EXPECT_VERB ---" >>"$status_file"
+        if bench-profile-status "$EXPECT_VERB" >>"$status_file" 2>&1; then
+            echo "PASS: bench-profile-status $EXPECT_VERB" >>"$status_file"
+        else
+            echo "FAIL: the machine is not in the '$REQUIRED_PROFILE' benchmark state." >>"$status_file"
+            echo "      Boot the '... benchmark $REQUIRED_PROFILE' entry; bench-prep.service" >>"$status_file"
+            echo "      applies the policy, or run 'sudo bench-prep' by hand." >>"$status_file"
+            # The unlimited phase cannot satisfy the isolation gates by design,
+            # but a failed canary there is still fatal, so the verb is still run
+            # and recorded -- it just does not block.
+            (( STRICT_ISOLATION == 1 )) && failures=$((failures + 1))
+        fi
+    else
+        echo "NOTE: bench-profile-status is not installed; relying on the inline checks" >>"$status_file"
+        echo "      above, which cannot detect a collapsed thread pool." >>"$status_file"
+        echo "      Install from https://github.com/sdd/bench-profile" >>"$status_file"
+    fi
+
+    if (( failures > 0 )); then
+        cat "$status_file" >&2
+        echo "Benchmark environment validation failed with $failures problems." >&2
+        return 1
+    fi
+    cat "$status_file" >>"$LOG_FILE"
+}
+
+# --- IRQ accounting ---------------------------------------------------------
+
+# Total hardware interrupts delivered to the benchmark CPUs so far.
+interrupt_total() {
+    local cpu_csv
+    cpu_csv=$(IFS=,; echo "${bench_cpus[*]}")
+    awk -v cpus="$cpu_csv" '
+        BEGIN {
+            split(cpus, wanted, ",")
+            for (i in wanted) target["CPU" wanted[i]] = 1
+        }
+        NR == 1 {
+            for (field = 1; field <= NF; field++)
+                if ($field in target) column[field + 1] = 1
+            next
+        }
+        $1 ~ /^[0-9]+:$/ {
+            for (field in column)
+                if (field <= NF && $field ~ /^[0-9]+$/) total += $field
+        }
+        END { print total + 0 }
+    ' /proc/interrupts
+}
+
+# --- build ------------------------------------------------------------------
+
+log "Building profile_cpp_competitors (features: $FEATURES)"
+benchmark_exe="$(
+    cd -- "$REPO_DIR"
+    RUSTC_WRAPPER= RUSTFLAGS='-C target-cpu=native' \
+        cargo bench --bench profile_cpp_competitors \
+        --features "$FEATURES" --no-run --message-format=json |
+        jq -r 'select(.reason == "compiler-artifact" and .target.name == "profile_cpp_competitors") | .executable // empty' |
+        tail -n 1
+)"
+[[ -n "$benchmark_exe" && -x "$benchmark_exe" ]] || {
+    echo "Could not resolve profile_cpp_competitors executable" >&2
+    exit 1
+}
+
+opt_level=$(cd -- "$REPO_DIR" && python3 - <<'PY'
+import re, pathlib
+text = pathlib.Path("Cargo.toml").read_text()
+section = re.search(r"\[profile\.bench\](.*?)(?=\n\[|\Z)", text, re.S)
+match = re.search(r"opt-level\s*=\s*(\d+)", section.group(1)) if section else None
+print(match.group(1) if match else "unset")
+PY
+)
+[[ "$opt_level" == 3 ]] || {
+    echo "profile.bench opt-level is $opt_level; hand-written SIMD kernels must be measured at 3" >&2
+    exit 2
+}
+
+native_cfg=$(rustc --print cfg -C target-cpu=native)
+[[ "$native_cfg" == *'target_feature="avx512f"'* ]] || {
+    echo "Donnelly cyclic SIMD descent requires native AVX-512F support" >&2
+    exit 2
+}
+
+validate_environment "$RUN_DIR/environment-before.txt"
+
+# --- cell execution ---------------------------------------------------------
+
+run_cell() {
+    local scalar=$1 height=$2 query_count=$3 role=$4
+    local warmup=${5:-$CRITERION_WARMUP}
+    local measurement=${6:-$CRITERION_MEASUREMENT}
+    local sample_size=${7:-$CRITERION_SAMPLE_SIZE}
+    local output_dir=${8:-$RUN_DIR}
+    local attempt=0 status result_key result_path tmp_dir irq_before irq_after
+
+    result_key="$SUITE_LABEL-$PHASE-batch-$role-$scalar-2p$height-q$query_count"
+    result_path="$output_dir/bench_result-pkdtree-batch-$result_key.json"
+
+    while true; do
+        tmp_dir="$(mktemp -d /dev/shm/kiddo-batch-parallel.XXXXXX)"
+        cp -- "$benchmark_exe" "$tmp_dir/benchmark"
+        chmod 0755 "$tmp_dir/benchmark"
+
+        irq_before=$(interrupt_total)
+        set +e
+        "${pin_command[@]}" env \
+            CRITERION_HOME="$tmp_dir/criterion" \
+            RAYON_NUM_THREADS="$WORKER_COUNT" \
+            PARLAY_NUM_THREADS="$WORKER_COUNT" \
+            KIDDO_CPP_SUITES=pkdtree_batch \
+            KIDDO_CPP_LIBRARIES="$BATCH_LIBRARIES" \
+            KIDDO_CPP_SCALARS="$scalar" \
+            KIDDO_PROFILE_QUERIES="$query_count" \
+            KIDDO_LARGE_MIN_LOG2_POINTS="$height" \
+            KIDDO_LARGE_MAX_LOG2_POINTS="$height" \
+            "$tmp_dir/benchmark" \
+            profile_pkdtree_batch \
+            --warm-up-time "$warmup" \
+            --measurement-time "$measurement" \
+            --sample-size "$sample_size" \
+            --noplot --bench 2>&1 | tee -a "$LOG_FILE" >&2
+        status=${PIPESTATUS[0]}
+        set -e
+        irq_after=$(interrupt_total)
+
+        if (( status == 0 && irq_after > irq_before )); then
+            echo "Cell $role $scalar 2^$height q$query_count saw $((irq_after - irq_before)) hardware IRQs on the benchmark CPUs" |
+                tee -a "$LOG_FILE" >&2
+            # Only a controlled run can promise an IRQ-free interval.
+            (( STRICT_ISOLATION == 1 )) && status=125
+        fi
+
+        if (( status == 0 )); then
+            (
+                cd -- "$REPO_DIR"
+                cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+                    "$tmp_dir/criterion" "$result_path" profile_pkdtree_batch >&2
+            )
+            rm -rf -- "$tmp_dir"
+            printf '%s\n' "$result_path"
+            return 0
+        fi
+
+        rm -rf -- "$tmp_dir"
+        if (( status != 125 || attempt >= IRQ_RETRIES )); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying invalidated cell $role $scalar 2^$height q$query_count ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE" >&2
+    done
+}
+
+
+# --- single-query cells -----------------------------------------------------
+
+# Per-query latency is sequential, so this pins to the FIRST benchmark CPU
+# only. Using the whole set would not make a sequential query faster and would
+# expose the measurement to seven more cores' worth of interference.
+readonly SINGLE_CPU=${bench_cpus[0]}
+if (( STRICT_ISOLATION == 1 )); then
+    single_pin_command=(taskset --cpu-list "$SINGLE_CPU")
+else
+    single_pin_command=(env)
+fi
+readonly single_pin_command
+
+run_single_cell() {
+    local scalar=$1 height=$2 role=$3
+    local warmup=${4:-$CRITERION_WARMUP}
+    local measurement=${5:-$CRITERION_MEASUREMENT}
+    local sample_size=${6:-$CRITERION_SAMPLE_SIZE}
+    local output_dir=${7:-$RUN_DIR}
+    local attempt=0 status result_key result_path tmp_dir irq_before irq_after
+
+    result_key="$SUITE_LABEL-$PHASE-single-$role-$scalar-2p$height"
+    result_path="$output_dir/bench_result-cpp-competitors-$result_key.json"
+
+    while true; do
+        tmp_dir="$(mktemp -d /dev/shm/kiddo-single.XXXXXX)"
+        cp -- "$benchmark_exe" "$tmp_dir/benchmark"
+        chmod 0755 "$tmp_dir/benchmark"
+
+        irq_before=$(interrupt_total)
+        set +e
+        "${single_pin_command[@]}" env \
+            CRITERION_HOME="$tmp_dir/criterion" \
+            RAYON_NUM_THREADS=1 \
+            PARLAY_NUM_THREADS=1 \
+            KIDDO_CPP_SUITES=cpp_competitors \
+            KIDDO_CPP_LIBRARIES="$SINGLE_LIBRARIES" \
+            KIDDO_CPP_SCALARS="$scalar" \
+            KIDDO_PROFILE_QUERIES="$SINGLE_QUERY_COUNT" \
+            KIDDO_PROFILE_MIN_LOG2_POINTS="$height" \
+            KIDDO_PROFILE_MAX_LOG2_POINTS="$height" \
+            KIDDO_PROFILE_RADIUS="$SINGLE_RADIUS" \
+            "$tmp_dir/benchmark" \
+            profile_cpp_competitors \
+            --warm-up-time "$warmup" \
+            --measurement-time "$measurement" \
+            --sample-size "$sample_size" \
+            --noplot --bench 2>&1 | tee -a "$LOG_FILE" >&2
+        status=${PIPESTATUS[0]}
+        set -e
+        irq_after=$(interrupt_total)
+
+        if (( status == 0 && irq_after > irq_before )); then
+            echo "Single cell $role $scalar 2^$height saw $((irq_after - irq_before)) hardware IRQs" |
+                tee -a "$LOG_FILE" >&2
+            (( STRICT_ISOLATION == 1 )) && status=125
+        fi
+
+        if (( status == 0 )); then
+            (
+                cd -- "$REPO_DIR"
+                cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+                    "$tmp_dir/criterion" "$result_path" profile_cpp_competitors >&2
+            )
+            rm -rf -- "$tmp_dir"
+            printf '%s\n' "$result_path"
+            return 0
+        fi
+
+        rm -rf -- "$tmp_dir"
+        if (( status != 125 || attempt >= IRQ_RETRIES )); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying invalidated single cell $role $scalar 2^$height ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE" >&2
+    done
+}
+
+# --- preflight --------------------------------------------------------------
+
+# Exercise the executable, pinning, IRQ accounting, exporter and chart parser
+# on a tiny cell before committing to the matrix.
+readonly PREFLIGHT_DIR="$(mktemp -d /dev/shm/kiddo-batch-preflight.XXXXXX)"
+cleanup_preflight() { rm -rf -- "$PREFLIGHT_DIR"; }
+trap cleanup_preflight EXIT INT TERM
+
+if [[ "$PHASE" != single ]]; then
+    log "Preflight ($PHASE): f64 2^16, 256 queries"
+    preflight_result=$(run_cell f64 16 256 preflight 0.5 1 10 "$PREFLIGHT_DIR")
+    (( $(jq '.results | length' "$preflight_result") > 0 )) || {
+        echo "$PHASE preflight produced no results" >&2
+        exit 1
+    }
+    python3 "$SCRIPT_DIR/chart_pkdtree_batch_results.py" all \
+        --result "$preflight_result" --result-label "$SUITE_LABEL-preflight" \
+        --output-dir "$PREFLIGHT_DIR/charts" --html-name preflight.html
+fi
+if [[ "$PHASE" == single ]]; then
+    log "Preflight (single): f64 2^16"
+    preflight_single=$(run_single_cell f64 16 preflight 0.5 1 10 "$PREFLIGHT_DIR")
+    (( $(jq '.results | length' "$preflight_single") > 0 )) || {
+        echo "Single preflight produced no results" >&2
+        exit 1
+    }
+fi
+cleanup_preflight
+trap - EXIT INT TERM
+
+# --- matrix -----------------------------------------------------------------
+
+planned=0
+if [[ "$PHASE" != single ]]; then
+    for scalar in "${scalars[@]}"; do
+        if [[ "$scalar" == f64 ]]; then
+            planned=$((planned + ${#f64_heights[@]} * ${#query_counts[@]}))
+        else
+            planned=$((planned + ${#f32_heights[@]} * ${#query_counts[@]}))
+        fi
+    done
+fi
+if [[ "$PHASE" == single ]]; then
+    for scalar in "${scalars[@]}"; do
+        if [[ "$scalar" == f64 ]]; then
+            planned=$((planned + ${#single_f64_heights[@]}))
+        else
+            planned=$((planned + ${#single_f32_heights[@]}))
+        fi
+    done
+fi
+log "Phase: $PHASE (boot profile: ${BOOT_PROFILE:-none}, gate: $EXPECT_VERB)"
+log "Planned cells: $planned"
+log "Per-cell budget: ${CRITERION_WARMUP}s warmup + ${CRITERION_MEASUREMENT}s measurement, ${CRITERION_SAMPLE_SIZE} samples"
+
+batch_results=()
+single_results=()
+completed=0
+
+if [[ "$PHASE" == single ]]; then
+    log "=== single-query phase: $SINGLE_LIBRARIES on cpu $SINGLE_CPU ==="
+    for scalar in "${scalars[@]}"; do
+        if [[ "$scalar" == f64 ]]; then
+            heights=("${single_f64_heights[@]}")
+        else
+            heights=("${single_f32_heights[@]}")
+        fi
+        for height in "${heights[@]}"; do
+            completed=$((completed + 1))
+            log "[$completed/$planned] single $scalar 2^$height"
+            single_results+=("$(run_single_cell "$scalar" "$height" matrix)")
+        done
+    done
+fi
+
+if [[ "$PHASE" != single ]]; then
+    log "=== $PHASE phase: $BATCH_LIBRARIES on cpus $BENCH_CPUS ($WORKER_COUNT workers) ==="
+    for scalar in "${scalars[@]}"; do
+        if [[ "$scalar" == f64 ]]; then
+            heights=("${f64_heights[@]}")
+        else
+            heights=("${f32_heights[@]}")
+        fi
+        for height in "${heights[@]}"; do
+            for query_count in "${query_counts[@]}"; do
+                completed=$((completed + 1))
+                log "[$completed/$planned] $PHASE $scalar 2^$height, $query_count queries"
+                batch_results+=("$(run_cell "$scalar" "$height" "$query_count" matrix)")
+            done
+        done
+    done
+fi
+
+validate_environment "$RUN_DIR/environment-after.txt"
+
+# --- charts -----------------------------------------------------------------
+
+if (( ${#batch_results[@]} > 0 )); then
+    chart_args=()
+    for result in "${batch_results[@]}"; do
+        chart_args+=(--result "$result")
+    done
+    python3 "$SCRIPT_DIR/chart_pkdtree_batch_results.py" all \
+        "${chart_args[@]}" \
+        --result-label "$SUITE_LABEL" \
+        --output-dir "$CHART_DIR" \
+        --html-name "$SUITE_LABEL-batch.html"
+    log "Batch charts: $CHART_DIR/$SUITE_LABEL-batch.html"
+fi
+
+# chart_cpp_competitor_results.py also needs kiddo's own single-query exports,
+# which come from the focused v6 suites rather than from here, so the
+# single-query phase stops at the result files and is charted separately.
+if (( ${#single_results[@]} > 0 )); then
+    log "Single-query results (chart with chart_cpp_competitor_results.py, adding the kiddo exports):"
+    for result in "${single_results[@]}"; do
+        log "  $result"
+    done
+fi
+
+log "Suite complete: $((${#batch_results[@]} + ${#single_results[@]})) result files in $RUN_DIR"

--- a/src/dist/squared_euclidean/mod.rs
+++ b/src/dist/squared_euclidean/mod.rs
@@ -39,48 +39,6 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::SquaredEuclidean;
-    use crate::dist::DistanceMetricScalar;
-
-    #[test]
-    fn signed_dist1_squares_direct_delta_in_both_directions() {
-        type Metric = SquaredEuclidean<f64>;
-
-        assert_eq!(<Metric as DistanceMetricScalar<f64>>::dist1(5.0, 2.0), 9.0);
-        assert_eq!(<Metric as DistanceMetricScalar<f64>>::dist1(2.0, 5.0), 9.0);
-    }
-
-    #[test]
-    fn unsigned_dist1_uses_ordered_subtraction() {
-        type Metric = SquaredEuclidean<u16>;
-
-        assert_eq!(<Metric as DistanceMetricScalar<u16>>::dist1(5, 2), 9);
-        assert_eq!(<Metric as DistanceMetricScalar<u16>>::dist1(2, 5), 9);
-    }
-
-    #[cfg(feature = "fixed")]
-    #[test]
-    fn signed_fixed_dist1_squares_direct_delta() {
-        use fixed::{types::extra::U16, FixedI32};
-
-        type Output = FixedI32<U16>;
-        type Metric = SquaredEuclidean<Output>;
-        let a = Output::from_num(-1.5);
-        let b = Output::from_num(0.5);
-
-        assert_eq!(
-            <Metric as DistanceMetricScalar<Output>>::dist1(a, b),
-            Output::from_num(4)
-        );
-        assert_eq!(
-            <Metric as DistanceMetricScalar<Output>>::dist1(b, a),
-            Output::from_num(4)
-        );
-    }
-}
-
 impl<A, R> DistanceMetricAvx512<A> for SquaredEuclidean<R>
 where
     A: Copy,
@@ -132,5 +90,47 @@ pub mod cargo_asm {
     #[unsafe(no_mangle)]
     pub fn v6_squared_euclidean_dist1_u16_cargo_asm_hook(a: u16, b: u16) -> u16 {
         <SquaredEuclidean<u16> as DistanceMetricScalar<u16>>::dist1(a, b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SquaredEuclidean;
+    use crate::dist::DistanceMetricScalar;
+
+    #[test]
+    fn signed_dist1_squares_direct_delta_in_both_directions() {
+        type Metric = SquaredEuclidean<f64>;
+
+        assert_eq!(<Metric as DistanceMetricScalar<f64>>::dist1(5.0, 2.0), 9.0);
+        assert_eq!(<Metric as DistanceMetricScalar<f64>>::dist1(2.0, 5.0), 9.0);
+    }
+
+    #[test]
+    fn unsigned_dist1_uses_ordered_subtraction() {
+        type Metric = SquaredEuclidean<u16>;
+
+        assert_eq!(<Metric as DistanceMetricScalar<u16>>::dist1(5, 2), 9);
+        assert_eq!(<Metric as DistanceMetricScalar<u16>>::dist1(2, 5), 9);
+    }
+
+    #[cfg(feature = "fixed")]
+    #[test]
+    fn signed_fixed_dist1_squares_direct_delta() {
+        use fixed::{types::extra::U16, FixedI32};
+
+        type Output = FixedI32<U16>;
+        type Metric = SquaredEuclidean<Output>;
+        let a = Output::from_num(-1.5);
+        let b = Output::from_num(0.5);
+
+        assert_eq!(
+            <Metric as DistanceMetricScalar<Output>>::dist1(a, b),
+            Output::from_num(4)
+        );
+        assert_eq!(
+            <Metric as DistanceMetricScalar<Output>>::dist1(b, a),
+            Output::from_num(4)
+        );
     }
 }

--- a/src/kd_tree/query/batch.rs
+++ b/src/kd_tree/query/batch.rs
@@ -160,6 +160,11 @@ impl PartialEq for ExecutorKind {
             // the same only when they name the very same pool.
             #[cfg(feature = "multi-threaded")]
             (Self::ParallelInPool(left), Self::ParallelInPool(right)) => Arc::ptr_eq(left, right),
+            // Without `multi-threaded`, ExecutorKind has only the Serial
+            // variant, so the arm above is already exhaustive and this
+            // wildcard would be unreachable -- hence it is cfg'd out rather
+            // than allowed.
+            #[cfg(feature = "multi-threaded")]
             _ => false,
         }
     }

--- a/src/kd_tree/query/batch.rs
+++ b/src/kd_tree/query/batch.rs
@@ -32,9 +32,57 @@
 use std::collections::BinaryHeap;
 use std::num::NonZeroUsize;
 use std::ops::{Deref, Index};
+#[cfg(feature = "multi-threaded")]
+use std::sync::Arc;
 
 #[cfg(feature = "multi-threaded")]
 use rayon::prelude::*;
+
+/// Re-exported so that callers of
+/// [`Executor::parallel_in_pool`] can name and build a pool without taking
+/// their own `rayon` dependency, which would have to be version-matched
+/// against the one Kiddo links.
+#[cfg(feature = "multi-threaded")]
+pub use rayon::{ThreadPool, ThreadPoolBuilder};
+
+/// Static chunks per pool thread used by
+/// [`Executor::with_default_static_chunking`].
+///
+/// Four is enough slack for the pool to even out uneven query costs, while
+/// still being far fewer tasks than adaptive splitting creates.
+#[cfg(feature = "multi-threaded")]
+pub const DEFAULT_STATIC_CHUNK_THREAD_MULTIPLIER: NonZeroUsize = NonZeroUsize::new(4).unwrap();
+
+/// Ceiling on the task-size floor imposed by
+/// [`Executor::with_static_chunk_thread_multiplier`].
+///
+/// A thread-proportional chunk count is constant in the batch size, so on a
+/// large batch each chunk is large, and load imbalance between chunks costs
+/// more than the dispatch coordination it saves. Measured on a 32-thread pool
+/// against a 2^24..2^27 `f64` sweep at 100,000 queries — where the uncapped
+/// floor works out at 781 — static chunking was 10-15% *slower* than letting
+/// rayon split adaptively, while at 1,000-4,000 queries it was 23-47% faster.
+/// Capping the floor keeps the small-batch win and lets large batches fall
+/// back to adaptive splitting, which is what work stealing needs.
+#[cfg(feature = "multi-threaded")]
+pub const MAX_STATIC_CHUNK_QUERIES: usize = 128;
+
+/// Batch size below which [`Executor::with_serial_fallback`] runs on the
+/// calling thread.
+///
+/// Parallel dispatch costs a fixed amount per batch, which a small enough
+/// batch never recovers. Measured on a 2^21-point 3D `f32` tree with
+/// [`with_default_static_chunking`](Executor::with_default_static_chunking)
+/// also enabled, `nearest_one` broke even at roughly 110 query points: at 96
+/// points serial reached 8.66 Melem/s against parallel's 7.99, and at 128 that
+/// had reversed to 8.77 against 9.69.
+///
+/// A query count is a crude proxy for the work in a batch, and this default is
+/// taken from the cheapest query there is. Costlier queries — a large `k`, or
+/// a high-dimensional tree — earn back the dispatch at far smaller batches, so
+/// prefer a lower threshold for those, or leave the fallback off entirely.
+#[cfg(feature = "multi-threaded")]
+pub const DEFAULT_SERIAL_FALLBACK_THRESHOLD: usize = 128;
 
 use super::builder::{
     ApproxQueryBuilder, BestNWithinQueryBuilder, ExclusiveBoundariesQueryBuilder,
@@ -55,40 +103,88 @@ use crate::results::query_result_item::QueryResultItem;
 /// between releases.
 ///
 /// Multi-threaded execution requires the `multi-threaded` crate feature, which
-/// is enabled by default. Without it `parallel` and
-/// `with_min_queries_per_task` are not compiled, and [`new`](Self::new) is
-/// equivalent to [`serial`](Self::serial).
+/// is enabled by default. Without it the parallel constructors and hints are
+/// not compiled, and [`new`](Self::new) is equivalent to
+/// [`serial`](Self::serial).
 ///
-/// To run a batch on a specific Rayon thread pool, use Rayon's own scoping:
+/// # Small batches
 ///
-/// ```ignore
-/// pool.install(|| tree.query_batch(&queries).nearest_one::<D>().execute());
-/// ```
+/// Splitting a batch across threads costs a fixed amount per call, so a batch
+/// small enough is faster to run on the calling thread. Two opt-in hints
+/// address that, both no-ops for [`serial`](Self::serial):
+///
+/// * [`with_default_static_chunking`](Self::with_default_static_chunking)
+///   stops the batch being split into tasks smaller than a size derived from
+///   the pool, instead of subdividing it as far as the splitter likes.
+/// * [`with_serial_fallback`](Self::with_serial_fallback) runs batches below a
+///   threshold on the calling thread, skipping the dispatch entirely.
 ///
 /// # Example
 ///
 /// ```
 /// # #[cfg(feature = "multi-threaded")] {
 /// use kiddo::batch::Executor;
-/// use std::num::NonZeroUsize;
 ///
 /// let executor = Executor::parallel()
-///     .with_min_queries_per_task(NonZeroUsize::new(256).unwrap());
+///     .with_default_static_chunking()
+///     .with_serial_fallback();
 /// # }
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct Executor {
     kind: ExecutorKind,
     #[cfg(feature = "multi-threaded")]
-    min_queries_per_task: Option<NonZeroUsize>,
+    static_chunk_thread_multiplier: Option<NonZeroUsize>,
+    #[cfg(feature = "multi-threaded")]
+    serial_fallback_threshold: Option<usize>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 enum ExecutorKind {
     Serial,
     #[cfg(feature = "multi-threaded")]
     Parallel,
+    /// Parallel, but confined to a pool the caller owns and configures.
+    #[cfg(feature = "multi-threaded")]
+    ParallelInPool(Arc<ThreadPool>),
 }
+
+impl PartialEq for ExecutorKind {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Serial, Self::Serial) => true,
+            #[cfg(feature = "multi-threaded")]
+            (Self::Parallel, Self::Parallel) => true,
+            // Thread pools have no equality of their own, so two executors are
+            // the same only when they name the very same pool.
+            #[cfg(feature = "multi-threaded")]
+            (Self::ParallelInPool(left), Self::ParallelInPool(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ExecutorKind {}
+
+impl PartialEq for Executor {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        #[cfg(feature = "multi-threaded")]
+        {
+            self.kind == other.kind
+                && self.static_chunk_thread_multiplier == other.static_chunk_thread_multiplier
+                && self.serial_fallback_threshold == other.serial_fallback_threshold
+        }
+
+        #[cfg(not(feature = "multi-threaded"))]
+        {
+            self.kind == other.kind
+        }
+    }
+}
+
+impl Eq for Executor {}
 
 impl Default for Executor {
     #[inline]
@@ -124,11 +220,14 @@ impl Executor {
         Self {
             kind: ExecutorKind::Serial,
             #[cfg(feature = "multi-threaded")]
-            min_queries_per_task: None,
+            static_chunk_thread_multiplier: None,
+            #[cfg(feature = "multi-threaded")]
+            serial_fallback_threshold: None,
         }
     }
 
-    /// Creates an executor that may spread queries across multiple threads.
+    /// Creates an executor that may spread queries across multiple threads,
+    /// using Rayon's global pool.
     ///
     /// Requires the `multi-threaded` feature.
     #[cfg(feature = "multi-threaded")]
@@ -136,34 +235,176 @@ impl Executor {
     pub fn parallel() -> Self {
         Self {
             kind: ExecutorKind::Parallel,
-            min_queries_per_task: None,
+            static_chunk_thread_multiplier: None,
+            serial_fallback_threshold: None,
         }
     }
 
-    /// Hints at the smallest number of query points worth handing to one task.
+    /// Creates an executor that runs every batch on `pool` rather than Rayon's
+    /// global pool.
     ///
-    /// This is advisory. It exists so that callers with unusually cheap or
-    /// unusually expensive queries can nudge the scheduler, and it may be
-    /// ignored entirely.
+    /// Use this to bound how many cores batch queries may take, to keep them
+    /// off a pool shared with latency-sensitive work, or to reuse one
+    /// configured pool across many batches. The pool is shared, not consumed,
+    /// so one pool can back any number of executors.
+    ///
+    /// Requires the `multi-threaded` feature.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "multi-threaded")] {
+    /// use kiddo::batch::{Executor, ThreadPoolBuilder};
+    /// use std::sync::Arc;
+    ///
+    /// let pool = Arc::new(ThreadPoolBuilder::new().num_threads(4).build().unwrap());
+    /// let executor = Executor::parallel_in_pool(Arc::clone(&pool));
+    /// # }
+    /// ```
+    #[cfg(feature = "multi-threaded")]
+    #[inline]
+    pub fn parallel_in_pool(pool: Arc<ThreadPool>) -> Self {
+        Self {
+            kind: ExecutorKind::ParallelInPool(pool),
+            static_chunk_thread_multiplier: None,
+            serial_fallback_threshold: None,
+        }
+    }
+
+    /// Stops the batch being split below `queries / (threads * multiplier)`,
+    /// rather than letting the work-stealing splitter subdivide it as far as
+    /// it likes.
+    ///
+    /// Adaptive splitting reacts to load imbalance, but pays coordination cost
+    /// per split. Bounding the split trades some of that reactivity for a
+    /// cheaper dispatch, which is what dominates on small batches. The bound
+    /// is derived from the pool size rather than given as an absolute, so it
+    /// always leaves at least `threads * multiplier` tasks and cannot starve
+    /// the pool, and is capped at [`MAX_STATIC_CHUNK_QUERIES`] so that it
+    /// stops applying to batches large enough to need work stealing instead.
+    ///
+    /// This helps small batches and does nothing for large ones. It is not a
+    /// general throughput knob.
+    ///
+    /// This is advisory, and a no-op for [`serial`](Self::serial).
     ///
     /// Requires the `multi-threaded` feature.
     #[cfg(feature = "multi-threaded")]
     #[inline]
-    pub fn with_min_queries_per_task(mut self, min_queries_per_task: NonZeroUsize) -> Self {
-        self.min_queries_per_task = Some(min_queries_per_task);
+    pub fn with_static_chunk_thread_multiplier(mut self, multiplier: NonZeroUsize) -> Self {
+        self.static_chunk_thread_multiplier = Some(multiplier);
         self
     }
 
+    /// Enables static chunking at
+    /// [`DEFAULT_STATIC_CHUNK_THREAD_MULTIPLIER`] chunks per thread.
+    ///
+    /// Requires the `multi-threaded` feature.
     #[cfg(feature = "multi-threaded")]
     #[inline]
-    fn is_parallel(&self) -> bool {
-        matches!(self.kind, ExecutorKind::Parallel)
+    pub fn with_default_static_chunking(self) -> Self {
+        self.with_static_chunk_thread_multiplier(DEFAULT_STATIC_CHUNK_THREAD_MULTIPLIER)
     }
 
+    /// Runs batches of fewer than `threshold` query points on the calling
+    /// thread, skipping parallel dispatch.
+    ///
+    /// # Choosing a threshold
+    ///
+    /// Parallel dispatch costs roughly a fixed amount per batch, so the
+    /// break-even point is where the batch's *total* work first exceeds it:
+    /// `threshold ≈ dispatch_cost / per_query_cost`. Dispatch cost is a
+    /// property of the machine and pool; per-query cost is a property of the
+    /// query, and is what varies. It rises with:
+    ///
+    /// * **`k`** — the dominant factor. A `nearest_n(50)` point costs several
+    ///   times a `nearest_one` point, so it breaks even at a proportionately
+    ///   smaller batch.
+    /// * **Tree size**, but only weakly: descent is logarithmic, and past the
+    ///   point where the tree stops fitting in cache the per-query cost is
+    ///   dominated by misses rather than by comparisons.
+    /// * **Dimensionality**, through both wider distance computations and less
+    ///   effective pruning.
+    /// * **Radius**, for the `within` family, since the cost scales with the
+    ///   number of matches rather than with the depth of the descent.
+    ///
+    /// The practical recipe is to time one batch each way at a size near the
+    /// suspected threshold, rather than to derive it. Failing that, scale
+    /// [`DEFAULT_SERIAL_FALLBACK_THRESHOLD`] down by the ratio of your query's
+    /// cost to a `nearest_one`: for `nearest_n`, dividing by `k` is a
+    /// serviceable first guess. Erring low is the safer direction — the
+    /// penalty for parallelising slightly too small a batch is a few
+    /// microseconds, while the penalty for serialising a large one is the
+    /// whole speedup.
+    ///
+    /// This is advisory, and a no-op for [`serial`](Self::serial).
+    ///
+    /// Requires the `multi-threaded` feature.
     #[cfg(feature = "multi-threaded")]
     #[inline]
-    fn min_len(&self) -> usize {
-        self.min_queries_per_task.map_or(1, NonZeroUsize::get)
+    pub fn with_serial_fallback_threshold(mut self, threshold: usize) -> Self {
+        self.serial_fallback_threshold = Some(threshold);
+        self
+    }
+
+    /// Enables the serial fallback at [`DEFAULT_SERIAL_FALLBACK_THRESHOLD`]
+    /// query points.
+    ///
+    /// Requires the `multi-threaded` feature.
+    #[cfg(feature = "multi-threaded")]
+    #[inline]
+    pub fn with_serial_fallback(self) -> Self {
+        self.with_serial_fallback_threshold(DEFAULT_SERIAL_FALLBACK_THRESHOLD)
+    }
+
+    /// Whether a batch of `query_count` points should run in parallel, which
+    /// requires a parallel executor and a batch above any serial-fallback
+    /// threshold.
+    #[cfg(feature = "multi-threaded")]
+    #[inline]
+    fn is_parallel(&self, query_count: usize) -> bool {
+        if matches!(self.kind, ExecutorKind::Serial) {
+            return false;
+        }
+        self.serial_fallback_threshold
+            .is_none_or(|threshold| query_count >= threshold)
+    }
+
+    /// The pool to run on, or `None` for Rayon's global pool.
+    #[cfg(feature = "multi-threaded")]
+    #[inline]
+    fn pool(&self) -> Option<&ThreadPool> {
+        match &self.kind {
+            ExecutorKind::ParallelInPool(pool) => Some(pool),
+            _ => None,
+        }
+    }
+
+    /// Smallest number of queries a task may be split down to.
+    ///
+    /// Returns 1 — rayon's own default, i.e. split as finely as the scheduler
+    /// likes — unless static chunking asked for a coarser floor. Because the
+    /// floor is derived from the pool size, it always leaves at least
+    /// `threads * multiplier` tasks available, so it can never starve the pool
+    /// the way a caller-supplied absolute minimum could.
+    ///
+    /// The floor is additionally capped at [`MAX_STATIC_CHUNK_QUERIES`], so it
+    /// stops binding on large batches. A fixed number of chunks means each one
+    /// grows with the batch, and past a point the imbalance between chunks
+    /// costs more than the dispatch it saves.
+    #[cfg(feature = "multi-threaded")]
+    #[inline]
+    fn static_chunk_len(&self, query_count: usize) -> usize {
+        let Some(multiplier) = self.static_chunk_thread_multiplier else {
+            return 1;
+        };
+        let threads = self
+            .pool()
+            .map_or_else(rayon::current_num_threads, ThreadPool::current_num_threads);
+        let chunks = threads.max(1).saturating_mul(multiplier.get());
+        query_count
+            .div_ceil(chunks)
+            .clamp(1, MAX_STATIC_CHUNK_QUERIES)
     }
 }
 
@@ -716,13 +957,21 @@ where
         };
 
         #[cfg(feature = "multi-threaded")]
-        if self.executor.is_parallel() {
-            let results = self
-                .queries
-                .par_iter()
-                .with_min_len(self.executor.min_len())
-                .map(run)
-                .collect::<Vec<_>>();
+        if self.executor.is_parallel(self.queries.len()) {
+            // Bounding the split length rather than pre-splitting keeps the
+            // iterator indexed, so rayon writes results straight into the
+            // output instead of collecting through per-task lists.
+            let collect = || {
+                self.queries
+                    .par_iter()
+                    .with_min_len(self.executor.static_chunk_len(self.queries.len()))
+                    .map(run)
+                    .collect::<Vec<_>>()
+            };
+            let results = match self.executor.pool() {
+                Some(pool) => pool.install(collect),
+                None => collect(),
+            };
 
             return <Qb::Output as BatchCollect>::collect_batch(results);
         }
@@ -785,12 +1034,18 @@ where
         };
 
         #[cfg(feature = "multi-threaded")]
-        if self.executor.is_parallel() {
-            self.queries
-                .par_iter()
-                .enumerate()
-                .with_min_len(self.executor.min_len())
-                .for_each(run);
+        if self.executor.is_parallel(self.queries.len()) {
+            let visit = || {
+                self.queries
+                    .par_iter()
+                    .enumerate()
+                    .with_min_len(self.executor.static_chunk_len(self.queries.len()))
+                    .for_each(run)
+            };
+            match self.executor.pool() {
+                Some(pool) => pool.install(visit),
+                None => visit(),
+            }
 
             return;
         }
@@ -832,7 +1087,31 @@ mod tests {
     fn executors() -> Vec<Executor> {
         #[cfg(feature = "multi-threaded")]
         {
-            vec![Executor::serial(), Executor::parallel(), Executor::new()]
+            // Every scheduling path must produce identical, correctly indexed
+            // results, including the ones that change how the batch is split.
+            vec![
+                Executor::serial(),
+                Executor::parallel(),
+                Executor::new(),
+                Executor::parallel().with_default_static_chunking(),
+                // A multiplier of one is the coarsest legal chunking, and a
+                // deliberately odd one exercises a ragged final chunk.
+                Executor::parallel()
+                    .with_static_chunk_thread_multiplier(NonZeroUsize::new(1).unwrap()),
+                Executor::parallel()
+                    .with_static_chunk_thread_multiplier(NonZeroUsize::new(7).unwrap()),
+                // Thresholds either side of the test batch sizes, so both the
+                // fallback and the parallel path are taken.
+                Executor::parallel().with_serial_fallback_threshold(usize::MAX),
+                Executor::parallel().with_serial_fallback_threshold(0),
+                Executor::parallel_in_pool(std::sync::Arc::new(
+                    rayon::ThreadPoolBuilder::new()
+                        .num_threads(3)
+                        .build()
+                        .unwrap(),
+                ))
+                .with_default_static_chunking(),
+            ]
         }
 
         #[cfg(not(feature = "multi-threaded"))]
@@ -1201,7 +1480,7 @@ mod tests {
 
     #[cfg(feature = "multi-threaded")]
     #[test]
-    fn min_queries_per_task_hint_does_not_change_results() {
+    fn scheduling_hints_do_not_change_results() {
         let (tree, queries) = tree_and_queries(1024, 200);
 
         let baseline = tree
@@ -1210,18 +1489,151 @@ mod tests {
             .with_executor(&Executor::serial())
             .execute();
 
-        for min in [1usize, 7, 64, 4096] {
-            let executor =
-                Executor::parallel().with_min_queries_per_task(NonZeroUsize::new(min).unwrap());
-
+        for executor in executors() {
             let hinted = tree
                 .query_batch(&queries)
                 .nearest_one::<SquaredEuclidean<f64>>()
                 .with_executor(&executor)
                 .execute();
 
-            assert_eq!(hinted.as_slice(), baseline.as_slice(), "min_len {min}");
+            assert_eq!(
+                hinted.as_slice(),
+                baseline.as_slice(),
+                "executor {executor:?}"
+            );
         }
+    }
+
+    /// A ragged final chunk is the case most likely to misindex results, so
+    /// walk batch sizes that do not divide evenly by the chunk count.
+    #[cfg(feature = "multi-threaded")]
+    #[test]
+    fn static_chunking_indexes_ragged_batches_correctly() {
+        for query_count in [1usize, 2, 3, 5, 17, 63, 64, 65, 257] {
+            let (tree, queries) = tree_and_queries(512, query_count);
+
+            let baseline = tree
+                .query_batch(&queries)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_executor(&Executor::serial())
+                .execute();
+
+            for multiplier in [1usize, 3, 4, 16] {
+                let executor = Executor::parallel()
+                    .with_static_chunk_thread_multiplier(NonZeroUsize::new(multiplier).unwrap());
+
+                let chunked = tree
+                    .query_batch(&queries)
+                    .nearest_one::<SquaredEuclidean<f64>>()
+                    .with_executor(&executor)
+                    .execute();
+
+                assert_eq!(
+                    chunked.as_slice(),
+                    baseline.as_slice(),
+                    "{query_count} queries, multiplier {multiplier}"
+                );
+            }
+        }
+    }
+
+    /// `for_each` reports indices itself rather than returning a positional
+    /// collection, so it needs its own ragged-batch check.
+    #[cfg(feature = "multi-threaded")]
+    #[test]
+    fn static_chunking_for_each_reports_correct_indices() {
+        use std::sync::Mutex;
+
+        for query_count in [1usize, 5, 17, 63, 65, 257] {
+            let (tree, queries) = tree_and_queries(512, query_count);
+
+            let expected: Vec<_> = queries
+                .iter()
+                .map(|query| {
+                    tree.query(query)
+                        .nearest_one::<SquaredEuclidean<f64>>()
+                        .execute()
+                })
+                .collect();
+
+            let seen = Mutex::new(vec![None; query_count]);
+            tree.query_batch(&queries)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_executor(&Executor::parallel().with_default_static_chunking())
+                .for_each(|index, result| {
+                    seen.lock().unwrap()[index] = Some(result);
+                });
+
+            let seen = seen.into_inner().unwrap();
+            for (index, (actual, expected)) in seen.iter().zip(expected.iter()).enumerate() {
+                assert_eq!(
+                    actual.as_ref(),
+                    Some(expected),
+                    "{query_count} queries, index {index}"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "multi-threaded")]
+    #[test]
+    fn serial_fallback_threshold_selects_the_calling_thread() {
+        let (tree, queries) = tree_and_queries(1024, 64);
+
+        // Above the threshold the batch goes parallel, below it stays here;
+        // either way the results must be identical.
+        for threshold in [0usize, 32, 64, 65, usize::MAX] {
+            let executor = Executor::parallel().with_serial_fallback_threshold(threshold);
+            assert_eq!(
+                executor.is_parallel(queries.len()),
+                queries.len() >= threshold
+            );
+
+            let results = tree
+                .query_batch(&queries)
+                .nearest_one::<SquaredEuclidean<f64>>()
+                .with_executor(&executor)
+                .execute();
+
+            assert_eq!(results.len(), queries.len());
+        }
+    }
+
+    #[cfg(feature = "multi-threaded")]
+    #[test]
+    fn caller_supplied_pool_bounds_the_thread_count() {
+        use std::collections::HashSet;
+        use std::sync::Mutex;
+
+        let (tree, queries) = tree_and_queries(4096, 512);
+        let pool = std::sync::Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(2)
+                .build()
+                .unwrap(),
+        );
+
+        let threads = Mutex::new(HashSet::new());
+        tree.query_batch(&queries)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .with_executor(&Executor::parallel_in_pool(std::sync::Arc::clone(&pool)))
+            .for_each(|_index, _result| {
+                threads
+                    .lock()
+                    .unwrap()
+                    .insert(rayon::current_thread_index());
+            });
+
+        // Assert on the indices rather than on how many are distinct: the
+        // calling thread is not a pool worker, so if it ran a chunk itself it
+        // would contribute a `None` and inflate a count-based check.
+        let threads = threads.into_inner().unwrap();
+        assert!(
+            threads
+                .iter()
+                .all(|index| index.is_none_or(|index| index < 2)),
+            "work escaped the caller-supplied 2-thread pool: {threads:?}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,10 @@
 //!   Disabling it drops that dependency and configures the threaded APIs out
 //!   rather than quietly downgrading them: `ParallelConstruction`,
 //!   `KdTreeBuilder::with_parallel_construction`,
-//!   the `*_parallel` constructors, `Executor::parallel` and
-//!   `Executor::with_min_queries_per_task` no longer exist, so code that used
-//!   them fails to compile instead of silently running on one thread. Whatever
+//!   the `*_parallel` constructors, `Executor::parallel`,
+//!   `Executor::parallel_in_pool` and the batch scheduling hints no longer
+//!   exist, so code that used them fails to compile instead of silently
+//!   running on one thread. Whatever
 //!   still compiles keeps working and produces identical trees and results.
 //!   Use it for WASM, embedded, or single-core targets, or wherever an extra
 //!   dependency is not worth it.
@@ -265,6 +266,11 @@ pub use kd_tree::{KdTreeBuilder, QueryScratch};
 pub mod batch {
     pub use crate::kd_tree::query::batch::{
         BatchGroups, BatchQueryBuilder, BatchResults, Executor, GroupIter,
+    };
+    #[cfg(feature = "multi-threaded")]
+    pub use crate::kd_tree::query::batch::{
+        ThreadPool, ThreadPoolBuilder, DEFAULT_SERIAL_FALLBACK_THRESHOLD,
+        DEFAULT_STATIC_CHUNK_THREAD_MULTIPLIER, MAX_STATIC_CHUNK_QUERIES,
     };
 }
 

--- a/src/stem_strategy/donnelly/cyclic_simd_descent.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_descent.rs
@@ -89,7 +89,7 @@ impl CyclicBlockCompare for f64 {
             let query_lanes = _mm512_permutexvar_pd(lane_indices, repeated);
             let pivots = _mm512_loadu_pd(stems.as_ptr().add(block_base_idx));
             let mask = _mm512_cmp_pd_mask(query_lanes, pivots, _CMP_GE_OQ);
-            return block3_child_from_mask(mask);
+            block3_child_from_mask(mask)
         }
 
         #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
@@ -118,7 +118,7 @@ impl CyclicBlockCompare for f32 {
             let query_lanes = _mm512_permutexvar_ps(lane_indices, repeated);
             let pivots = _mm512_loadu_ps(stems.as_ptr().add(block_base_idx));
             let mask = _mm512_cmp_ps_mask(query_lanes, pivots, _CMP_GE_OQ);
-            return block4_child_from_mask(mask);
+            block4_child_from_mask(mask)
         }
 
         #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]

--- a/src/stem_strategy/donnelly/simd_descent.rs
+++ b/src/stem_strategy/donnelly/simd_descent.rs
@@ -318,10 +318,12 @@ mod tests {
 
     #[test]
     fn canonical_variants_use_arithmetic_scalar_continuations() {
-        assert!(DonnellySimdDescent::<3>::SUPPORTS_ARITHMETIC_LEAF_RESOLUTION);
-        assert!(DonnellySimdDescent::<4>::SUPPORTS_ARITHMETIC_LEAF_RESOLUTION);
-        assert!(DonnellySimdDescent::<3>::USES_SIMD_BLOCK_DESCENT);
-        assert!(DonnellySimdDescent::<4>::USES_SIMD_BLOCK_DESCENT);
+        const {
+            assert!(DonnellySimdDescent::<3>::SUPPORTS_ARITHMETIC_LEAF_RESOLUTION);
+            assert!(DonnellySimdDescent::<4>::SUPPORTS_ARITHMETIC_LEAF_RESOLUTION);
+            assert!(DonnellySimdDescent::<3>::USES_SIMD_BLOCK_DESCENT);
+            assert!(DonnellySimdDescent::<4>::USES_SIMD_BLOCK_DESCENT);
+        }
     }
 
     #[test]

--- a/src/traits/axis.rs
+++ b/src/traits/axis.rs
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn float_axis_helpers_behave_as_expected() {
-        assert!(<f32 as Axis>::IS_SIGNED);
+        const { assert!(<f32 as Axis>::IS_SIGNED) };
         assert_eq!(<f32 as Axis>::zero(), 0.0);
         assert!(<f32 as Axis>::is_max_value(<f32 as Axis>::max_value()));
         assert_eq!(<f32 as Axis>::cmp(1.0, 2.0), std::cmp::Ordering::Less);
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn unsigned_axis_helpers_behave_as_expected() {
-        assert!(!<u8 as Axis>::IS_SIGNED);
+        const { assert!(!<u8 as Axis>::IS_SIGNED) };
         assert_eq!(<u8 as Axis>::zero(), 0);
         assert_eq!(<u8 as Axis>::min_value(), 0);
         assert_eq!(<u8 as Axis>::max_value(), u8::MAX);
@@ -419,8 +419,8 @@ mod tests {
     #[cfg(feature = "fixed")]
     #[test]
     fn fixed_axis_helpers_behave_as_expected() {
-        assert!(<fixed::FixedI32<fixed::types::extra::U16> as Axis>::IS_SIGNED);
-        assert!(!<fixed::FixedU16<fixed::types::extra::U8> as Axis>::IS_SIGNED);
+        const { assert!(<fixed::FixedI32<fixed::types::extra::U16> as Axis>::IS_SIGNED) };
+        const { assert!(!<fixed::FixedU16<fixed::types::extra::U8> as Axis>::IS_SIGNED) };
         let a = fixed::FixedI32::<fixed::types::extra::U16>::from_num(1.5);
         let b = fixed::FixedI32::<fixed::types::extra::U16>::from_num(0.25);
         assert_eq!(


### PR DESCRIPTION
## Summary

Three additions to `Executor` for batch queries, plus the measurements behind their defaults:

- **`Executor::parallel_in_pool(pool)`** — run a batch on a caller-supplied `rayon::ThreadPool` instead of the global one. Lets batch queries be bounded to a subset of cores, kept off a pool shared with latency-sensitive work, or reuse one configured pool across many batches.
- **`with_default_static_chunking()` / `with_static_chunk_thread_multiplier()`** — stop adaptive splitting subdividing a batch below a pool-derived floor (`queries / (threads * multiplier)`), capped at `MAX_STATIC_CHUNK_QUERIES` so large batches still fall back to work-stealing. Measured on a 2^24-2^27 point / 100k-query sweep: an *uncapped* floor was 10-15% **slower** than adaptive splitting (imbalance between large chunks cost more than it saved); capped, small batches (1k-4k queries) were 23-47% faster while large ones were unaffected.
- **`with_serial_fallback()` / `with_serial_fallback_threshold()`** — run batches below a threshold on the calling thread, skipping dispatch entirely. Default (128) is measured at `nearest_one`, kiddo's cheapest query; costlier queries (larger `k`, higher-dimensional trees) break even at smaller batches, so the doc comment says to lower the threshold for those rather than trust the default blindly.

**Dropped:** `with_min_queries_per_task`. Under work-stealing it could only ever act as a weak, order-independent hint — it couldn't express either of the two things that actually mattered: a hard floor derived from the pool, or skipping dispatch altogether. The two new hints replace it with mechanisms that do.

`examples/batch_overhead_probe.rs` isolates where small-batch throughput is lost — between the `nearest_one`/`nearest_n` allocation shape (flat `Vec` vs `Vec<Vec<_>>`) and the two scheduling hints.

`profile.bench` moves from `opt-level = 2` to `3`, matching `profile.release`: benchmarks measuring hand-written SIMD kernels aren't representative of the code under test if compiled a level below release.

A handful of unrelated `cargo clippy -D warnings` fixes are folded in (`needless_return`, and a couple of runtime `assert!`s promoted to `const { assert!(...) }` where the property is compile-time-known) — they were needed to keep this branch clippy-clean and are otherwise unrelated to batch mode.

## Why

This grew out of head-to-head throughput comparisons against a C++ competitor (Pkd-tree) at parallel batch mode — see the companion PR, which depends on the three APIs above (its "tuned" executor is `Executor::parallel().with_default_static_chunking().with_serial_fallback()`).

## Testing

- `cargo test --lib kd_tree::query::batch` — 21 tests pass, including the new pool/chunking/fallback behaviour
- `cargo test --doc batch` — 5 doctests pass, including the new `parallel_in_pool` example
- `cargo clippy --features=serde,test_utils --no-deps` — clean
- `cargo check --example batch_overhead_probe --features test_utils,multi-threaded` — clean
- All pre-commit hooks pass (fmt, clippy, cargo-sort, cargo-machete, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8SWimtznixdAkNWTyvE1j