### PR TITLE
New `DonnellyCyclicSimdFull` stem strategy / traversal / backtrack / prune

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,6 +312,12 @@ harness = false
 required-features = ["simd", "test_utils"]
 
 [[bench]]
+name = "profile_v6_cyclic_query_pool"
+path = "benches/profile_v6_cyclic_query_pool.rs"
+harness = false
+required-features = ["simd", "test_utils"]
+
+[[bench]]
 name = "profile_v6_query_pool_perf"
 path = "benches/profile_v6_query_pool_perf.rs"
 harness = false

--- a/benches/profile_v6_cyclic_query_pool.rs
+++ b/benches/profile_v6_cyclic_query_pool.rs
@@ -14,8 +14,8 @@ use criterion::{
 use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::FlatVec;
 use kiddo::{
-    DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, EytzingerFlexPf, SquaredEuclidean,
-    StemStrategy,
+    DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, DonnellyUnrolled, EytzingerFlexPf,
+    SquaredEuclidean, StemStrategy,
 };
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -27,8 +27,9 @@ const DEFAULT_POOL_SIZES: [usize; 7] = [256, 512, 1_000, 2_048, 4_096, 8_192, 16
 const POINT_SEED: u64 = 0x5eed_0000_0000_0401;
 const QUERY_SEED: u64 = 0x5eed_0000_0000_0402;
 const SPLITMIX_GAMMA: u64 = 0x9e37_79b9_7f4a_7c15;
-const SUPPORTED_STRATEGIES: [&str; 3] = [
+const SUPPORTED_STRATEGIES: [&str; 4] = [
     "eytzinger",
+    "donnelly_unrolled",
     "donnelly_cyclic_simd_descent",
     "donnelly_cyclic_simd_full",
 ];
@@ -71,7 +72,8 @@ fn read_pool_sizes() -> Vec<usize> {
 
 fn strategies() -> Vec<String> {
     let value = std::env::var("KIDDO_CYCLIC_STRATEGIES").unwrap_or_else(|_| {
-        "eytzinger,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full".to_owned()
+        "eytzinger,donnelly_unrolled,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full"
+            .to_owned()
     });
     let requested: Vec<String> = value
         .split(',')
@@ -261,6 +263,9 @@ fn bench_f64<const K: usize>(
             "eytzinger" => bench_f64_strategy::<EytzingerComparator, K>(
                 &mut group, strategy, &points, &queries, pool_sizes, query_seed,
             ),
+            "donnelly_unrolled" => bench_f64_strategy::<DonnellyUnrolled<3>, K>(
+                &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+            ),
             "donnelly_cyclic_simd_descent" => {
                 bench_f64_strategy::<DonnellyCyclicSimdDescent<3>, K>(
                     &mut group, strategy, &points, &queries, pool_sizes, query_seed,
@@ -297,6 +302,9 @@ fn bench_f32<const K: usize>(
     for strategy in enabled {
         match strategy.as_str() {
             "eytzinger" => bench_f32_strategy::<EytzingerComparator, K>(
+                &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+            ),
+            "donnelly_unrolled" => bench_f32_strategy::<DonnellyUnrolled<4>, K>(
                 &mut group, strategy, &points, &queries, pool_sizes, query_seed,
             ),
             "donnelly_cyclic_simd_descent" => {

--- a/benches/profile_v6_cyclic_query_pool.rs
+++ b/benches/profile_v6_cyclic_query_pool.rs
@@ -1,0 +1,370 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, coverage(off))]
+
+//! Exact-nearest-one query-pool benchmark for cyclic Donnelly strategies.
+//!
+//! This deliberately excludes the abandoned block-dimension strategies. It can
+//! instantiate the native and awkward phase combinations: f64/K3, f64/K4,
+//! f32/K4, and f32/K3.
+
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use kiddo::kd_tree::KdTree;
+use kiddo::leaf_strategy::FlatVec;
+use kiddo::{
+    DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, EytzingerFlexPf, SquaredEuclidean,
+    StemStrategy,
+};
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+const B: usize = 32;
+const DEFAULT_POINT_LOG2: usize = 23;
+const DEFAULT_POOL_SIZES: [usize; 7] = [256, 512, 1_000, 2_048, 4_096, 8_192, 16_384];
+const POINT_SEED: u64 = 0x5eed_0000_0000_0401;
+const QUERY_SEED: u64 = 0x5eed_0000_0000_0402;
+const SPLITMIX_GAMMA: u64 = 0x9e37_79b9_7f4a_7c15;
+const SUPPORTED_STRATEGIES: [&str; 3] = [
+    "eytzinger",
+    "donnelly_cyclic_simd_descent",
+    "donnelly_cyclic_simd_full",
+];
+
+type EytzingerComparator = EytzingerFlexPf<0, -1>;
+
+fn read_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn read_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn read_pool_sizes() -> Vec<usize> {
+    let Ok(value) = std::env::var("KIDDO_CYCLIC_POOL_SIZES") else {
+        return DEFAULT_POOL_SIZES.to_vec();
+    };
+    let mut sizes: Vec<usize> = value
+        .split(',')
+        .map(|entry| {
+            entry
+                .trim()
+                .parse()
+                .expect("KIDDO_CYCLIC_POOL_SIZES entries must be positive integers")
+        })
+        .collect();
+    assert!(!sizes.is_empty());
+    assert!(sizes.iter().all(|&size| size > 0));
+    sizes.sort_unstable();
+    sizes.dedup();
+    sizes
+}
+
+fn strategies() -> Vec<String> {
+    let value = std::env::var("KIDDO_CYCLIC_STRATEGIES").unwrap_or_else(|_| {
+        "eytzinger,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full".to_owned()
+    });
+    let requested: Vec<String> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_owned)
+        .collect();
+    assert!(!requested.is_empty(), "no cyclic strategies selected");
+    for strategy in &requested {
+        assert!(
+            SUPPORTED_STRATEGIES.contains(&strategy.as_str()),
+            "unsupported KIDDO_CYCLIC_STRATEGIES entry: {strategy}"
+        );
+    }
+    requested
+}
+
+#[inline(always)]
+fn splitmix64(counter: u64) -> u64 {
+    let mut value = counter.wrapping_add(SPLITMIX_GAMMA);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[inline(always)]
+fn query_word<const K: usize>(seed: u64, query_index: usize, dimension: usize) -> u64 {
+    let counter = (query_index * K + dimension) as u64;
+    splitmix64(seed.wrapping_add(counter.wrapping_mul(SPLITMIX_GAMMA)))
+}
+
+#[inline(always)]
+fn query_f64<const K: usize>(seed: u64, query_index: usize) -> [f64; K] {
+    const SCALE: f64 = 1.0 / ((1u64 << 53) as f64);
+    std::array::from_fn(|dimension| {
+        (query_word::<K>(seed, query_index, dimension) >> 11) as f64 * SCALE
+    })
+}
+
+#[inline(always)]
+fn query_f32<const K: usize>(seed: u64, query_index: usize) -> [f32; K] {
+    const SCALE: f32 = 1.0 / ((1u32 << 24) as f32);
+    std::array::from_fn(|dimension| {
+        (query_word::<K>(seed, query_index, dimension) >> 40) as f32 * SCALE
+    })
+}
+
+fn run_stored_f64<SS: StemStrategy, const K: usize>(
+    tree: &KdTree<f64, u32, SS, FlatVec<f64, u32, K, B>, K, B>,
+    queries: &[[f64; K]],
+) -> (f64, u64) {
+    let mut distance = 0.0;
+    let mut item = 0u64;
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        distance += result.distance;
+        item = item.wrapping_add(result.item as u64);
+    }
+    (distance, item)
+}
+
+fn run_stored_f32<SS: StemStrategy, const K: usize>(
+    tree: &KdTree<f32, u32, SS, FlatVec<f32, u32, K, B>, K, B>,
+    queries: &[[f32; K]],
+) -> (f32, u64) {
+    let mut distance = 0.0;
+    let mut item = 0u64;
+    for query in queries {
+        let result = tree
+            .query(black_box(query))
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        distance += result.distance;
+        item = item.wrapping_add(result.item as u64);
+    }
+    (distance, item)
+}
+
+fn run_generated_f64<SS: StemStrategy, const K: usize>(
+    tree: &KdTree<f64, u32, SS, FlatVec<f64, u32, K, B>, K, B>,
+    count: usize,
+    seed: u64,
+) -> (f64, u64) {
+    let mut distance = 0.0;
+    let mut item = 0u64;
+    for index in 0..count {
+        let query = query_f64::<K>(seed, index);
+        let result = tree
+            .query(black_box(&query))
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        distance += result.distance;
+        item = item.wrapping_add(result.item as u64);
+    }
+    (distance, item)
+}
+
+fn run_generated_f32<SS: StemStrategy, const K: usize>(
+    tree: &KdTree<f32, u32, SS, FlatVec<f32, u32, K, B>, K, B>,
+    count: usize,
+    seed: u64,
+) -> (f32, u64) {
+    let mut distance = 0.0;
+    let mut item = 0u64;
+    for index in 0..count {
+        let query = query_f32::<K>(seed, index);
+        let result = tree
+            .query(black_box(&query))
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        distance += result.distance;
+        item = item.wrapping_add(result.item as u64);
+    }
+    (distance, item)
+}
+
+fn bench_f64_strategy<SS: StemStrategy, const K: usize>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    points: &[[f64; K]],
+    queries: &[[f64; K]],
+    pool_sizes: &[usize],
+    seed: u64,
+) {
+    let tree: KdTree<f64, u32, SS, FlatVec<f64, u32, K, B>, K, B> =
+        KdTree::new_from_slice(points).unwrap();
+    for &pool_size in pool_sizes {
+        group.throughput(Throughput::Elements(pool_size as u64));
+        group.bench_function(
+            BenchmarkId::new(format!("stored_{label}"), pool_size),
+            |b| b.iter(|| black_box(run_stored_f64(&tree, &queries[..pool_size]))),
+        );
+        group.bench_function(
+            BenchmarkId::new(format!("generated_{label}"), pool_size),
+            |b| b.iter(|| black_box(run_generated_f64(&tree, pool_size, seed))),
+        );
+    }
+}
+
+fn bench_f32_strategy<SS: StemStrategy, const K: usize>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    points: &[[f32; K]],
+    queries: &[[f32; K]],
+    pool_sizes: &[usize],
+    seed: u64,
+) {
+    let tree: KdTree<f32, u32, SS, FlatVec<f32, u32, K, B>, K, B> =
+        KdTree::new_from_slice(points).unwrap();
+    for &pool_size in pool_sizes {
+        group.throughput(Throughput::Elements(pool_size as u64));
+        group.bench_function(
+            BenchmarkId::new(format!("stored_{label}"), pool_size),
+            |b| b.iter(|| black_box(run_stored_f32(&tree, &queries[..pool_size]))),
+        );
+        group.bench_function(
+            BenchmarkId::new(format!("generated_{label}"), pool_size),
+            |b| b.iter(|| black_box(run_generated_f32(&tree, pool_size, seed))),
+        );
+    }
+}
+
+fn bench_f64<const K: usize>(
+    c: &mut Criterion,
+    point_count: usize,
+    pool_sizes: &[usize],
+    enabled: &[String],
+    point_seed: u64,
+    query_seed: u64,
+) {
+    let mut rng = ChaCha8Rng::seed_from_u64(point_seed);
+    let points: Vec<[f64; K]> = (0..point_count)
+        .map(|_| std::array::from_fn(|_| rng.random::<f64>()))
+        .collect();
+    let queries: Vec<_> = (0..*pool_sizes.last().unwrap())
+        .map(|index| query_f64::<K>(query_seed, index))
+        .collect();
+    let mut group = c.benchmark_group(format!(
+        "profile_v6_cyclic_query_pool/f64_k{K}/{point_count}"
+    ));
+
+    for strategy in enabled {
+        match strategy.as_str() {
+            "eytzinger" => bench_f64_strategy::<EytzingerComparator, K>(
+                &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+            ),
+            "donnelly_cyclic_simd_descent" => {
+                bench_f64_strategy::<DonnellyCyclicSimdDescent<3>, K>(
+                    &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+                )
+            }
+            "donnelly_cyclic_simd_full" => bench_f64_strategy::<DonnellyCyclicSimdFull<3>, K>(
+                &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+            ),
+            _ => unreachable!(),
+        }
+    }
+    group.finish();
+}
+
+fn bench_f32<const K: usize>(
+    c: &mut Criterion,
+    point_count: usize,
+    pool_sizes: &[usize],
+    enabled: &[String],
+    point_seed: u64,
+    query_seed: u64,
+) {
+    let mut rng = ChaCha8Rng::seed_from_u64(point_seed);
+    let points: Vec<[f32; K]> = (0..point_count)
+        .map(|_| std::array::from_fn(|_| rng.random::<f32>()))
+        .collect();
+    let queries: Vec<_> = (0..*pool_sizes.last().unwrap())
+        .map(|index| query_f32::<K>(query_seed, index))
+        .collect();
+    let mut group = c.benchmark_group(format!(
+        "profile_v6_cyclic_query_pool/f32_k{K}/{point_count}"
+    ));
+
+    for strategy in enabled {
+        match strategy.as_str() {
+            "eytzinger" => bench_f32_strategy::<EytzingerComparator, K>(
+                &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+            ),
+            "donnelly_cyclic_simd_descent" => {
+                bench_f32_strategy::<DonnellyCyclicSimdDescent<4>, K>(
+                    &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+                )
+            }
+            "donnelly_cyclic_simd_full" => bench_f32_strategy::<DonnellyCyclicSimdFull<4>, K>(
+                &mut group, strategy, &points, &queries, pool_sizes, query_seed,
+            ),
+            _ => unreachable!(),
+        }
+    }
+    group.finish();
+}
+
+fn query_pool(c: &mut Criterion) {
+    let axis = std::env::var("KIDDO_CYCLIC_AXIS").unwrap_or_else(|_| "f64".to_owned());
+    let dimensions = read_usize("KIDDO_CYCLIC_DIMENSIONS", if axis == "f32" { 4 } else { 3 });
+    let point_log2 = read_usize("KIDDO_CYCLIC_POINT_LOG2", DEFAULT_POINT_LOG2);
+    assert!(point_log2 < usize::BITS as usize);
+    let point_count = 1usize << point_log2;
+    let pool_sizes = read_pool_sizes();
+    let enabled = strategies();
+    let point_seed = read_u64("KIDDO_PROFILE_POINT_SEED", POINT_SEED);
+    let query_seed = read_u64("KIDDO_PROFILE_QUERY_SEED", QUERY_SEED);
+
+    eprintln!(
+        "cyclic exact-NN: axis={axis} dimensions={dimensions} points=2^{point_log2} \
+         pools={pool_sizes:?} strategies={enabled:?}"
+    );
+
+    match (axis.as_str(), dimensions) {
+        ("f64", 3) => bench_f64::<3>(
+            c,
+            point_count,
+            &pool_sizes,
+            &enabled,
+            point_seed,
+            query_seed,
+        ),
+        ("f64", 4) => bench_f64::<4>(
+            c,
+            point_count,
+            &pool_sizes,
+            &enabled,
+            point_seed,
+            query_seed,
+        ),
+        ("f32", 3) => bench_f32::<3>(
+            c,
+            point_count,
+            &pool_sizes,
+            &enabled,
+            point_seed,
+            query_seed,
+        ),
+        ("f32", 4) => bench_f32::<4>(
+            c,
+            point_count,
+            &pool_sizes,
+            &enabled,
+            point_seed,
+            query_seed,
+        ),
+        _ => panic!("supported combinations are f64/f32 with 3 or 4 dimensions"),
+    }
+}
+
+criterion_group!(benches, query_pool);
+criterion_main!(benches);

--- a/benches/profile_v6_query_pool_perf.rs
+++ b/benches/profile_v6_query_pool_perf.rs
@@ -11,8 +11,9 @@ use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::FlatVec;
 use kiddo::stem_strategies::donnelly::DonnellySimdInitialDescent;
 use kiddo::{
-    Donnelly, DonnellyCyclicSimdDescent, DonnellySimdDescent, DonnellySimdFull, DonnellyUnrolled,
-    DonnellyUnrolledBlockDim, EytzingerFlexPf, SquaredEuclidean, StemStrategy,
+    Donnelly, DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, DonnellySimdDescent,
+    DonnellySimdFull, DonnellyUnrolled, DonnellyUnrolledBlockDim, EytzingerFlexPf,
+    SquaredEuclidean, StemStrategy,
 };
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -287,6 +288,12 @@ fn main() {
                     warmup_repeats,
                     repeats,
                 ),
+                "donnelly_cyclic_simd_full" => execute_f64::<DonnellyCyclicSimdFull<3>>(
+                    &points,
+                    &queries,
+                    warmup_repeats,
+                    repeats,
+                ),
                 "donnelly_simd_initial_descent" => execute_f64::<DonnellySimdInitialDescent<3>>(
                     &points,
                     &queries,
@@ -326,6 +333,12 @@ fn main() {
                     repeats,
                 ),
                 "donnelly_cyclic_simd_descent" => execute_f32::<DonnellyCyclicSimdDescent<4>>(
+                    &points,
+                    &queries,
+                    warmup_repeats,
+                    repeats,
+                ),
+                "donnelly_cyclic_simd_full" => execute_f32::<DonnellyCyclicSimdFull<4>>(
                     &points,
                     &queries,
                     warmup_repeats,

--- a/justfile
+++ b/justfile
@@ -1354,14 +1354,14 @@ perf-v6-donnelly-vs-eytzinger-query-pool POINT_LOG2='27' POOL_SIZE='2048' TOTAL_
     fi
     case "$axis" in f32|f64) ;; *) echo "AXIS must be f32 or f64" >&2; exit 2 ;; esac
     case "$strategy" in
-        eytzinger|donnelly|donnelly_unrolled|donnelly_unrolled_block_dim|donnelly_simd_descent|donnelly_cyclic_simd_descent|donnelly_simd_initial_descent|donnelly_simd_full) ;;
+        eytzinger|donnelly|donnelly_unrolled|donnelly_unrolled_block_dim|donnelly_simd_descent|donnelly_cyclic_simd_descent|donnelly_cyclic_simd_full|donnelly_simd_initial_descent|donnelly_simd_full) ;;
         *) echo "unsupported STRATEGY: $strategy" >&2; exit 2 ;;
     esac
     events="$(scripts/query_pool_perf_events.sh "$event_set")"
 
     benchmark_exe="$(
         RUSTC_WRAPPER= RUSTFLAGS='-C target-cpu=native' \
-            cargo bench --bench profile_v6_query_pool_perf \
+            cargo bench --offline --bench profile_v6_query_pool_perf \
             --features simd,test_utils,logging_off --no-run --message-format=json |
         jq -r 'select(.reason == "compiler-artifact" and .target.name == "profile_v6_query_pool_perf") | .executable // empty' |
         tail -n 1

--- a/scripts/chart_donnelly_variant_results.py
+++ b/scripts/chart_donnelly_variant_results.py
@@ -20,6 +20,7 @@ STRATEGIES = {
     "donnelly_unrolled_block_dim": "Donnelly unrolled/block-dim",
     "donnelly_simd_descent": "Donnelly SIMD descent",
     "donnelly_cyclic_simd_descent": "Donnelly cyclic SIMD descent",
+    "donnelly_cyclic_simd_full": "Donnelly cyclic SIMD-full control",
     "donnelly_simd_initial_descent": "Donnelly initial-only SIMD",
     "donnelly_simd_full": "Donnelly full SIMD",
 }
@@ -30,6 +31,7 @@ COLORS = {
     "donnelly_unrolled_block_dim": "#298f75",
     "donnelly_simd_descent": "#8a6d1d",
     "donnelly_cyclic_simd_descent": "#16a085",
+    "donnelly_cyclic_simd_full": "#c0392b",
     "donnelly_simd_initial_descent": "#7d5fff",
     "donnelly_simd_full": "#c0392b",
 }
@@ -173,7 +175,7 @@ def render(
         eytzinger = [table[("eytzinger", size)].query_ns for size in sizes]
         if mode == "generated":
             eytzinger = [
-                value - controls[(axis, point_count, size)]
+                value - controls.get((axis, point_count, size), 0.0)
                 for value, size in zip(eytzinger, sizes)
             ]
         for strategy in strategies:
@@ -182,7 +184,7 @@ def render(
             values = [table[(strategy, size)].query_ns for size in sizes]
             if mode == "generated":
                 values = [
-                    value - controls[(axis, point_count, size)]
+                    value - controls.get((axis, point_count, size), 0.0)
                     for value, size in zip(values, sizes)
                 ]
             speedups = [
@@ -207,7 +209,12 @@ def render(
         advantage.set_xticks(x, [f"{size:,}" for size in sizes])
         advantage.grid(True, color="#dfe3e8", linewidth=0.8)
 
-    dimensions = 3 if axis == "f64" else 4
+    if "_k" in axis:
+        scalar, dimension_text = axis.split("_k", 1)
+        dimensions = int(dimension_text)
+    else:
+        scalar = axis
+        dimensions = 3 if axis == "f64" else 4
     present = {point.strategy for point in selected}
     if (
         "donnelly_unrolled_block_dim" in present
@@ -221,7 +228,7 @@ def render(
     else:
         experiment = "strategy screen"
     figure.suptitle(
-        f"Exact nearest-one Donnelly variant screen — {dimensions}D {axis}, "
+        f"Exact nearest-one Donnelly variant screen — {dimensions}D {scalar}, "
         f"2^{point_log2} points — {experiment}"
     )
     figure.savefig(output, dpi=180)
@@ -233,7 +240,7 @@ def main() -> None:
     points, controls = load(args.result)
     args.output_dir.mkdir(parents=True, exist_ok=True)
     chart_names: list[str] = []
-    for axis in ("f64", "f32"):
+    for axis in sorted({point.axis for point in points}):
         for point_count in sorted(
             {point.point_count for point in points if point.axis == axis}
         ):

--- a/scripts/chart_donnelly_variant_results.py
+++ b/scripts/chart_donnelly_variant_results.py
@@ -215,6 +215,9 @@ def render(
     else:
         scalar = axis
         dimensions = 3 if axis == "f64" else 4
+    block_height = 3 if scalar == "f64" else 4
+    padding = (-(point_log2 - 5)) % block_height
+    height_role = "exact block height" if padding == 0 else f"+{padding} root padding"
     present = {point.strategy for point in selected}
     if (
         "donnelly_unrolled_block_dim" in present
@@ -229,8 +232,132 @@ def render(
         experiment = "strategy screen"
     figure.suptitle(
         f"Exact nearest-one Donnelly variant screen — {dimensions}D {scalar}, "
-        f"2^{point_log2} points — {experiment}"
+        f"2^{point_log2} points ({height_role}) — {experiment}"
     )
+    figure.savefig(output, dpi=180)
+    plt.close(figure)
+
+
+def render_height_sweep(
+    points: list[Point],
+    controls: dict[tuple[str, int, int], float],
+    axis: str,
+    pool_size: int,
+    output: Path,
+) -> None:
+    matplotlib_config = Path(tempfile.gettempdir()) / "kiddo-matplotlib"
+    matplotlib_config.mkdir(exist_ok=True)
+    os.environ.setdefault("MPLCONFIGDIR", str(matplotlib_config))
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter
+
+    selected = [
+        point
+        for point in points
+        if point.axis == axis and point.pool_size == pool_size
+    ]
+    point_counts = sorted({point.point_count for point in selected})
+    strategies = [
+        strategy
+        for strategy in STRATEGIES
+        if any(point.strategy == strategy for point in selected)
+    ]
+    figure, axes = plt.subplots(2, 2, figsize=(14, 10), sharex=True)
+    x = [round(math.log2(point_count)) for point_count in point_counts]
+
+    for row, mode in enumerate(("stored", "generated")):
+        timing = axes[row][0]
+        advantage = axes[row][1]
+        table = {
+            (point.strategy, point.point_count): point
+            for point in selected
+            if point.mode == mode
+        }
+        for strategy in strategies:
+            samples = [table[(strategy, point_count)] for point_count in point_counts]
+            timing.plot(
+                x,
+                [sample.query_ns for sample in samples],
+                label=STRATEGIES[strategy],
+                color=COLORS[strategy],
+                marker="o",
+                linewidth=2.0,
+            )
+            timing.fill_between(
+                x,
+                [sample.low_ns for sample in samples],
+                [sample.high_ns for sample in samples],
+                color=COLORS[strategy],
+                alpha=0.10,
+            )
+
+        timing.set_title(f"{mode.capitalize()} queries")
+        timing.set_ylabel("Criterion slope (ns/query)")
+        timing.grid(True, color="#dfe3e8", linewidth=0.8)
+        timing.legend(fontsize=8.5)
+
+        advantage.axhline(0.0, color="#555", linewidth=1.0)
+        eytzinger = [
+            table[("eytzinger", point_count)].query_ns
+            for point_count in point_counts
+        ]
+        if mode == "generated":
+            eytzinger = [
+                value - controls.get((axis, point_count, pool_size), 0.0)
+                for value, point_count in zip(eytzinger, point_counts)
+            ]
+        for strategy in strategies:
+            if strategy == "eytzinger":
+                continue
+            values = [
+                table[(strategy, point_count)].query_ns
+                for point_count in point_counts
+            ]
+            if mode == "generated":
+                values = [
+                    value - controls.get((axis, point_count, pool_size), 0.0)
+                    for value, point_count in zip(values, point_counts)
+                ]
+            advantage.plot(
+                x,
+                [
+                    (baseline / value - 1.0) * 100.0
+                    if baseline > 0.0 and value > 0.0
+                    else math.nan
+                    for baseline, value in zip(eytzinger, values)
+                ],
+                label=STRATEGIES[strategy],
+                color=COLORS[strategy],
+                marker="o",
+                linewidth=2.0,
+            )
+        advantage.set_ylabel("Advantage over Eytzinger")
+        advantage.yaxis.set_major_formatter(
+            FuncFormatter(lambda value, _: f"{value:+.0f}%")
+        )
+        advantage.grid(True, color="#dfe3e8", linewidth=0.8)
+
+    if "_k" in axis:
+        scalar, dimension_text = axis.split("_k", 1)
+        dimensions = int(dimension_text)
+    else:
+        scalar = axis
+        dimensions = 3 if axis == "f64" else 4
+    block_height = 3 if scalar == "f64" else 4
+    tick_labels = []
+    for height in x:
+        padding = (-(height - 5)) % block_height
+        role = "exact" if padding == 0 else f"+{padding} pad"
+        tick_labels.append(f"2^{height}\n{role}")
+    for row in axes:
+        for chart in row:
+            chart.set_xticks(x, tick_labels)
+            chart.set_xlabel("Tree points")
+    figure.suptitle(
+        f"Exact nearest-one height sweep — {dimensions}D {scalar}, "
+        f"{pool_size:,} distinct queries"
+    )
+    figure.tight_layout()
     figure.savefig(output, dpi=180)
     plt.close(figure)
 
@@ -241,9 +368,27 @@ def main() -> None:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     chart_names: list[str] = []
     for axis in sorted({point.axis for point in points}):
-        for point_count in sorted(
+        axis_point_counts = sorted(
             {point.point_count for point in points if point.axis == axis}
-        ):
+        )
+        common_pool_sizes = set.intersection(
+            *(
+                {
+                    point.pool_size
+                    for point in points
+                    if point.axis == axis and point.point_count == point_count
+                }
+                for point_count in axis_point_counts
+            )
+        )
+        for pool_size in sorted(common_pool_sizes):
+            name = f"donnelly-variant-height-sweep-{axis}-q{pool_size}.png"
+            render_height_sweep(
+                points, controls, axis, pool_size, args.output_dir / name
+            )
+            chart_names.append(name)
+
+        for point_count in axis_point_counts:
             point_log2 = round(math.log2(point_count))
             name = f"donnelly-variant-screen-{axis}-2p{point_log2}.png"
             render(points, controls, axis, point_count, args.output_dir / name)

--- a/scripts/chart_donnelly_variant_results.py
+++ b/scripts/chart_donnelly_variant_results.py
@@ -20,7 +20,7 @@ STRATEGIES = {
     "donnelly_unrolled_block_dim": "Donnelly unrolled/block-dim",
     "donnelly_simd_descent": "Donnelly SIMD descent",
     "donnelly_cyclic_simd_descent": "Donnelly cyclic SIMD descent",
-    "donnelly_cyclic_simd_full": "Donnelly cyclic SIMD-full control",
+    "donnelly_cyclic_simd_full": "Donnelly cyclic SIMD full",
     "donnelly_simd_initial_descent": "Donnelly initial-only SIMD",
     "donnelly_simd_full": "Donnelly full SIMD",
 }

--- a/scripts/run_donnelly_cyclic_full_height_matrix.sh
+++ b/scripts/run_donnelly_cyclic_full_height_matrix.sh
@@ -1,0 +1,460 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publication-oriented exact-nearest-one matrix for the final cyclic Donnelly
+# strategies. Every tree size is measured at the two query-pool sizes around
+# the previously observed cache crossover. Selected exact-height/worst-padding
+# pairs receive the complete query-pool sweep.
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+HEIGHTS=${HEIGHTS:-20,21,22,23,24,25,26,27,28,29}
+BASE_POOL_SIZES=${BASE_POOL_SIZES:-1000,4096}
+DENSE_POOL_SIZES=${DENSE_POOL_SIZES:-256,512,1000,2048,4096,8192,16384}
+F64_DENSE_HEIGHTS=${F64_DENSE_HEIGHTS:-26,27,29}
+F32_DENSE_HEIGHTS=${F32_DENSE_HEIGHTS:-25,26,29}
+CRITERION_WARMUP=${CRITERION_WARMUP:-3}
+CRITERION_MEASUREMENT=${CRITERION_MEASUREMENT:-8}
+CRITERION_SAMPLE_SIZE=${CRITERION_SAMPLE_SIZE:-30}
+STRATEGIES=${STRATEGIES:-eytzinger,donnelly_unrolled,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full}
+IRQ_RETRIES=${IRQ_RETRIES:-2}
+RUN_PERF=${RUN_PERF:-1}
+PERF_F64_HEIGHT=${PERF_F64_HEIGHT:-26}
+PERF_F32_HEIGHT=${PERF_F32_HEIGHT:-25}
+PERF_POOL_SIZE=${PERF_POOL_SIZE:-4096}
+PERF_TOTAL_QUERIES=${PERF_TOTAL_QUERIES:-4000000}
+PERF_WARMUP_REPEATS=${PERF_WARMUP_REPEATS:-2}
+PERF_EVENT_SETS=${PERF_EVENT_SETS:-core,cache,tlb}
+OUTPUT_BASE=${OUTPUT_BASE:-$REPO_DIR/focused-results}
+CHART_BASE=${CHART_BASE:-$REPO_DIR/focused-charts}
+SUITE_LABEL=${SUITE_LABEL:-donnelly-cyclic-full-height-matrix-$(date -u +%Y%m%dT%H%M%SZ)}
+
+readonly RUN_DIR="$OUTPUT_BASE/$SUITE_LABEL"
+readonly CHART_DIR="$CHART_BASE/$SUITE_LABEL"
+readonly RESULT_FILE="$RUN_DIR/bench_result-v6-donnelly-cyclic-full-$SUITE_LABEL.json"
+readonly HTML_FILE="$CHART_DIR/$SUITE_LABEL.html"
+readonly LOG_FILE="$RUN_DIR/run.log"
+
+for command_name in bench-profile-run bench-profile-status cargo git jq just mktemp perf python3 rustc; do
+    command -v "$command_name" >/dev/null || {
+        echo "Required command is unavailable: $command_name" >&2
+        exit 2
+    }
+done
+[[ "$SUITE_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]] || {
+    echo "SUITE_LABEL contains unsupported characters: $SUITE_LABEL" >&2
+    exit 2
+}
+[[ ! -e "$RUN_DIR" && ! -e "$CHART_DIR" ]] || {
+    echo "Refusing to overwrite existing suite $SUITE_LABEL" >&2
+    exit 2
+}
+case "$RUN_PERF" in
+    0|1) ;;
+    *) echo "RUN_PERF must be 0 or 1" >&2; exit 2 ;;
+esac
+
+IFS=',' read -r -a heights <<<"$HEIGHTS"
+IFS=',' read -r -a base_pools <<<"$BASE_POOL_SIZES"
+IFS=',' read -r -a dense_pools <<<"$DENSE_POOL_SIZES"
+IFS=',' read -r -a f64_dense_heights <<<"$F64_DENSE_HEIGHTS"
+IFS=',' read -r -a f32_dense_heights <<<"$F32_DENSE_HEIGHTS"
+IFS=',' read -r -a strategies <<<"$STRATEGIES"
+IFS=',' read -r -a perf_event_sets <<<"$PERF_EVENT_SETS"
+
+readonly -a supported_strategies=(
+    eytzinger donnelly_unrolled donnelly_cyclic_simd_descent
+    donnelly_cyclic_simd_full
+)
+
+contains() {
+    local needle=$1
+    shift
+    local value
+    for value in "$@"; do
+        [[ "$value" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+validate_unique_positive_list() {
+    local label=$1
+    shift
+    local -a values=("$@")
+    local i j value
+    (( ${#values[@]} > 0 )) || {
+        echo "$label must not be empty" >&2
+        exit 2
+    }
+    for value in "${values[@]}"; do
+        [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
+            echo "$label contains an invalid positive integer: $value" >&2
+            exit 2
+        }
+    done
+    for ((i = 0; i < ${#values[@]}; i++)); do
+        for ((j = i + 1; j < ${#values[@]}; j++)); do
+            [[ "${values[i]}" != "${values[j]}" ]] || {
+                echo "$label contains a duplicate: ${values[i]}" >&2
+                exit 2
+            }
+        done
+    done
+}
+
+validate_unique_positive_list HEIGHTS "${heights[@]}"
+validate_unique_positive_list BASE_POOL_SIZES "${base_pools[@]}"
+validate_unique_positive_list DENSE_POOL_SIZES "${dense_pools[@]}"
+validate_unique_positive_list F64_DENSE_HEIGHTS "${f64_dense_heights[@]}"
+validate_unique_positive_list F32_DENSE_HEIGHTS "${f32_dense_heights[@]}"
+
+for height in "${heights[@]}"; do
+    (( height >= 5 && height < 30 )) || {
+        echo "HEIGHTS entries must be between 5 and 29: $height" >&2
+        exit 2
+    }
+done
+for height in "${f64_dense_heights[@]}" "${f32_dense_heights[@]}"; do
+    contains "$height" "${heights[@]}" || {
+        echo "Dense height $height is absent from HEIGHTS" >&2
+        exit 2
+    }
+done
+for pool in "${base_pools[@]}"; do
+    contains "$pool" "${dense_pools[@]}" || {
+        echo "DENSE_POOL_SIZES must include base pool $pool" >&2
+        exit 2
+    }
+done
+
+(( ${#strategies[@]} > 0 )) || {
+    echo "STRATEGIES must not be empty" >&2
+    exit 2
+}
+for strategy in "${strategies[@]}"; do
+    contains "$strategy" "${supported_strategies[@]}" || {
+        echo "Unsupported strategy: $strategy" >&2
+        exit 2
+    }
+done
+for ((i = 0; i < ${#strategies[@]}; i++)); do
+    for ((j = i + 1; j < ${#strategies[@]}; j++)); do
+        [[ "${strategies[i]}" != "${strategies[j]}" ]] || {
+            echo "STRATEGIES contains a duplicate: ${strategies[i]}" >&2
+            exit 2
+        }
+    done
+done
+contains eytzinger "${strategies[@]}" || {
+    echo "STRATEGIES must retain the Eytzinger control" >&2
+    exit 2
+}
+
+for value_name in CRITERION_WARMUP CRITERION_MEASUREMENT; do
+    value=${!value_name}
+    [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] || {
+        echo "$value_name must be a non-negative number: $value" >&2
+        exit 2
+    }
+done
+[[ "$CRITERION_SAMPLE_SIZE" =~ ^[1-9][0-9]*$ ]] \
+    && (( CRITERION_SAMPLE_SIZE >= 10 )) || {
+    echo "CRITERION_SAMPLE_SIZE must be an integer of at least 10" >&2
+    exit 2
+}
+[[ "$IRQ_RETRIES" =~ ^[0-9]+$ ]] || {
+    echo "IRQ_RETRIES must be a non-negative integer" >&2
+    exit 2
+}
+for value_name in PERF_F64_HEIGHT PERF_F32_HEIGHT PERF_POOL_SIZE \
+    PERF_TOTAL_QUERIES PERF_WARMUP_REPEATS; do
+    value=${!value_name}
+    [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
+        echo "$value_name must be a positive integer: $value" >&2
+        exit 2
+    }
+done
+(( PERF_F64_HEIGHT >= 5 && PERF_F64_HEIGHT < 30 )) || {
+    echo "PERF_F64_HEIGHT must be between 5 and 29" >&2
+    exit 2
+}
+(( PERF_F32_HEIGHT >= 5 && PERF_F32_HEIGHT < 30 )) || {
+    echo "PERF_F32_HEIGHT must be between 5 and 29" >&2
+    exit 2
+}
+(( (PERF_F64_HEIGHT - 5) % 3 == 0 )) || {
+    echo "PERF_F64_HEIGHT must be an exact Block3 height" >&2
+    exit 2
+}
+(( (PERF_F32_HEIGHT - 5) % 4 == 0 )) || {
+    echo "PERF_F32_HEIGHT must be an exact Block4 height" >&2
+    exit 2
+}
+for event_set in "${perf_event_sets[@]}"; do
+    case "$event_set" in
+        core|cache|tlb) ;;
+        *) echo "Unsupported PERF_EVENT_SETS entry: $event_set" >&2; exit 2 ;;
+    esac
+done
+for ((i = 0; i < ${#perf_event_sets[@]}; i++)); do
+    for ((j = i + 1; j < ${#perf_event_sets[@]}; j++)); do
+        [[ "${perf_event_sets[i]}" != "${perf_event_sets[j]}" ]] || {
+            echo "PERF_EVENT_SETS contains a duplicate: ${perf_event_sets[i]}" >&2
+            exit 2
+        }
+    done
+done
+
+native_cfg=$(rustc --print cfg -C target-cpu=native)
+[[ "$native_cfg" == *'target_feature="avx512f"'* ]] || {
+    echo "This experiment requires native AVX-512F support" >&2
+    exit 2
+}
+
+mkdir -p -- "$RUN_DIR" "$CHART_DIR"
+
+planned_dense_cells=$((${#f64_dense_heights[@]} + ${#f32_dense_heights[@]}))
+planned_cells=$((2 * ${#heights[@]}))
+planned_base_cells=$((planned_cells - planned_dense_cells))
+planned_results=$((
+    planned_base_cells * ${#base_pools[@]} * ${#strategies[@]} * 2
+    + planned_dense_cells * ${#dense_pools[@]} * ${#strategies[@]} * 2
+))
+{
+    echo "Planned timing cells: $planned_cells ($planned_dense_cells dense query sweeps)"
+    echo "Planned Criterion functions: $planned_results"
+    echo "Per-function budget: ${CRITERION_WARMUP}s warmup + ${CRITERION_MEASUREMENT}s measurement"
+    if (( RUN_PERF == 1 )); then
+        echo "Planned perf passes: $((2 * ${#strategies[@]} * ${#perf_event_sets[@]}))"
+    fi
+} | tee -a "$LOG_FILE"
+
+capture_profile_status() {
+    local destination=$1 phase=$2 status
+    set +e
+    bench-profile-status >"$destination" 2>&1
+    status=$?
+    set -e
+    if (( status != 0 )); then
+        cat "$destination" >&2
+        echo >&2
+        echo "Benchmark profile validation failed $phase; refusing to continue." >&2
+        echo "Full status was saved to $destination" >&2
+        return "$status"
+    fi
+}
+
+capture_profile_status "$RUN_DIR/bench-profile-status-before.txt" "before the suite"
+if (( RUN_PERF == 1 )); then
+    for event_set in "${perf_event_sets[@]}"; do
+        "$SCRIPT_DIR/query_pool_perf_events.sh" --check "$event_set"
+    done
+fi
+
+benchmark_exe="$(
+    cd -- "$REPO_DIR"
+    RUSTC_WRAPPER= RUSTFLAGS='-C target-cpu=native' \
+        cargo bench --offline --bench profile_v6_cyclic_query_pool \
+        --features simd,test_utils,logging_off --no-run --message-format=json |
+        jq -r \
+            'select(.reason == "compiler-artifact" and .target.name == "profile_v6_cyclic_query_pool") | .executable // empty' |
+        tail -n 1
+)"
+[[ -n "$benchmark_exe" && -x "$benchmark_exe" ]] || {
+    echo "Could not resolve profile_v6_cyclic_query_pool executable" >&2
+    exit 1
+}
+
+run_irq_retry_logged() {
+    local attempt=0 status
+    while true; do
+        set +e
+        (cd -- "$REPO_DIR"; "$@") 2>&1 | tee -a "$LOG_FILE"
+        status=${PIPESTATUS[0]}
+        set -e
+        if (( status != 125 || attempt >= IRQ_RETRIES )); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying IRQ-invalidated perf interval ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE"
+    done
+}
+
+run_cell() {
+    local axis=$1 dimensions=$2 height=$3 pool_csv=$4 role=$5
+    local warmup=${6:-$CRITERION_WARMUP}
+    local measurement=${7:-$CRITERION_MEASUREMENT}
+    local sample_size=${8:-$CRITERION_SAMPLE_SIZE}
+    local output_dir=${9:-$RUN_DIR}
+    local attempt=0 status result_key result_path tmp_dir
+
+    result_key="$SUITE_LABEL-$role-2p$height"
+    result_path="$output_dir/bench_result-v6-donnelly-cyclic-full-$result_key.json"
+    while true; do
+        tmp_dir="$(mktemp -d /dev/shm/kiddo-cyclic-full.XXXXXX)"
+        cp -- "$benchmark_exe" "$tmp_dir/benchmark"
+        chmod 0755 "$tmp_dir/benchmark"
+
+        set +e
+        bench-profile-run env \
+            CRITERION_HOME="$tmp_dir/criterion" \
+            KIDDO_CYCLIC_AXIS="$axis" \
+            KIDDO_CYCLIC_DIMENSIONS="$dimensions" \
+            KIDDO_CYCLIC_POINT_LOG2="$height" \
+            KIDDO_CYCLIC_POOL_SIZES="$pool_csv" \
+            KIDDO_CYCLIC_STRATEGIES="$STRATEGIES" \
+            "$tmp_dir/benchmark" \
+            profile_v6_cyclic_query_pool \
+            --warm-up-time "$warmup" \
+            --measurement-time "$measurement" \
+            --sample-size "$sample_size" \
+            --noplot --bench 2>&1 | tee -a "$LOG_FILE" >&2
+        status=${PIPESTATUS[0]}
+        set -e
+
+        if (( status == 0 )); then
+            (
+                cd -- "$REPO_DIR"
+                cargo run --quiet --offline \
+                    --manifest-path tools/criterion-export/Cargo.toml -- \
+                    "$tmp_dir/criterion" "$result_path" \
+                    profile_v6_cyclic_query_pool >&2
+            )
+            rm -rf -- "$tmp_dir"
+            printf '%s\n' "$result_path"
+            return 0
+        fi
+
+        rm -rf -- "$tmp_dir"
+        if (( status != 125 || attempt >= IRQ_RETRIES )); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying IRQ-invalidated cell $role 2^$height ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE" >&2
+    done
+}
+
+# Exercise the exact executable, isolation wrapper, exporter, and chart parser
+# before starting the long matrix.
+readonly PREFLIGHT_DIR="$(mktemp -d /dev/shm/kiddo-cyclic-full-preflight.XXXXXX)"
+cleanup_preflight() {
+    rm -rf -- "$PREFLIGHT_DIR"
+}
+trap cleanup_preflight EXIT INT TERM
+preflight_result=$(run_cell f64 3 10 16 preflight 0.01 0.02 10 "$PREFLIGHT_DIR")
+preflight_expected=$((${#strategies[@]} * 2))
+preflight_actual=$(jq '.results | length' "$preflight_result")
+if (( preflight_actual != preflight_expected )); then
+    echo "Preflight produced $preflight_actual entries; expected $preflight_expected" >&2
+    exit 1
+fi
+python3 "$SCRIPT_DIR/chart_donnelly_variant_results.py" all \
+    --result "$preflight_result" --result-label "$SUITE_LABEL-preflight" \
+    --output-dir "$PREFLIGHT_DIR/charts" --html-name preflight.html
+if (( RUN_PERF == 1 )); then
+    run_irq_retry_logged just perf-v6-donnelly-vs-eytzinger-query-pool \
+        10 16 128 1 f64 eytzinger core "$SUITE_LABEL-preflight-perf" "$PREFLIGHT_DIR"
+    preflight_perf="$PREFLIGHT_DIR/$SUITE_LABEL-preflight-perf-f64-eytzinger-q16-core.perf.csv"
+    "$SCRIPT_DIR/query_pool_perf_events.sh" --validate "$preflight_perf"
+fi
+cleanup_preflight
+trap - EXIT INT TERM
+
+inputs=()
+expected_total=0
+for axis in f64 f32; do
+    if [[ "$axis" == f64 ]]; then
+        dimensions=3
+        dense_height_csv=$F64_DENSE_HEIGHTS
+        dense_height_list=("${f64_dense_heights[@]}")
+    else
+        dimensions=4
+        dense_height_csv=$F32_DENSE_HEIGHTS
+        dense_height_list=("${f32_dense_heights[@]}")
+    fi
+    for height in "${heights[@]}"; do
+        pool_csv=$BASE_POOL_SIZES
+        pool_count=${#base_pools[@]}
+        if contains "$height" "${dense_height_list[@]}"; then
+            pool_csv=$DENSE_POOL_SIZES
+            pool_count=${#dense_pools[@]}
+        fi
+        result_path=$(run_cell "$axis" "$dimensions" "$height" "$pool_csv" "$axis-k$dimensions")
+        inputs+=("$result_path")
+        expected_total=$((expected_total + pool_count * ${#strategies[@]} * 2))
+    done
+    echo "$axis dense heights: $dense_height_csv" | tee -a "$LOG_FILE"
+done
+
+jq -s --arg criterion_root "merged:$SUITE_LABEL" '
+    {
+        schema_version: 1,
+        criterion_root: $criterion_root,
+        collected_at_unix_ms: ([.[].collected_at_unix_ms] | max),
+        filters: ([.[].filters[]] | unique),
+        results: ([.[].results[]] | sort_by(.benchmark))
+    }
+' "${inputs[@]}" >"$RESULT_FILE"
+
+actual_total=$(jq '.results | length' "$RESULT_FILE")
+if (( actual_total != expected_total )); then
+    echo "Merged result has $actual_total entries; expected $expected_total" >&2
+    exit 1
+fi
+
+python3 "$SCRIPT_DIR/chart_donnelly_variant_results.py" all \
+    --result "$RESULT_FILE" --result-label "$SUITE_LABEL" \
+    --output-dir "$CHART_DIR" --html-name "$SUITE_LABEL.html"
+
+if (( RUN_PERF == 1 )); then
+    for axis in f64 f32; do
+        if [[ "$axis" == f64 ]]; then
+            perf_height=$PERF_F64_HEIGHT
+        else
+            perf_height=$PERF_F32_HEIGHT
+        fi
+        for strategy in "${strategies[@]}"; do
+            for event_set in "${perf_event_sets[@]}"; do
+                result_key="$SUITE_LABEL-exact-height"
+                run_irq_retry_logged just perf-v6-donnelly-vs-eytzinger-query-pool \
+                    "$perf_height" "$PERF_POOL_SIZE" "$PERF_TOTAL_QUERIES" \
+                    "$PERF_WARMUP_REPEATS" "$axis" "$strategy" "$event_set" \
+                    "$result_key" "$RUN_DIR"
+                perf_csv="$RUN_DIR/$result_key-$axis-$strategy-q$PERF_POOL_SIZE-$event_set.perf.csv"
+                "$SCRIPT_DIR/query_pool_perf_events.sh" --validate "$perf_csv"
+            done
+        done
+    done
+fi
+
+capture_profile_status "$RUN_DIR/bench-profile-status-after.txt" "after the suite"
+{
+    echo "suite_label=$SUITE_LABEL"
+    echo "finished_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "heights=$HEIGHTS"
+    echo "base_pool_sizes=$BASE_POOL_SIZES"
+    echo "dense_pool_sizes=$DENSE_POOL_SIZES"
+    echo "f64_dense_heights=$F64_DENSE_HEIGHTS"
+    echo "f32_dense_heights=$F32_DENSE_HEIGHTS"
+    echo "strategies=$STRATEGIES"
+    echo "cells=f64-k3:2p20-2p29,f32-k4:2p20-2p29"
+    echo "exact_heights=f64:2p20,2p23,2p26,2p29;f32:2p21,2p25,2p29"
+    echo "run_perf=$RUN_PERF"
+    echo "perf_heights=f64:2p$PERF_F64_HEIGHT,f32:2p$PERF_F32_HEIGHT"
+    echo "perf_pool_size=$PERF_POOL_SIZE"
+    echo "perf_total_queries=$PERF_TOTAL_QUERIES"
+    echo "perf_event_sets=$PERF_EVENT_SETS"
+    echo "result_count=$actual_total"
+    echo "result_file=$RESULT_FILE"
+    echo "chart_file=$HTML_FILE"
+    echo "git_head=$(git -C "$REPO_DIR" rev-parse HEAD)"
+    echo "rustc=$(rustc --version)"
+} >"$RUN_DIR/manifest.txt"
+
+echo
+echo "Cyclic SIMD-full height/query matrix complete"
+echo "Results: $RESULT_FILE"
+echo "Charts:  $HTML_FILE"

--- a/scripts/run_donnelly_cyclic_phase_matrix.sh
+++ b/scripts/run_donnelly_cyclic_phase_matrix.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Controlled exact-NN matrix for phase-aware cyclic SIMD. The four cells pair a
+# native dimension/block-height case with an awkward dimension count, and an
+# exact block height with a root-padded height, for both scalar widths.
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+POOL_SIZES=${POOL_SIZES:-256,512,1000,2048,4096,8192,16384}
+CRITERION_WARMUP=${CRITERION_WARMUP:-3}
+CRITERION_MEASUREMENT=${CRITERION_MEASUREMENT:-8}
+CRITERION_SAMPLE_SIZE=${CRITERION_SAMPLE_SIZE:-30}
+STRATEGIES=${STRATEGIES:-eytzinger,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full}
+IRQ_RETRIES=${IRQ_RETRIES:-2}
+PERF_POOL_SIZE=${PERF_POOL_SIZE:-4096}
+PERF_TOTAL_QUERIES=${PERF_TOTAL_QUERIES:-4000000}
+PERF_WARMUP_REPEATS=${PERF_WARMUP_REPEATS:-2}
+PERF_EVENT_SETS=${PERF_EVENT_SETS:-core,cache,tlb}
+OUTPUT_BASE=${OUTPUT_BASE:-$REPO_DIR/focused-results}
+CHART_BASE=${CHART_BASE:-$REPO_DIR/focused-charts}
+SUITE_LABEL=${SUITE_LABEL:-donnelly-cyclic-phase-matrix-$(date -u +%Y%m%dT%H%M%SZ)}
+
+readonly RUN_DIR="$OUTPUT_BASE/$SUITE_LABEL"
+readonly CHART_DIR="$CHART_BASE/$SUITE_LABEL"
+readonly RESULT_FILE="$RUN_DIR/bench_result-v6-donnelly-cyclic-phase-$SUITE_LABEL.json"
+readonly HTML_FILE="$CHART_DIR/$SUITE_LABEL.html"
+readonly LOG_FILE="$RUN_DIR/run.log"
+
+for command_name in bench-profile-run bench-profile-status cargo jq just mktemp perf python3 rustc; do
+    command -v "$command_name" >/dev/null || {
+        echo "Required command is unavailable: $command_name" >&2
+        exit 2
+    }
+done
+[[ "$SUITE_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]] || {
+    echo "SUITE_LABEL contains unsupported characters" >&2
+    exit 2
+}
+[[ ! -e "$RUN_DIR" && ! -e "$CHART_DIR" ]] || {
+    echo "Refusing to overwrite existing suite $SUITE_LABEL" >&2
+    exit 2
+}
+
+IFS=',' read -r -a pools <<<"$POOL_SIZES"
+IFS=',' read -r -a strategies <<<"$STRATEGIES"
+IFS=',' read -r -a perf_event_sets <<<"$PERF_EVENT_SETS"
+readonly -a supported=(
+    eytzinger donnelly_cyclic_simd_descent donnelly_cyclic_simd_full
+)
+for strategy in "${strategies[@]}"; do
+    [[ " ${supported[*]} " == *" $strategy "* ]] || {
+        echo "Unsupported strategy: $strategy" >&2
+        exit 2
+    }
+done
+for pool_size in "${pools[@]}"; do
+    [[ "$pool_size" =~ ^[1-9][0-9]*$ ]] || {
+        echo "POOL_SIZES entries must be positive integers: $pool_size" >&2
+        exit 2
+    }
+done
+for value_name in CRITERION_WARMUP CRITERION_MEASUREMENT; do
+    value=${!value_name}
+    [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] || {
+        echo "$value_name must be a non-negative number: $value" >&2
+        exit 2
+    }
+done
+[[ "$CRITERION_SAMPLE_SIZE" =~ ^[1-9][0-9]*$ ]] || {
+    echo "CRITERION_SAMPLE_SIZE must be a positive integer" >&2
+    exit 2
+}
+[[ "$IRQ_RETRIES" =~ ^[0-9]+$ ]] || {
+    echo "IRQ_RETRIES must be a non-negative integer" >&2
+    exit 2
+}
+for value_name in PERF_POOL_SIZE PERF_TOTAL_QUERIES PERF_WARMUP_REPEATS; do
+    value=${!value_name}
+    [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
+        echo "$value_name must be a positive integer" >&2
+        exit 2
+    }
+done
+for event_set in "${perf_event_sets[@]}"; do
+    case "$event_set" in
+        core|cache|tlb) ;;
+        *) echo "Unsupported PERF_EVENT_SETS entry: $event_set" >&2; exit 2 ;;
+    esac
+done
+[[ " ${strategies[*]} " == *" eytzinger "* ]] || {
+    echo "STRATEGIES must retain the Eytzinger control" >&2
+    exit 2
+}
+
+native_cfg=$(rustc --print cfg -C target-cpu=native)
+[[ "$native_cfg" == *'target_feature="avx512f"'* ]] || {
+    echo "This experiment requires AVX-512F" >&2
+    exit 2
+}
+
+mkdir -p -- "$RUN_DIR" "$CHART_DIR"
+capture_profile_status() {
+    local destination=$1 phase=$2 status
+    set +e
+    bench-profile-status >"$destination" 2>&1
+    status=$?
+    set -e
+    if (( status != 0 )); then
+        cat "$destination" >&2
+        echo >&2
+        echo "Benchmark profile validation failed $phase; refusing to continue." >&2
+        echo "Full status was saved to $destination" >&2
+        return "$status"
+    fi
+}
+capture_profile_status "$RUN_DIR/bench-profile-status-before.txt" "before the suite"
+for event_set in "${perf_event_sets[@]}"; do
+    "$SCRIPT_DIR/query_pool_perf_events.sh" --check "$event_set"
+done
+
+benchmark_exe="$(
+    cd -- "$REPO_DIR"
+    RUSTC_WRAPPER= RUSTFLAGS='-C target-cpu=native' \
+        cargo bench --offline --bench profile_v6_cyclic_query_pool \
+        --features simd,test_utils,logging_off --no-run --message-format=json |
+        jq -r \
+            'select(.reason == "compiler-artifact" and .target.name == "profile_v6_cyclic_query_pool") | .executable // empty' |
+        tail -n 1
+)"
+[[ -n "$benchmark_exe" && -x "$benchmark_exe" ]] || {
+    echo "Could not resolve profile_v6_cyclic_query_pool executable" >&2
+    exit 1
+}
+
+run_irq_retry_logged() {
+    local attempt=0 status
+    while true; do
+        set +e
+        (cd -- "$REPO_DIR"; "$@") 2>&1 | tee -a "$LOG_FILE"
+        status=${PIPESTATUS[0]}
+        set -e
+        if (( status != 125 || attempt >= IRQ_RETRIES )); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying IRQ-invalidated perf interval ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE"
+    done
+}
+
+# B=32 removes five levels. p23 f64 and p25 f32 are exact native block
+# boundaries; p22 f64 and p24 f32 each require one cyclic root-padding level.
+readonly -a cell_axes=(f64 f64 f32 f32)
+readonly -a cell_dimensions=(3 4 4 3)
+readonly -a cell_heights=(23 22 25 24)
+readonly -a cell_roles=(
+    f64-k3-exact
+    f64-k4-padded
+    f32-k4-exact
+    f32-k3-padded
+)
+
+run_cell() {
+    local axis=$1 dimensions=$2 height=$3 role=$4
+    local pool_csv=${5:-$POOL_SIZES}
+    local strategy_csv=${6:-$STRATEGIES}
+    local warmup=${7:-$CRITERION_WARMUP}
+    local measurement=${8:-$CRITERION_MEASUREMENT}
+    local sample_size=${9:-$CRITERION_SAMPLE_SIZE}
+    local output_dir=${10:-$RUN_DIR}
+    local attempt=0 status result_key result_path tmp_dir
+
+    result_key="$SUITE_LABEL-$role-2p$height"
+    result_path="$output_dir/bench_result-v6-donnelly-cyclic-phase-$result_key.json"
+    while true; do
+        tmp_dir="$(mktemp -d /dev/shm/kiddo-cyclic-phase.XXXXXX)"
+        cp -- "$benchmark_exe" "$tmp_dir/benchmark"
+        chmod 0755 "$tmp_dir/benchmark"
+
+        set +e
+        bench-profile-run env \
+            CRITERION_HOME="$tmp_dir/criterion" \
+            KIDDO_CYCLIC_AXIS="$axis" \
+            KIDDO_CYCLIC_DIMENSIONS="$dimensions" \
+            KIDDO_CYCLIC_POINT_LOG2="$height" \
+            KIDDO_CYCLIC_POOL_SIZES="$pool_csv" \
+            KIDDO_CYCLIC_STRATEGIES="$strategy_csv" \
+            "$tmp_dir/benchmark" \
+            profile_v6_cyclic_query_pool \
+            --warm-up-time "$warmup" \
+            --measurement-time "$measurement" \
+            --sample-size "$sample_size" \
+            --noplot --bench 2>&1 | tee -a "$LOG_FILE" >&2
+        status=${PIPESTATUS[0]}
+        set -e
+
+        if (( status == 0 )); then
+            (
+                cd -- "$REPO_DIR"
+                cargo run --quiet --offline \
+                    --manifest-path tools/criterion-export/Cargo.toml -- \
+                    "$tmp_dir/criterion" "$result_path" \
+                    profile_v6_cyclic_query_pool >&2
+            )
+            rm -rf -- "$tmp_dir"
+            printf '%s\n' "$result_path"
+            return 0
+        fi
+
+        rm -rf -- "$tmp_dir"
+        if (( status != 125 || attempt >= IRQ_RETRIES )); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying IRQ-invalidated cell $role ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE"
+    done
+}
+
+# Exercise the exact executable, isolation wrapper, exporter, and chart parser
+# before committing to the long matrix. This takes seconds and catches CLI or
+# Criterion-format drift while the run is still cheap to restart.
+readonly PREFLIGHT_DIR="$(mktemp -d /dev/shm/kiddo-cyclic-preflight.XXXXXX)"
+cleanup_preflight() {
+    rm -rf -- "$PREFLIGHT_DIR"
+}
+trap cleanup_preflight EXIT INT TERM
+preflight_result=$(run_cell f64 4 10 preflight 16 "$STRATEGIES" 0.01 0.02 10 "$PREFLIGHT_DIR")
+preflight_expected=$((${#strategies[@]} * 2))
+preflight_actual=$(jq '.results | length' "$preflight_result")
+if (( preflight_actual != preflight_expected )); then
+    echo "Preflight produced $preflight_actual entries; expected $preflight_expected" >&2
+    exit 1
+fi
+python3 "$SCRIPT_DIR/chart_donnelly_variant_results.py" all \
+    --result "$preflight_result" --result-label "$SUITE_LABEL-preflight" \
+    --output-dir "$PREFLIGHT_DIR/charts" --html-name preflight.html
+run_irq_retry_logged just perf-v6-donnelly-vs-eytzinger-query-pool \
+    10 16 128 1 f64 eytzinger core "$SUITE_LABEL-preflight-perf" "$PREFLIGHT_DIR"
+preflight_perf="$PREFLIGHT_DIR/$SUITE_LABEL-preflight-perf-f64-eytzinger-q16-core.perf.csv"
+"$SCRIPT_DIR/query_pool_perf_events.sh" --validate "$preflight_perf"
+cleanup_preflight
+trap - EXIT INT TERM
+
+inputs=()
+for index in "${!cell_axes[@]}"; do
+    result_path=$(run_cell \
+        "${cell_axes[index]}" \
+        "${cell_dimensions[index]}" \
+        "${cell_heights[index]}" \
+        "${cell_roles[index]}")
+    inputs+=("$result_path")
+done
+
+jq -s --arg criterion_root "merged:$SUITE_LABEL" '
+    {
+        schema_version: 1,
+        criterion_root: $criterion_root,
+        collected_at_unix_ms: ([.[].collected_at_unix_ms] | max),
+        filters: ([.[].filters[]] | unique),
+        results: ([.[].results[]] | sort_by(.benchmark))
+    }
+' "${inputs[@]}" >"$RESULT_FILE"
+
+expected_per_cell=$((${#pools[@]} * ${#strategies[@]} * 2))
+expected_total=$((expected_per_cell * ${#cell_axes[@]}))
+actual_total=$(jq '.results | length' "$RESULT_FILE")
+if (( actual_total != expected_total )); then
+    echo "Merged result has $actual_total entries; expected $expected_total" >&2
+    exit 1
+fi
+
+python3 "$SCRIPT_DIR/chart_donnelly_variant_results.py" all \
+    --result "$RESULT_FILE" --result-label "$SUITE_LABEL" \
+    --output-dir "$CHART_DIR" --html-name "$SUITE_LABEL.html"
+
+# One exact-block-height counter pass per scalar width. Counter classes remain
+# separate so perf never multiplexes or scales the publication evidence.
+readonly -a perf_axes=(f64 f32)
+readonly -a perf_heights=(23 25)
+for perf_index in "${!perf_axes[@]}"; do
+    axis=${perf_axes[perf_index]}
+    height=${perf_heights[perf_index]}
+    for strategy in "${strategies[@]}"; do
+        for event_set in "${perf_event_sets[@]}"; do
+            result_key="$SUITE_LABEL-exact-height"
+            run_irq_retry_logged just perf-v6-donnelly-vs-eytzinger-query-pool \
+                "$height" "$PERF_POOL_SIZE" "$PERF_TOTAL_QUERIES" \
+                "$PERF_WARMUP_REPEATS" "$axis" "$strategy" "$event_set" \
+                "$result_key" "$RUN_DIR"
+            perf_csv="$RUN_DIR/$result_key-$axis-$strategy-q$PERF_POOL_SIZE-$event_set.perf.csv"
+            "$SCRIPT_DIR/query_pool_perf_events.sh" --validate "$perf_csv"
+        done
+    done
+done
+
+capture_profile_status "$RUN_DIR/bench-profile-status-after.txt" "after the suite"
+{
+    echo "suite_label=$SUITE_LABEL"
+    echo "finished_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "pool_sizes=$POOL_SIZES"
+    echo "strategies=$STRATEGIES"
+    echo "perf_axes=f64:2p23,f32:2p25"
+    echo "perf_pool_size=$PERF_POOL_SIZE"
+    echo "perf_total_queries=$PERF_TOTAL_QUERIES"
+    echo "perf_warmup_repeats=$PERF_WARMUP_REPEATS"
+    echo "perf_event_sets=$PERF_EVENT_SETS"
+    echo "cells=f64-k3-p23,f64-k4-p22,f32-k4-p25,f32-k3-p24"
+    echo "result_count=$actual_total"
+    echo "result_file=$RESULT_FILE"
+    echo "chart_file=$HTML_FILE"
+    echo "git_head=$(git -C "$REPO_DIR" rev-parse HEAD)"
+    echo "rustc=$(rustc --version)"
+} >"$RUN_DIR/manifest.txt"
+
+echo
+echo "Cyclic phase matrix complete"
+echo "Results: $RESULT_FILE"
+echo "Charts:  $HTML_FILE"

--- a/src/dist/chebyshev/avx512.rs
+++ b/src/dist/chebyshev/avx512.rs
@@ -17,6 +17,11 @@ impl Avx512F64LeafOps for ChebyshevAvx512F64LeafOps {
     }
 
     #[inline(always)]
+    unsafe fn rect_dist_f64x8_3(off0: __m512d, off1: __m512d, off2: __m512d) -> __m512d {
+        _mm512_max_pd(_mm512_max_pd(off0, off1), off2)
+    }
+
+    #[inline(always)]
     unsafe fn dist_k0_f64x4(delta: __m256d) -> __m256d {
         custom_mm256_abs_pd(delta)
     }
@@ -58,6 +63,11 @@ impl Avx512F32LeafOps for ChebyshevAvx512F32LeafOps {
     #[inline(always)]
     unsafe fn dist_kn_f32x16(acc: __m512, delta: __m512) -> __m512 {
         _mm512_max_ps(acc, custom_mm512_abs_ps(delta))
+    }
+
+    #[inline(always)]
+    unsafe fn rect_dist_f32x16_4(off0: __m512, off1: __m512, off2: __m512, off3: __m512) -> __m512 {
+        _mm512_max_ps(_mm512_max_ps(off0, off1), _mm512_max_ps(off2, off3))
     }
 
     #[inline(always)]

--- a/src/dist/distance_metric_avx512.rs
+++ b/src/dist/distance_metric_avx512.rs
@@ -12,6 +12,18 @@ pub trait Avx512F64LeafOps {
     /// calculate distance on 8 f64's at once (dimensions 1+, ie add to accumulator)
     unsafe fn dist_kn_f64x8(acc: __m512d, delta: __m512d) -> __m512d;
 
+    /// Calculate the distance to three-dimensional rectangles from their
+    /// non-negative per-axis offsets.
+    ///
+    /// Metrics may override this composition to expose more instruction-level
+    /// parallelism than the accumulator-shaped leaf operations permit.
+    #[inline(always)]
+    unsafe fn rect_dist_f64x8_3(off0: __m512d, off1: __m512d, off2: __m512d) -> __m512d {
+        let acc = Self::dist_k0_f64x8(off0);
+        let acc = Self::dist_kn_f64x8(acc, off1);
+        Self::dist_kn_f64x8(acc, off2)
+    }
+
     /// calculate distance on 4 f64's at once (dimension 0, ie set initial accumulator value)
     unsafe fn dist_k0_f64x4(delta: __m256d) -> __m256d;
 
@@ -91,6 +103,19 @@ pub trait Avx512F32LeafOps {
 
     /// Accumulate distance on 16 f32 lanes for subsequent dimensions.
     unsafe fn dist_kn_f32x16(acc: __m512, delta: __m512) -> __m512;
+
+    /// Calculate the distance to four-dimensional rectangles from their
+    /// non-negative per-axis offsets.
+    ///
+    /// Metrics may override this composition to expose more instruction-level
+    /// parallelism than the accumulator-shaped leaf operations permit.
+    #[inline(always)]
+    unsafe fn rect_dist_f32x16_4(off0: __m512, off1: __m512, off2: __m512, off3: __m512) -> __m512 {
+        let acc = Self::dist_k0_f32x16(off0);
+        let acc = Self::dist_kn_f32x16(acc, off1);
+        let acc = Self::dist_kn_f32x16(acc, off2);
+        Self::dist_kn_f32x16(acc, off3)
+    }
 
     /// Calculate distance on 8 f32 lanes for the first dimension.
     unsafe fn dist_k0_f32x8(delta: __m256) -> __m256;

--- a/src/dist/manhattan/avx512.rs
+++ b/src/dist/manhattan/avx512.rs
@@ -51,6 +51,11 @@ impl Avx512F64LeafOps for ManhattanAvx512F64LeafOps {
     }
 
     #[inline(always)]
+    unsafe fn rect_dist_f64x8_3(off0: __m512d, off1: __m512d, off2: __m512d) -> __m512d {
+        _mm512_add_pd(_mm512_add_pd(off0, off1), off2)
+    }
+
+    #[inline(always)]
     unsafe fn dist_k0_f64x4(delta: __m256d) -> __m256d {
         abs_pd_256(delta)
     }
@@ -92,6 +97,11 @@ impl Avx512F32LeafOps for ManhattanAvx512F32LeafOps {
     #[inline(always)]
     unsafe fn dist_kn_f32x16(acc: __m512, delta: __m512) -> __m512 {
         _mm512_add_ps(acc, abs_ps_512(delta))
+    }
+
+    #[inline(always)]
+    unsafe fn rect_dist_f32x16_4(off0: __m512, off1: __m512, off2: __m512, off3: __m512) -> __m512 {
+        _mm512_add_ps(_mm512_add_ps(off0, off1), _mm512_add_ps(off2, off3))
     }
 
     #[inline(always)]

--- a/src/dist/minkowski/avx512.rs
+++ b/src/dist/minkowski/avx512.rs
@@ -269,6 +269,14 @@ impl<const P: u32> Avx512F64LeafOps for MinkowskiAvx512F64LeafOps<P> {
     }
 
     #[inline(always)]
+    unsafe fn rect_dist_f64x8_3(off0: __m512d, off1: __m512d, off2: __m512d) -> __m512d {
+        let dist0 = pow_pd_512::<P>(off0);
+        let dist1 = pow_pd_512::<P>(off1);
+        let dist2 = pow_pd_512::<P>(off2);
+        _mm512_add_pd(_mm512_add_pd(dist0, dist1), dist2)
+    }
+
+    #[inline(always)]
     unsafe fn dist_k0_f64x4(delta: __m256d) -> __m256d {
         pow_pd_256::<P>(custom_mm256_abs_pd(delta))
     }
@@ -310,6 +318,15 @@ impl<const P: u32> Avx512F32LeafOps for MinkowskiAvx512F32LeafOps<P> {
     #[inline(always)]
     unsafe fn dist_kn_f32x16(acc: __m512, delta: __m512) -> __m512 {
         _mm512_add_ps(acc, pow_ps_512::<P>(custom_mm512_abs_ps(delta)))
+    }
+
+    #[inline(always)]
+    unsafe fn rect_dist_f32x16_4(off0: __m512, off1: __m512, off2: __m512, off3: __m512) -> __m512 {
+        let dist0 = pow_ps_512::<P>(off0);
+        let dist1 = pow_ps_512::<P>(off1);
+        let dist2 = pow_ps_512::<P>(off2);
+        let dist3 = pow_ps_512::<P>(off3);
+        _mm512_add_ps(_mm512_add_ps(dist0, dist1), _mm512_add_ps(dist2, dist3))
     }
 
     #[inline(always)]

--- a/src/dist/squared_euclidean/avx512.rs
+++ b/src/dist/squared_euclidean/avx512.rs
@@ -16,6 +16,14 @@ impl Avx512F64LeafOps for SquaredEuclideanAvx512F64LeafOps {
     }
 
     #[inline(always)]
+    unsafe fn rect_dist_f64x8_3(off0: __m512d, off1: __m512d, off2: __m512d) -> __m512d {
+        let dist0 = _mm512_mul_pd(off0, off0);
+        let dist1 = _mm512_mul_pd(off1, off1);
+        let dist2 = _mm512_mul_pd(off2, off2);
+        _mm512_add_pd(_mm512_add_pd(dist0, dist1), dist2)
+    }
+
+    #[inline(always)]
     unsafe fn dist_k0_f64x4(delta: __m256d) -> __m256d {
         _mm256_mul_pd(delta, delta)
     }
@@ -57,6 +65,13 @@ impl Avx512F32LeafOps for SquaredEuclideanAvx512F32LeafOps {
     #[inline(always)]
     unsafe fn dist_kn_f32x16(acc: __m512, delta: __m512) -> __m512 {
         _mm512_fmadd_ps(delta, delta, acc)
+    }
+
+    #[inline(always)]
+    unsafe fn rect_dist_f32x16_4(off0: __m512, off1: __m512, off2: __m512, off3: __m512) -> __m512 {
+        let dist01 = _mm512_add_ps(_mm512_mul_ps(off0, off0), _mm512_mul_ps(off1, off1));
+        let dist23 = _mm512_add_ps(_mm512_mul_ps(off2, off2), _mm512_mul_ps(off3, off3));
+        _mm512_add_ps(dist01, dist23)
     }
 
     #[inline(always)]

--- a/src/kd_tree/orchestrator/mod.rs
+++ b/src/kd_tree/orchestrator/mod.rs
@@ -355,7 +355,11 @@ where
         process_leaf: impl FnMut(usize, &[O; K], &mut QC),
     ) where
         QC: QueryContext<A, O, K>,
-        O: Axis<Coord = O> + BacktrackBlock3 + BacktrackBlock4,
+        O: Axis<Coord = O>
+            + SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4,
         D: DistanceMetric<A, Output = O>,
         SS::Stack<O>: StackTrait<O, SS> + Default,
     {
@@ -372,7 +376,11 @@ where
         process_leaf: impl FnMut(usize, &[O; K], &mut QC),
     ) where
         QC: QueryContext<A, O, K>,
-        O: Axis<Coord = O> + BacktrackBlock3 + BacktrackBlock4,
+        O: Axis<Coord = O>
+            + SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4,
         D: DistanceMetric<A, Output = O>,
         SS::Stack<O>: StackTrait<O, SS>,
         SS::StackContext<O>: ScalarStackContext<O, SS::DeferredState>,

--- a/src/kd_tree/orchestrator/mod.rs
+++ b/src/kd_tree/orchestrator/mod.rs
@@ -13,6 +13,7 @@ use crate::stem_strategy::{
     donnelly::simd_full::{BacktrackBlock3, BacktrackBlock4},
     SimdPrune, SimdSelectBestChildBlock3,
 };
+use crate::traits::stem_strategy::PreparedBlockQuery;
 use crate::{Axis, Content, LeafStrategy, StemStrategy};
 
 #[derive(Clone, Copy, Debug)]
@@ -406,6 +407,7 @@ where
         let mut stem_strat: SS = SS::new(stems_ptr);
 
         let query: [A; K] = *query_ctx.query();
+        let prepared_block_query = SS::prepare_block_query(&query);
         let mut query_wide: [O; K] = [O::zero(); K];
         for dim in 0..K {
             query_wide[dim] = D::widen_coord(query[dim]);
@@ -426,6 +428,7 @@ where
         let leaf_idx = if query_ctx.initial_bound_is_unbounded() {
             self.arithmetic_descend_to_leaf::<QC, O, D, false, false>(
                 &query,
+                &prepared_block_query,
                 &query_wide,
                 query_ctx,
                 &mut stem_strat,
@@ -437,6 +440,7 @@ where
         } else {
             self.arithmetic_descend_to_leaf::<QC, O, D, true, false>(
                 &query,
+                &prepared_block_query,
                 &query_wide,
                 query_ctx,
                 &mut stem_strat,
@@ -511,6 +515,7 @@ where
 
                 let leaf_idx = self.arithmetic_descend_to_leaf::<QC, O, D, true, true>(
                     &query,
+                    &prepared_block_query,
                     &query_wide,
                     query_ctx,
                     &mut stem_strat,
@@ -540,6 +545,7 @@ where
     >(
         &self,
         query: &[A; K],
+        prepared_block_query: &PreparedBlockQuery<A, K>,
         query_wide: &[O; K],
         query_ctx: &QC,
         stem_strat: &mut SS,
@@ -673,7 +679,12 @@ where
             if SS::BLOCK_SIZE == 4 {
                 while stem_strat.level() + 3 <= self.max_stem_level() {
                     let dim = stem_strat.dim::<K>();
-                    let child_idx = stem_strat.select_block_child(self.stems(), query, dim);
+                    let child_idx = stem_strat.select_prepared_block_child(
+                        self.stems(),
+                        query,
+                        prepared_block_query,
+                        dim,
+                    );
 
                     descend_selected!(child_idx, 0b1000, branch_relative_head, traverse_head);
                     descend_selected!(child_idx, 0b0100, branch_relative_head, traverse_head);
@@ -683,7 +694,12 @@ where
             } else if SS::BLOCK_SIZE == 3 {
                 while stem_strat.level() + 2 <= self.max_stem_level() {
                     let dim = stem_strat.dim::<K>();
-                    let child_idx = stem_strat.select_block_child(self.stems(), query, dim);
+                    let child_idx = stem_strat.select_prepared_block_child(
+                        self.stems(),
+                        query,
+                        prepared_block_query,
+                        dim,
+                    );
 
                     descend_selected!(child_idx, 0b100, branch_relative_head, traverse_head);
                     descend_selected!(child_idx, 0b010, branch_relative_head, traverse_head);

--- a/src/kd_tree/query_stack_simd.rs
+++ b/src/kd_tree/query_stack_simd.rs
@@ -4,6 +4,10 @@ use crate::kd_tree::query_stack::{ScalarStackContext, StackTrait};
 use crate::{Axis, StemStrategy};
 
 const DEFAULT_INLINE_SIMD_QUERY_STACK_CAPACITY: usize = 50;
+/// Native cyclic SIMD-full traversal pushes one frame per Donnelly block.
+/// Twelve inline entries cover every tree representable by the current u32
+/// Donnelly address space while keeping the hot stack footprint compact.
+pub(crate) const CYCLIC_SIMD_FULL_INLINE_QUERY_STACK_CAPACITY: usize = 12;
 // Block3 exact traversal pushes at most one pending context per 3-level block.
 // Supporting trees up to 30 stem levels therefore requires ceil(30 / 3) = 10 entries.
 pub(crate) const BLOCK3_EXACT_INLINE_SIMD_QUERY_STACK_CAPACITY: usize = 10;
@@ -58,6 +62,41 @@ pub enum Block3ExactStackContextState<A, SS, const K: usize> {
         lower: [A; K],
         upper: [A; K],
     },
+}
+
+/// Compact stack state for native cyclic SIMD-full traversal.
+///
+/// Pending block entries retain the parent rectangle's per-axis query offsets.
+/// For squared Euclidean distance these four values completely describe the
+/// rectangle distance and are enough to derive every child offset in a block.
+#[derive(Debug)]
+pub enum CyclicSimdFullQueryStackContext<A, S> {
+    Scalar {
+        stem_state: S,
+        restore_dim: Option<usize>,
+        old_off: A,
+        rd: A,
+    },
+    Pending {
+        base_state: S,
+        pending_mask: u16,
+        off: [A; 4],
+        /// Exact minimum lower-bound distance in `pending_mask`, or zero when
+        /// the frame came from cheap near descent and has not been evaluated.
+        min_rd: A,
+    },
+}
+
+impl<A, S> CyclicSimdFullQueryStackContext<A, S> {
+    #[inline(always)]
+    pub fn pending(base_state: S, pending_mask: u16, off: [A; 4], min_rd: A) -> Self {
+        Self::Pending {
+            base_state,
+            pending_mask,
+            off,
+            min_rd,
+        }
+    }
 }
 
 pub trait Block3ExactStackContext<A, SS: StemStrategy, const K: usize>: Sized {
@@ -642,6 +681,58 @@ impl<A, SS, S> ScalarStackContext<A, S> for Block3SimdQueryStackContext<A, SS> {
     #[inline(always)]
     fn into_parts(self) -> (S, A, A) {
         unreachable!("SIMD stack contexts do not support scalar stack unpacking")
+    }
+}
+
+impl<A, S> ScalarStackContext<A, S> for CyclicSimdFullQueryStackContext<A, S> {
+    #[inline(always)]
+    fn from_parts(stem_state: S, old_off: A, rd: A) -> Self {
+        Self::Scalar {
+            stem_state,
+            restore_dim: None,
+            old_off,
+            rd,
+        }
+    }
+
+    #[inline(always)]
+    fn into_parts(self) -> (S, A, A) {
+        match self {
+            Self::Scalar {
+                stem_state,
+                old_off,
+                rd,
+                ..
+            } => (stem_state, old_off, rd),
+            Self::Pending { .. } => {
+                panic!("scalar stack unpack called on cyclic SIMD pending block")
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn from_parts_with_restore_dim(stem_state: S, restore_dim: usize, old_off: A, rd: A) -> Self {
+        Self::Scalar {
+            stem_state,
+            restore_dim: Some(restore_dim),
+            old_off,
+            rd,
+        }
+    }
+
+    #[inline(always)]
+    fn into_parts_with_restore_dim(self) -> (S, Option<usize>, A, A) {
+        match self {
+            Self::Scalar {
+                stem_state,
+                restore_dim,
+                old_off,
+                rd,
+            } => (stem_state, restore_dim, old_off, rd),
+            Self::Pending { .. } => {
+                panic!("scalar stack unpack called on cyclic SIMD pending block")
+            }
+        }
     }
 }
 

--- a/src/kd_tree/query_stack_simd.rs
+++ b/src/kd_tree/query_stack_simd.rs
@@ -67,8 +67,8 @@ pub enum Block3ExactStackContextState<A, SS, const K: usize> {
 /// Compact stack state for native cyclic SIMD-full traversal.
 ///
 /// Pending block entries retain the parent rectangle's per-axis query offsets.
-/// For squared Euclidean distance these four values completely describe the
-/// rectangle distance and are enough to derive every child offset in a block.
+/// These four values are enough for the metric-specific SIMD kernel to derive
+/// every child rectangle distance in a block.
 #[derive(Debug)]
 pub enum CyclicSimdFullQueryStackContext<A, S> {
     Scalar {
@@ -81,20 +81,34 @@ pub enum CyclicSimdFullQueryStackContext<A, S> {
         base_state: S,
         pending_mask: u16,
         off: [A; 4],
-        /// Exact minimum lower-bound distance in `pending_mask`, or zero when
-        /// the frame came from cheap near descent and has not been evaluated.
-        min_rd: A,
     },
 }
 
 impl<A, S> CyclicSimdFullQueryStackContext<A, S> {
     #[inline(always)]
-    pub fn pending(base_state: S, pending_mask: u16, off: [A; 4], min_rd: A) -> Self {
+    pub fn pending(base_state: S, pending_mask: u16, off: [A; 4]) -> Self {
         Self::Pending {
             base_state,
             pending_mask,
             off,
-            min_rd,
+        }
+    }
+
+    /// Extract a native cyclic SIMD-full pending frame without retaining the
+    /// scalar fallback variant in the hot control-flow graph.
+    ///
+    /// # Safety
+    ///
+    /// The value must be [`Self::Pending`].
+    #[inline(always)]
+    pub unsafe fn into_pending_unchecked(self) -> (S, u16, [A; 4]) {
+        match self {
+            Self::Pending {
+                base_state,
+                pending_mask,
+                off,
+            } => (base_state, pending_mask, off),
+            Self::Scalar { .. } => unsafe { core::hint::unreachable_unchecked() },
         }
     }
 }
@@ -341,6 +355,45 @@ impl<A, SS: StemStrategy, const INLINE_CAPACITY: usize> SimdQueryStack<A, SS, IN
     #[inline]
     pub fn pop(&mut self) -> Option<SS::StackContext<A>> {
         <Self as StackTrait<A, SS>>::pop(self)
+    }
+
+    /// Push directly into inline storage when the caller can prove that this
+    /// query can never exceed `INLINE_CAPACITY`.
+    ///
+    /// # Safety
+    ///
+    /// `self.len` must be less than `INLINE_CAPACITY`, and the stack must not
+    /// currently contain spill entries.
+    #[inline(always)]
+    pub(crate) unsafe fn push_inline_unchecked(&mut self, item: SS::StackContext<A>) {
+        debug_assert!(self.spill.is_empty());
+        debug_assert!(self.len < INLINE_CAPACITY);
+        unsafe { core::hint::assert_unchecked(self.len < INLINE_CAPACITY) };
+        unsafe { self.stack.get_unchecked_mut(self.len) }.write(item);
+        self.len += 1;
+
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        crate::results::exact_query_stats::record_simd_stack_len(self.len);
+    }
+
+    /// Pop directly from inline storage under the same no-spill invariant as
+    /// [`Self::push_inline_unchecked`].
+    ///
+    /// # Safety
+    ///
+    /// The stack must not contain spill entries and `self.len` must not exceed
+    /// `INLINE_CAPACITY`.
+    #[inline(always)]
+    pub(crate) unsafe fn pop_inline_unchecked(&mut self) -> Option<SS::StackContext<A>> {
+        debug_assert!(self.spill.is_empty());
+        debug_assert!(self.len <= INLINE_CAPACITY);
+        unsafe { core::hint::assert_unchecked(self.len <= INLINE_CAPACITY) };
+        if self.len == 0 {
+            None
+        } else {
+            self.len -= 1;
+            Some(unsafe { self.stack.get_unchecked(self.len).assume_init_read() })
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,9 @@ pub type DonnellyNoPf<const BH: usize> = stem_strategies::donnelly::DonnellyNoPf
 pub type DonnellyCyclicSimdDescent<const BH: usize> =
     stem_strategies::donnelly::DonnellyCyclicSimdDescent<BH>;
 #[doc(hidden)]
+pub type DonnellyCyclicSimdFull<const BH: usize> =
+    stem_strategies::donnelly::DonnellyCyclicSimdFull<BH>;
+#[doc(hidden)]
 pub type DonnellySimdDescent<const BH: usize> = stem_strategies::donnelly::DonnellySimdDescent<BH>;
 #[doc(hidden)]
 pub type DonnellySimdFull<const BH: usize> = stem_strategies::donnelly::DonnellySimdFull<BH>;

--- a/src/stem_strategy/donnelly/cyclic_simd_descent.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_descent.rs
@@ -147,6 +147,7 @@ fn scalar_prepared_path<A: PartialOrd + Copy, const BH: usize>(
     child
 }
 
+#[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
 #[inline(always)]
 fn block3_child_from_mask(mask: u8) -> u8 {
     let b0 = mask & 1;
@@ -155,8 +156,7 @@ fn block3_child_from_mask(mask: u8) -> u8 {
     (b0 << 2) | (b1 << 1) | b2
 }
 
-// TODO: can remove?
-#[allow(unused)]
+#[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
 #[inline(always)]
 fn block4_child_from_mask(mask: u16) -> u8 {
     let b0 = (mask & 1) as u8;

--- a/src/stem_strategy/donnelly/cyclic_simd_descent.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_descent.rs
@@ -11,12 +11,16 @@ use std::ptr::NonNull;
 
 use aligned_vec::AVec;
 
+use crate::dist::DistanceMetric;
+use crate::kd_tree::query_context::QueryContext;
 use crate::kd_tree::query_stack::{QueryStack, QueryStackContext};
+use crate::kd_tree::{KdTreeAccessor, KdTreeQueryOps};
 use crate::stem_strategy::donnelly::core::{
     leaf_idx_from_block_base, DonnellyCore, DonnellyCoreDeferred,
 };
+use crate::stem_strategy::SimdPrune;
 use crate::traits::stem_strategy::PreparedBlockQuery;
-use crate::{Axis, StemStrategy};
+use crate::{Axis, Content, LeafStrategy, StemStrategy};
 
 /// Type-specific cyclic block comparison used by [`Axis`].
 pub(crate) trait CyclicBlockCompare: Copy {
@@ -35,7 +39,7 @@ pub(crate) trait CyclicBlockCompare: Copy {
 }
 
 #[inline(always)]
-fn prepare_query_lanes<A: Axis<Coord = A>, const BH: usize, const K: usize>(
+pub(super) fn prepare_query_lanes<A: Axis<Coord = A>, const BH: usize, const K: usize>(
     query: &[A; K],
 ) -> PreparedBlockQuery<A, K> {
     assert!(K > 0);
@@ -282,22 +286,19 @@ pub struct DonnellyCyclicSimdDescent<const BH: usize> {
     core: DonnellyCore<BH>,
 }
 
-/// Experimental home for cyclic-axis SIMD descent plus block-level pruning.
-///
-/// A direct reuse of [`super::DonnellySimdFull`]'s pending mask is not sound:
-/// that kernel represents each terminal child as an interval on the block's
-/// single split axis, whereas cyclic terminal children are multi-axis
-/// rectangles. This initial implementation therefore deliberately shares the
-/// proven scalar continuation engine with [`DonnellyCyclicSimdDescent`]. It is
-/// a correctness and code-generation control, and a stable home for a future
-/// multi-axis pending-mask kernel, without risking false pruning meanwhile.
-#[derive(Copy, Clone, Debug)]
-pub struct DonnellyCyclicSimdFull<const BH: usize> {
-    core: DonnellyCore<BH>,
-}
-
 macro_rules! impl_cyclic_simd_descent {
-    ($strategy:ident, $bh:literal, $block_base_bias:literal) => {
+    (
+        $strategy:ident,
+        $bh:literal,
+        $block_base_bias:literal,
+        $stack_context:ty,
+        $stack_type:ty,
+        $tree:ident,
+        $query_ctx:ident,
+        $stack:ident,
+        $process_leaf:ident,
+        $arithmetic:block
+    ) => {
         impl StemStrategy for $strategy<$bh> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $bh;
@@ -307,8 +308,8 @@ macro_rules! impl_cyclic_simd_descent {
             const USES_PREPARED_BLOCK_QUERY: bool = true;
 
             type DeferredState = DonnellyCoreDeferred;
-            type StackContext<A> = QueryStackContext<A, Self::DeferredState>;
-            type Stack<A> = QueryStack<A, Self>;
+            type StackContext<A> = $stack_context;
+            type Stack<A> = $stack_type;
 
             #[inline(always)]
             fn new(stems_ptr: NonNull<u8>) -> Self {
@@ -495,15 +496,71 @@ macro_rules! impl_cyclic_simd_descent {
                 }
                 ordering.leaf_idx()
             }
+
+            #[inline(always)]
+            fn arithmetic_query_with_scratch<
+                Tree,
+                A,
+                T,
+                O,
+                D,
+                QC,
+                LS,
+                const K2: usize,
+                const B: usize,
+            >(
+                $tree: &Tree,
+                $query_ctx: &mut QC,
+                $stack: &mut Self::Stack<O>,
+                $process_leaf: impl FnMut(usize, &[O; K2], &mut QC),
+            ) where
+                Self: Sized,
+                Tree: KdTreeAccessor<A, T, Self, LS, K2, B>
+                    + KdTreeQueryOps<A, T, Self, LS, K2, B>,
+                A: Axis<Coord = A>,
+                T: Content,
+                O: Axis<Coord = O>
+                    + SimdPrune
+                    + crate::stem_strategy::SimdSelectBestChildBlock3
+                    + super::simd_full::BacktrackBlock3
+                    + super::simd_full::BacktrackBlock4,
+                D: DistanceMetric<A, Output = O>,
+                QC: QueryContext<A, O, K2>,
+                LS: LeafStrategy<A, T, Self, K2, B>,
+                Self::Stack<O>: crate::kd_tree::query_stack::StackTrait<O, Self>,
+            $arithmetic
         }
     };
 }
 
-impl_cyclic_simd_descent!(DonnellyCyclicSimdDescent, 3, 1);
-impl_cyclic_simd_descent!(DonnellyCyclicSimdDescent, 4, 7);
-impl_cyclic_simd_descent!(DonnellyCyclicSimdFull, 3, 1);
-impl_cyclic_simd_descent!(DonnellyCyclicSimdFull, 4, 7);
-
+impl_cyclic_simd_descent!(
+    DonnellyCyclicSimdDescent,
+    3,
+    1,
+    QueryStackContext<A, Self::DeferredState>,
+    QueryStack<A, Self>,
+    tree,
+    query_ctx,
+    stack,
+    process_leaf,
+    {
+        tree.arithmetic_query_with_scratch_impl::<QC, O, D>(query_ctx, stack, process_leaf);
+    }
+);
+impl_cyclic_simd_descent!(
+    DonnellyCyclicSimdDescent,
+    4,
+    7,
+    QueryStackContext<A, Self::DeferredState>,
+    QueryStack<A, Self>,
+    tree,
+    query_ctx,
+    stack,
+    process_leaf,
+    {
+        tree.arithmetic_query_with_scratch_impl::<QC, O, D>(query_ctx, stack, process_leaf);
+    }
+);
 #[cfg(feature = "cargo_asm")]
 mod cargo_asm {
     use super::{prepare_query_lanes, MaybeUninit, PreparedBlockQuery};

--- a/src/stem_strategy/donnelly/cyclic_simd_descent.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_descent.rs
@@ -2,9 +2,11 @@
 //!
 //! Unlike [`super::DonnellySimdDescent`], this strategy preserves the ordinary
 //! per-level axis cadence. Its SIMD query vector therefore mirrors the heap
-//! levels in a block: `X, YY, ZZZZ` for `f64`/3D/block-height 3 and
-//! `X, YY, ZZZZ, WWWWWWWW` for `f32`/4D/block-height 4.
+//! levels in a block. For a block beginning at dimension `d`, the query lanes
+//! are `d, (d+1)(d+1), (d+2)(d+2)(d+2)(d+2)` for block height 3, and the
+//! analogous 1/2/4/8 pattern for block height 4. Dimensions wrap modulo `K`.
 
+use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 
 use aligned_vec::AVec;
@@ -13,6 +15,7 @@ use crate::kd_tree::query_stack::{QueryStack, QueryStackContext};
 use crate::stem_strategy::donnelly::core::{
     leaf_idx_from_block_base, DonnellyCore, DonnellyCoreDeferred,
 };
+use crate::traits::stem_strategy::PreparedBlockQuery;
 use crate::{Axis, StemStrategy};
 
 /// Type-specific cyclic block comparison used by [`Axis`].
@@ -23,6 +26,75 @@ pub(crate) trait CyclicBlockCompare: Copy {
         block_base_idx: usize,
         start_dim: usize,
     ) -> u8;
+
+    fn compare_prepared_cyclic_block<const BH: usize>(
+        stems: &[Self],
+        query_lanes: &[MaybeUninit<Self>; 16],
+        block_base_idx: usize,
+    ) -> u8;
+}
+
+#[inline(always)]
+fn prepare_query_lanes<A: Axis<Coord = A>, const BH: usize, const K: usize>(
+    query: &[A; K],
+) -> PreparedBlockQuery<A, K> {
+    assert!(K > 0);
+    let mut phases = PreparedBlockQuery([[MaybeUninit::uninit(); 16]; K]);
+    let mut phase = 0usize;
+    loop {
+        let dim1 = if phase + 1 == K { 0 } else { phase + 1 };
+        let dim2 = if dim1 + 1 == K { 0 } else { dim1 + 1 };
+        let q0 = query[phase];
+        let q1 = query[dim1];
+        let q2 = query[dim2];
+        if BH == 3 {
+            phases.0[phase] = [
+                MaybeUninit::new(q0),
+                MaybeUninit::new(q1),
+                MaybeUninit::new(q1),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+                MaybeUninit::uninit(),
+            ];
+        } else {
+            assert!(BH == 4, "cyclic SIMD preparation requires BH=3 or BH=4");
+            let dim3 = if dim2 + 1 == K { 0 } else { dim2 + 1 };
+            let q3 = query[dim3];
+            phases.0[phase] = [
+                MaybeUninit::new(q0),
+                MaybeUninit::new(q1),
+                MaybeUninit::new(q1),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q2),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+                MaybeUninit::new(q3),
+            ];
+        }
+        phase = (phase + BH) % K;
+        if phase == 0 {
+            break;
+        }
+    }
+    phases
 }
 
 #[inline(always)]
@@ -50,6 +122,28 @@ fn scalar_path<A: PartialOrd + Copy, const BH: usize, const K: usize>(
 // TODO: can remove?
 #[allow(unused)]
 #[inline(always)]
+#[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
+fn scalar_prepared_path<A: PartialOrd + Copy, const BH: usize>(
+    stems: &[A],
+    query_lanes: &[MaybeUninit<A>; 16],
+    block_base_idx: usize,
+) -> u8 {
+    let mut heap_idx = 0usize;
+    let mut child = 0u8;
+    let mut depth = 0usize;
+    while depth < BH {
+        let is_right = unsafe {
+            query_lanes.get_unchecked(heap_idx).assume_init()
+                >= *stems.get_unchecked(block_base_idx + heap_idx)
+        };
+        child = (child << 1) | is_right as u8;
+        heap_idx = (heap_idx << 1) + 1 + is_right as usize;
+        depth += 1;
+    }
+    child
+}
+
+#[inline(always)]
 fn block3_child_from_mask(mask: u8) -> u8 {
     let b0 = mask & 1;
     let b1 = (mask >> (1 + b0)) & 1;
@@ -76,17 +170,20 @@ impl CyclicBlockCompare for f64 {
         block_base_idx: usize,
         start_dim: usize,
     ) -> u8 {
-        assert!(BH == 3 && K == 3, "f64 cyclic SIMD requires BH=3 and K=3");
-        debug_assert_eq!(start_dim, 0);
+        assert!(BH == 3, "f64 cyclic SIMD requires BH=3");
+        assert!(K > 0, "cyclic SIMD requires at least one dimension");
+        debug_assert!(start_dim < K);
 
         #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
         unsafe {
             use std::arch::x86_64::*;
 
-            let query_xyz = _mm256_maskz_loadu_pd(0b0111, query.as_ptr());
-            let repeated = _mm512_broadcast_f64x4(query_xyz);
-            let lane_indices = _mm512_set_epi64(2, 2, 2, 2, 2, 1, 1, 0);
-            let query_lanes = _mm512_permutexvar_pd(lane_indices, repeated);
+            let dim1 = if start_dim + 1 == K { 0 } else { start_dim + 1 };
+            let dim2 = if dim1 + 1 == K { 0 } else { dim1 + 1 };
+            let q0 = *query.get_unchecked(start_dim);
+            let q1 = *query.get_unchecked(dim1);
+            let q2 = *query.get_unchecked(dim2);
+            let query_lanes = _mm512_set_pd(q2, q2, q2, q2, q2, q1, q1, q0);
             let pivots = _mm512_loadu_pd(stems.as_ptr().add(block_base_idx));
             let mask = _mm512_cmp_pd_mask(query_lanes, pivots, _CMP_GE_OQ);
             block3_child_from_mask(mask)
@@ -94,6 +191,27 @@ impl CyclicBlockCompare for f64 {
 
         #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
         scalar_path::<Self, BH, K>(stems, query, block_base_idx, start_dim)
+    }
+
+    #[inline(always)]
+    fn compare_prepared_cyclic_block<const BH: usize>(
+        stems: &[Self],
+        query_lanes: &[MaybeUninit<Self>; 16],
+        block_base_idx: usize,
+    ) -> u8 {
+        assert!(BH == 3, "f64 cyclic SIMD requires BH=3");
+
+        #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+        unsafe {
+            use std::arch::x86_64::*;
+
+            let prepared = _mm512_loadu_pd(query_lanes.as_ptr().cast());
+            let pivots = _mm512_loadu_pd(stems.as_ptr().add(block_base_idx));
+            return block3_child_from_mask(_mm512_cmp_pd_mask(prepared, pivots, _CMP_GE_OQ));
+        }
+
+        #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
+        scalar_prepared_path::<Self, BH>(stems, query_lanes, block_base_idx)
     }
 }
 
@@ -105,17 +223,24 @@ impl CyclicBlockCompare for f32 {
         block_base_idx: usize,
         start_dim: usize,
     ) -> u8 {
-        assert!(BH == 4 && K == 4, "f32 cyclic SIMD requires BH=4 and K=4");
-        debug_assert_eq!(start_dim, 0);
+        assert!(BH == 4, "f32 cyclic SIMD requires BH=4");
+        assert!(K > 0, "cyclic SIMD requires at least one dimension");
+        debug_assert!(start_dim < K);
 
         #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
         unsafe {
             use std::arch::x86_64::*;
 
-            let query_xyzw = _mm_loadu_ps(query.as_ptr());
-            let repeated = _mm512_broadcast_f32x4(query_xyzw);
-            let lane_indices = _mm512_set_epi32(3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 1, 1, 0);
-            let query_lanes = _mm512_permutexvar_ps(lane_indices, repeated);
+            let dim1 = if start_dim + 1 == K { 0 } else { start_dim + 1 };
+            let dim2 = if dim1 + 1 == K { 0 } else { dim1 + 1 };
+            let dim3 = if dim2 + 1 == K { 0 } else { dim2 + 1 };
+            let q0 = *query.get_unchecked(start_dim);
+            let q1 = *query.get_unchecked(dim1);
+            let q2 = *query.get_unchecked(dim2);
+            let q3 = *query.get_unchecked(dim3);
+            let query_lanes = _mm512_set_ps(
+                q3, q3, q3, q3, q3, q3, q3, q3, q3, q2, q2, q2, q2, q1, q1, q0,
+            );
             let pivots = _mm512_loadu_ps(stems.as_ptr().add(block_base_idx));
             let mask = _mm512_cmp_ps_mask(query_lanes, pivots, _CMP_GE_OQ);
             block4_child_from_mask(mask)
@@ -124,26 +249,62 @@ impl CyclicBlockCompare for f32 {
         #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
         scalar_path::<Self, BH, K>(stems, query, block_base_idx, start_dim)
     }
+
+    #[inline(always)]
+    fn compare_prepared_cyclic_block<const BH: usize>(
+        stems: &[Self],
+        query_lanes: &[MaybeUninit<Self>; 16],
+        block_base_idx: usize,
+    ) -> u8 {
+        assert!(BH == 4, "f32 cyclic SIMD requires BH=4");
+
+        #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+        unsafe {
+            use std::arch::x86_64::*;
+
+            let prepared = _mm512_loadu_ps(query_lanes.as_ptr().cast());
+            let pivots = _mm512_loadu_ps(stems.as_ptr().add(block_base_idx));
+            return block4_child_from_mask(_mm512_cmp_ps_mask(prepared, pivots, _CMP_GE_OQ));
+        }
+
+        #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
+        scalar_prepared_path::<Self, BH>(stems, query_lanes, block_base_idx)
+    }
 }
 
 /// Donnelly block-at-once descent with the ordinary per-level axis cadence.
 ///
-/// AVX-512 acceleration is currently restricted to `f64`/3D/BH3 and
-/// `f32`/4D/BH4. Other type/dimension combinations are not supported by this
-/// experimental strategy.
+/// AVX-512 acceleration uses a block-height-3 specialization for `f64` and a
+/// block-height-4 specialization for `f32`. The dimension count is independent
+/// of the block height; blocks carry their cyclic start phase explicitly.
 #[derive(Copy, Clone, Debug)]
 pub struct DonnellyCyclicSimdDescent<const BH: usize> {
     core: DonnellyCore<BH>,
 }
 
+/// Experimental home for cyclic-axis SIMD descent plus block-level pruning.
+///
+/// A direct reuse of [`super::DonnellySimdFull`]'s pending mask is not sound:
+/// that kernel represents each terminal child as an interval on the block's
+/// single split axis, whereas cyclic terminal children are multi-axis
+/// rectangles. This initial implementation therefore deliberately shares the
+/// proven scalar continuation engine with [`DonnellyCyclicSimdDescent`]. It is
+/// a correctness and code-generation control, and a stable home for a future
+/// multi-axis pending-mask kernel, without risking false pruning meanwhile.
+#[derive(Copy, Clone, Debug)]
+pub struct DonnellyCyclicSimdFull<const BH: usize> {
+    core: DonnellyCore<BH>,
+}
+
 macro_rules! impl_cyclic_simd_descent {
-    ($bh:literal, $block_base_bias:literal) => {
-        impl StemStrategy for DonnellyCyclicSimdDescent<$bh> {
+    ($strategy:ident, $bh:literal, $block_base_bias:literal) => {
+        impl StemStrategy for $strategy<$bh> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $bh;
             const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
             const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;
             const USES_SIMD_BLOCK_DESCENT: bool = true;
+            const USES_PREPARED_BLOCK_QUERY: bool = true;
 
             type DeferredState = DonnellyCoreDeferred;
             type StackContext<A> = QueryStackContext<A, Self::DeferredState>;
@@ -189,6 +350,28 @@ macro_rules! impl_cyclic_simd_descent {
                 start_dim: usize,
             ) -> u8 {
                 A::compare_cyclic_block::<$bh, K>(stems, query, self.stem_idx(), start_dim)
+            }
+
+            #[inline(always)]
+            fn prepare_block_query<A: Axis<Coord = A>, const K: usize>(
+                query: &[A; K],
+            ) -> PreparedBlockQuery<A, K> {
+                prepare_query_lanes::<A, $bh, K>(query)
+            }
+
+            #[inline(always)]
+            fn select_prepared_block_child<A: Axis<Coord = A>, const K: usize>(
+                &self,
+                stems: &[A],
+                _query: &[A; K],
+                prepared: &PreparedBlockQuery<A, K>,
+                start_dim: usize,
+            ) -> u8 {
+                A::compare_prepared_cyclic_block::<$bh>(
+                    stems,
+                    &prepared[start_dim],
+                    self.stem_idx(),
+                )
             }
 
             #[inline(always)]
@@ -283,15 +466,21 @@ macro_rules! impl_cyclic_simd_descent {
             ) -> usize {
                 let total_levels = (max_stem_level + 1).max(0) as usize;
                 let native_bh = (64 / A::VALUE_WIDTH_BYTES as u32).ilog2() as usize;
-                if native_bh == $bh && K == $bh && total_levels.is_multiple_of($bh) {
+                if native_bh == $bh && total_levels.is_multiple_of($bh) {
                     let mut block_base = 0u32;
+                    let mut start_dim = 0usize;
+                    let prepared = prepare_query_lanes::<A, $bh, K>(query);
                     for _ in 0..(total_levels / $bh) {
-                        let child =
-                            A::compare_cyclic_block::<$bh, K>(stems, query, block_base as usize, 0);
+                        let child = A::compare_prepared_cyclic_block::<$bh>(
+                            stems,
+                            &prepared[start_dim],
+                            block_base as usize,
+                        );
                         block_base = block_base
                             .wrapping_add($block_base_bias)
                             .wrapping_add(child as u32)
                             .wrapping_shl($bh as u32);
+                        start_dim = (start_dim + $bh) % K;
                     }
                     return leaf_idx_from_block_base::<$bh>(block_base, total_levels);
                 }
@@ -310,11 +499,14 @@ macro_rules! impl_cyclic_simd_descent {
     };
 }
 
-impl_cyclic_simd_descent!(3, 1);
-impl_cyclic_simd_descent!(4, 7);
+impl_cyclic_simd_descent!(DonnellyCyclicSimdDescent, 3, 1);
+impl_cyclic_simd_descent!(DonnellyCyclicSimdDescent, 4, 7);
+impl_cyclic_simd_descent!(DonnellyCyclicSimdFull, 3, 1);
+impl_cyclic_simd_descent!(DonnellyCyclicSimdFull, 4, 7);
 
 #[cfg(feature = "cargo_asm")]
 mod cargo_asm {
+    use super::{prepare_query_lanes, MaybeUninit, PreparedBlockQuery};
     use crate::Axis;
 
     #[inline(never)]
@@ -336,11 +528,44 @@ mod cargo_asm {
     ) -> u8 {
         <f32 as Axis>::compare_cyclic_block::<4, 4>(stems, query, block_base, 0)
     }
+
+    #[inline(never)]
+    #[unsafe(no_mangle)]
+    pub fn donnelly_cyclic_block3_f64_prepared_cargo_asm_hook(
+        stems: &[f64],
+        query_lanes: &[MaybeUninit<f64>; 16],
+        block_base: usize,
+    ) -> u8 {
+        <f64 as Axis>::compare_prepared_cyclic_block::<3>(stems, query_lanes, block_base)
+    }
+
+    #[inline(never)]
+    #[unsafe(no_mangle)]
+    pub fn donnelly_cyclic_prepare_f64_k4_cargo_asm_hook(
+        query: &[f64; 4],
+    ) -> PreparedBlockQuery<f64, 4> {
+        prepare_query_lanes::<f64, 3, 4>(query)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn scalar_reference<A: PartialOrd + Copy, const BH: usize, const K: usize>(
+        stems: &[A],
+        query: &[A; K],
+        start_dim: usize,
+    ) -> u8 {
+        let mut heap_idx = 0usize;
+        let mut child = 0u8;
+        for depth in 0..BH {
+            let is_right = query[(start_dim + depth) % K] >= stems[heap_idx];
+            child = (child << 1) | is_right as u8;
+            heap_idx = (heap_idx << 1) + 1 + is_right as usize;
+        }
+        child
+    }
 
     #[test]
     fn f64_block3_mask_follows_xyz_path() {
@@ -377,5 +602,56 @@ mod tests {
             <f32 as Axis>::compare_cyclic_block::<4, 4>(&stems, &query, 0, 0),
             0b1011
         );
+    }
+
+    #[test]
+    fn f64_block3_honours_every_k4_start_phase() {
+        let stems = [0.5, 0.25, 0.75, 0.1, 0.4, 0.6, 0.9, f64::INFINITY];
+        let query = [0.8, 0.2, 0.7, 0.35];
+        let prepared = prepare_query_lanes::<f64, 3, 4>(&query);
+        for start_dim in 0..4 {
+            assert_eq!(
+                <f64 as Axis>::compare_cyclic_block::<3, 4>(&stems, &query, 0, start_dim,),
+                scalar_reference::<_, 3, 4>(&stems, &query, start_dim),
+            );
+            assert_eq!(
+                <f64 as Axis>::compare_prepared_cyclic_block::<3>(&stems, &prepared[start_dim], 0,),
+                scalar_reference::<_, 3, 4>(&stems, &query, start_dim),
+            );
+        }
+    }
+
+    #[test]
+    fn f32_block4_honours_every_k3_start_phase() {
+        let stems = [
+            0.5,
+            0.25,
+            0.75,
+            0.1,
+            0.4,
+            0.6,
+            0.9,
+            0.05,
+            0.2,
+            0.3,
+            0.45,
+            0.55,
+            0.7,
+            0.8,
+            0.95,
+            f32::INFINITY,
+        ];
+        let query = [0.8, 0.2, 0.7];
+        let prepared = prepare_query_lanes::<f32, 4, 3>(&query);
+        for start_dim in 0..3 {
+            assert_eq!(
+                <f32 as Axis>::compare_cyclic_block::<4, 3>(&stems, &query, 0, start_dim,),
+                scalar_reference::<_, 4, 3>(&stems, &query, start_dim),
+            );
+            assert_eq!(
+                <f32 as Axis>::compare_prepared_cyclic_block::<4>(&stems, &prepared[start_dim], 0,),
+                scalar_reference::<_, 4, 3>(&stems, &query, start_dim),
+            );
+        }
     }
 }

--- a/src/stem_strategy/donnelly/cyclic_simd_full.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_full.rs
@@ -1,0 +1,1135 @@
+//! Cyclic-axis SIMD descent with block-level SIMD pruning and backtracking.
+
+use std::any::TypeId;
+use std::ptr::NonNull;
+
+use aligned_vec::AVec;
+
+use crate::dist::DistanceMetric;
+#[cfg(all(feature = "simd", target_feature = "avx512f"))]
+use crate::dist::{
+    distance_metric_avx512::{
+        Avx512F32LeafOps, Avx512F64LeafOps, UnsupportedAvx512F32LeafOps,
+        UnsupportedAvx512F64LeafOps,
+    },
+    DistanceMetricAvx512,
+};
+use crate::kd_tree::query_context::QueryContext;
+use crate::kd_tree::query_stack::StackTrait;
+use crate::kd_tree::query_stack_simd::{
+    CyclicSimdFullQueryStackContext, SimdQueryStack, CYCLIC_SIMD_FULL_INLINE_QUERY_STACK_CAPACITY,
+};
+use crate::kd_tree::{KdTreeAccessor, KdTreeQueryOps};
+use crate::stem_strategy::donnelly::core::{
+    leaf_idx_from_block_base, DonnellyCore, DonnellyCoreDeferred,
+};
+use crate::stem_strategy::SimdPrune;
+use crate::traits::stem_strategy::PreparedBlockQuery;
+use crate::{Axis, Content, LeafStrategy, StemStrategy};
+
+use super::cyclic_simd_descent::prepare_query_lanes;
+
+#[derive(Clone, Copy, Debug)]
+struct CyclicChildSelection<O> {
+    child_idx: u8,
+    remaining_mask: u16,
+    remaining_min_rd: O,
+    child_off: [O; 4],
+}
+
+#[inline(always)]
+fn selected_cyclic_child_offsets<A, O, D, const K: usize, const BH: usize>(
+    stems: &[A],
+    block_base_idx: usize,
+    query: &[A; K],
+    parent_off: &[O; 4],
+    child_idx: u8,
+) -> Option<([O; 4], O)>
+where
+    A: Axis<Coord = A>,
+    O: Axis<Coord = O>,
+    D: DistanceMetric<A, Output = O>,
+{
+    debug_assert_eq!(K, BH);
+    debug_assert!(K <= 4);
+
+    let mut child_off = *parent_off;
+    let mut heap_idx = 0usize;
+    let mut depth = 0usize;
+    while depth < BH {
+        let goes_right = ((child_idx >> (BH - 1 - depth)) & 1) != 0;
+        let pivot = unsafe { *stems.get_unchecked(block_base_idx + heap_idx) };
+        if A::is_max_value(pivot) {
+            if goes_right {
+                return None;
+            }
+        } else {
+            let query_value = unsafe { *query.get_unchecked(depth) };
+            let query_goes_right = query_value >= pivot;
+            if goes_right != query_goes_right {
+                child_off[depth] =
+                    O::saturating_dist(D::widen_coord(query_value), D::widen_coord(pivot));
+            }
+        }
+        heap_idx = (heap_idx << 1) + 1 + goes_right as usize;
+        depth += 1;
+    }
+
+    let rd = D::rect_dist_from_off(unsafe { &*child_off.as_ptr().cast::<[O; K]>() });
+    Some((child_off, rd))
+}
+
+#[inline(always)]
+fn select_cyclic_child_scalar<A, O, D, const K: usize, const BH: usize>(
+    stems: &[A],
+    block_base_idx: usize,
+    query: &[A; K],
+    parent_off: &[O; 4],
+    pending_mask: u16,
+    max_dist: O,
+    prune_equal: bool,
+) -> Option<CyclicChildSelection<O>>
+where
+    A: Axis<Coord = A>,
+    O: Axis<Coord = O>,
+    D: DistanceMetric<A, Output = O>,
+{
+    let mut candidate_mask = 0u16;
+    let mut rd_values = [O::max_value(); 16];
+    let mut off_values = [[O::zero(); 4]; 16];
+    let mut remaining = pending_mask;
+    while remaining != 0 {
+        let child = remaining.trailing_zeros() as usize;
+        remaining &= remaining - 1;
+        if let Some((child_off, rd)) = selected_cyclic_child_offsets::<A, O, D, K, BH>(
+            stems,
+            block_base_idx,
+            query,
+            parent_off,
+            child as u8,
+        ) {
+            let ordering = O::cmp(rd, max_dist);
+            let survives = ordering == std::cmp::Ordering::Less
+                || (!prune_equal && ordering == std::cmp::Ordering::Equal);
+            if survives {
+                candidate_mask |= 1u16 << child;
+                rd_values[child] = rd;
+                off_values[child] = child_off;
+            }
+        }
+    }
+
+    if candidate_mask == 0 {
+        return None;
+    }
+    let mut live = candidate_mask;
+    let mut best = live.trailing_zeros() as usize;
+    live &= live - 1;
+    while live != 0 {
+        let child = live.trailing_zeros() as usize;
+        live &= live - 1;
+        if O::cmp(rd_values[child], rd_values[best]) == std::cmp::Ordering::Less {
+            best = child;
+        }
+    }
+    let remaining_mask = candidate_mask & !(1u16 << best);
+    let mut remaining_min_rd = O::max_value();
+    let mut live = remaining_mask;
+    while live != 0 {
+        let child = live.trailing_zeros() as usize;
+        live &= live - 1;
+        if O::cmp(rd_values[child], remaining_min_rd) == std::cmp::Ordering::Less {
+            remaining_min_rd = rd_values[child];
+        }
+    }
+    Some(CyclicChildSelection {
+        child_idx: best as u8,
+        remaining_mask,
+        remaining_min_rd,
+        child_off: off_values[best],
+    })
+}
+
+#[cfg(all(
+    feature = "simd",
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "fma"
+))]
+#[inline(always)]
+unsafe fn cyclic_axis_offsets_f64(
+    pivots: std::arch::x86_64::__m512d,
+    right_mask: u8,
+    query: f64,
+    parent_off: f64,
+) -> (std::arch::x86_64::__m512d, u8) {
+    use std::arch::x86_64::*;
+
+    let query = _mm512_set1_pd(query);
+    let query_right = _mm512_cmp_pd_mask(query, pivots, _CMP_GE_OQ);
+    let opposite = right_mask ^ query_right;
+    let diff = _mm512_max_pd(_mm512_sub_pd(query, pivots), _mm512_sub_pd(pivots, query));
+    let off = _mm512_mask_mov_pd(_mm512_set1_pd(parent_off), opposite, diff);
+    let real_pivot = _mm512_cmp_pd_mask(pivots, _mm512_set1_pd(f64::INFINITY), _CMP_LT_OQ);
+    (off, (!right_mask) | real_pivot)
+}
+
+#[cfg(all(
+    feature = "simd",
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "fma"
+))]
+#[inline(always)]
+unsafe fn select_cyclic_block3_f64<Ops: Avx512F64LeafOps>(
+    stems: *const f64,
+    block_base_idx: usize,
+    query: *const f64,
+    parent_off: *const f64,
+    pending_mask: u16,
+    max_dist: f64,
+    prune_equal: bool,
+    child_off: *mut f64,
+    remaining_min_rd: *mut f64,
+) -> u32 {
+    use std::arch::x86_64::*;
+
+    let block = _mm512_loadu_pd(stems.add(block_base_idx));
+    let x = _mm512_permutexvar_pd(_mm512_setzero_si512(), block);
+    let y = _mm512_permutexvar_pd(_mm512_set_epi64(2, 2, 2, 2, 1, 1, 1, 1), block);
+    let z = _mm512_permutexvar_pd(_mm512_set_epi64(6, 6, 5, 5, 4, 4, 3, 3), block);
+
+    let (off_x, valid_x) = cyclic_axis_offsets_f64(x, 0xf0, *query, *parent_off);
+    let (off_y, valid_y) = cyclic_axis_offsets_f64(y, 0xcc, *query.add(1), *parent_off.add(1));
+    let (off_z, valid_z) = cyclic_axis_offsets_f64(z, 0xaa, *query.add(2), *parent_off.add(2));
+    let rd = Ops::rect_dist_f64x8_3(off_x, off_y, off_z);
+    let threshold = _mm512_set1_pd(max_dist);
+    let within = if prune_equal {
+        _mm512_cmp_pd_mask(rd, threshold, _CMP_LT_OQ)
+    } else {
+        _mm512_cmp_pd_mask(rd, threshold, _CMP_LE_OQ)
+    };
+    let candidates = (pending_mask as u8) & valid_x & valid_y & valid_z & within;
+    if candidates == 0 {
+        return u32::MAX;
+    }
+
+    let child = if CYCLIC_FULL_SELECT_MIN_RD_CHILD {
+        let min_rd = _mm512_mask_reduce_min_pd(candidates, rd);
+        let best_mask = candidates & _mm512_cmp_pd_mask(rd, _mm512_set1_pd(min_rd), _CMP_EQ_OQ);
+        best_mask.trailing_zeros() as u8
+    } else {
+        candidates.trailing_zeros() as u8
+    };
+    let chosen_mask = 1u8 << child;
+    let lane = _mm512_set1_epi64(i64::from(child));
+    *child_off = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_x)));
+    *child_off.add(1) = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_y)));
+    *child_off.add(2) = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_z)));
+    *child_off.add(3) = 0.0;
+
+    let remaining = candidates & !chosen_mask;
+    *remaining_min_rd = if !CYCLIC_FULL_CACHE_REMAINING_MIN_RD {
+        0.0
+    } else if remaining == 0 {
+        f64::INFINITY
+    } else {
+        _mm512_mask_reduce_min_pd(remaining, rd)
+    };
+    u32::from(child) | (u32::from(remaining) << 8)
+}
+
+#[cfg(all(
+    feature = "simd",
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "fma"
+))]
+#[inline(always)]
+unsafe fn cyclic_axis_offsets_f32(
+    pivots: std::arch::x86_64::__m512,
+    right_mask: u16,
+    query: f32,
+    parent_off: f32,
+) -> (std::arch::x86_64::__m512, u16) {
+    use std::arch::x86_64::*;
+
+    let query = _mm512_set1_ps(query);
+    let query_right = _mm512_cmp_ps_mask(query, pivots, _CMP_GE_OQ);
+    let opposite = right_mask ^ query_right;
+    let diff = _mm512_max_ps(_mm512_sub_ps(query, pivots), _mm512_sub_ps(pivots, query));
+    let off = _mm512_mask_mov_ps(_mm512_set1_ps(parent_off), opposite, diff);
+    let real_pivot = _mm512_cmp_ps_mask(pivots, _mm512_set1_ps(f32::INFINITY), _CMP_LT_OQ);
+    (off, (!right_mask) | real_pivot)
+}
+
+#[cfg(all(
+    feature = "simd",
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "fma"
+))]
+#[inline(always)]
+unsafe fn select_cyclic_block4_f32<Ops: Avx512F32LeafOps>(
+    stems: *const f32,
+    block_base_idx: usize,
+    query: *const f32,
+    parent_off: *const f32,
+    pending_mask: u16,
+    max_dist: f32,
+    prune_equal: bool,
+    child_off: *mut f32,
+    remaining_min_rd: *mut f32,
+) -> u32 {
+    use std::arch::x86_64::*;
+
+    let block = _mm512_loadu_ps(stems.add(block_base_idx));
+    let x = _mm512_permutexvar_ps(_mm512_setzero_si512(), block);
+    let y = _mm512_permutexvar_ps(
+        _mm512_set_epi32(2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1),
+        block,
+    );
+    let z = _mm512_permutexvar_ps(
+        _mm512_set_epi32(6, 6, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3, 3),
+        block,
+    );
+    let w = _mm512_permutexvar_ps(
+        _mm512_set_epi32(14, 14, 13, 13, 12, 12, 11, 11, 10, 10, 9, 9, 8, 8, 7, 7),
+        block,
+    );
+
+    let (off_x, valid_x) = cyclic_axis_offsets_f32(x, 0xff00, *query, *parent_off);
+    let (off_y, valid_y) = cyclic_axis_offsets_f32(y, 0xf0f0, *query.add(1), *parent_off.add(1));
+    let (off_z, valid_z) = cyclic_axis_offsets_f32(z, 0xcccc, *query.add(2), *parent_off.add(2));
+    let (off_w, valid_w) = cyclic_axis_offsets_f32(w, 0xaaaa, *query.add(3), *parent_off.add(3));
+    let rd = Ops::rect_dist_f32x16_4(off_x, off_y, off_z, off_w);
+    let threshold = _mm512_set1_ps(max_dist);
+    let within = if prune_equal {
+        _mm512_cmp_ps_mask(rd, threshold, _CMP_LT_OQ)
+    } else {
+        _mm512_cmp_ps_mask(rd, threshold, _CMP_LE_OQ)
+    };
+    let candidates = pending_mask & valid_x & valid_y & valid_z & valid_w & within;
+    if candidates == 0 {
+        return u32::MAX;
+    }
+
+    let child = if CYCLIC_FULL_SELECT_MIN_RD_CHILD {
+        let min_rd = _mm512_mask_reduce_min_ps(candidates, rd);
+        let best_mask = candidates & _mm512_cmp_ps_mask(rd, _mm512_set1_ps(min_rd), _CMP_EQ_OQ);
+        best_mask.trailing_zeros() as u8
+    } else {
+        candidates.trailing_zeros() as u8
+    };
+    let chosen_mask = 1u16 << child;
+    let lane = _mm512_set1_epi32(i32::from(child));
+    *child_off = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_x)));
+    *child_off.add(1) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_y)));
+    *child_off.add(2) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_z)));
+    *child_off.add(3) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_w)));
+
+    let remaining = candidates & !chosen_mask;
+    *remaining_min_rd = if !CYCLIC_FULL_CACHE_REMAINING_MIN_RD {
+        0.0
+    } else if remaining == 0 {
+        f32::INFINITY
+    } else {
+        _mm512_mask_reduce_min_ps(remaining, rd)
+    };
+    u32::from(child) | (u32::from(remaining) << 8)
+}
+
+#[inline(always)]
+fn select_cyclic_child<A, O, D, const K: usize, const BH: usize>(
+    stems: &[A],
+    block_base_idx: usize,
+    query: &[A; K],
+    parent_off: &[O; 4],
+    pending_mask: u16,
+    max_dist: O,
+    prune_equal: bool,
+) -> Option<CyclicChildSelection<O>>
+where
+    A: Axis<Coord = A>,
+    O: Axis<Coord = O>,
+    D: DistanceMetric<A, Output = O>,
+{
+    #[cfg(all(
+        feature = "simd",
+        target_arch = "x86_64",
+        target_feature = "avx512f",
+        target_feature = "fma"
+    ))]
+    unsafe {
+        // SAFETY: TypeId proves both stored coordinates and widened output have
+        // the exact primitive representation expected by the selected kernel.
+        // The K/BH guards prove the fixed query and bounds lengths it reads.
+        if K == 3
+            && BH == 3
+            && TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<O>() == TypeId::of::<f64>()
+            && TypeId::of::<<D as DistanceMetricAvx512<A>>::Avx512F64Ops>()
+                != TypeId::of::<UnsupportedAvx512F64LeafOps>()
+        {
+            let mut child_off = [O::zero(); 4];
+            let mut remaining_min_rd = O::max_value();
+            let packed = select_cyclic_block3_f64::<<D as DistanceMetricAvx512<A>>::Avx512F64Ops>(
+                stems.as_ptr().cast(),
+                block_base_idx,
+                query.as_ptr().cast(),
+                parent_off.as_ptr().cast(),
+                pending_mask,
+                *(&max_dist as *const O).cast::<f64>(),
+                prune_equal,
+                child_off.as_mut_ptr().cast(),
+                (&mut remaining_min_rd as *mut O).cast(),
+            );
+            return (packed != u32::MAX).then_some(CyclicChildSelection {
+                child_idx: packed as u8,
+                remaining_mask: (packed >> 8) as u16,
+                remaining_min_rd,
+                child_off,
+            });
+        }
+        if K == 4
+            && BH == 4
+            && TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<O>() == TypeId::of::<f32>()
+            && TypeId::of::<<D as DistanceMetricAvx512<A>>::Avx512F32Ops>()
+                != TypeId::of::<UnsupportedAvx512F32LeafOps>()
+        {
+            let mut child_off = [O::zero(); 4];
+            let mut remaining_min_rd = O::max_value();
+            let packed = select_cyclic_block4_f32::<<D as DistanceMetricAvx512<A>>::Avx512F32Ops>(
+                stems.as_ptr().cast(),
+                block_base_idx,
+                query.as_ptr().cast(),
+                parent_off.as_ptr().cast(),
+                pending_mask,
+                *(&max_dist as *const O).cast::<f32>(),
+                prune_equal,
+                child_off.as_mut_ptr().cast(),
+                (&mut remaining_min_rd as *mut O).cast(),
+            );
+            return (packed != u32::MAX).then_some(CyclicChildSelection {
+                child_idx: packed as u8,
+                remaining_mask: (packed >> 8) as u16,
+                remaining_min_rd,
+                child_off,
+            });
+        }
+    }
+
+    select_cyclic_child_scalar::<A, O, D, K, BH>(
+        stems,
+        block_base_idx,
+        query,
+        parent_off,
+        pending_mask,
+        max_dist,
+        prune_equal,
+    )
+}
+
+#[inline(always)]
+fn select_single_cyclic_child<A, O, D, const K: usize, const BH: usize>(
+    stems: &[A],
+    block_base_idx: usize,
+    query: &[A; K],
+    parent_off: &[O; 4],
+    pending_mask: u16,
+    max_dist: O,
+    prune_equal: bool,
+) -> Option<CyclicChildSelection<O>>
+where
+    A: Axis<Coord = A>,
+    O: Axis<Coord = O>,
+    D: DistanceMetric<A, Output = O>,
+{
+    debug_assert!(pending_mask.is_power_of_two());
+    let child_idx = pending_mask.trailing_zeros() as u8;
+    let (child_off, rd) = selected_cyclic_child_offsets::<A, O, D, K, BH>(
+        stems,
+        block_base_idx,
+        query,
+        parent_off,
+        child_idx,
+    )?;
+    let ordering = O::cmp(rd, max_dist);
+    if ordering == std::cmp::Ordering::Greater
+        || (prune_equal && ordering == std::cmp::Ordering::Equal)
+    {
+        return None;
+    }
+    Some(CyclicChildSelection {
+        child_idx,
+        remaining_mask: 0,
+        remaining_min_rd: O::max_value(),
+        child_off,
+    })
+}
+
+/// Cyclic-axis SIMD descent plus native block-level pruning and backtracking.
+///
+/// For `f64`/3D/Block3 and `f32`/4D/Block4, each terminal block child is a
+/// multi-axis rectangle. AVX-512 computes all child rectangle distances in one
+/// operation; a pending mask retains viable siblings for later backtracking.
+/// Ordinary near descent continues to use the cheaper cyclic block comparator.
+/// Other type/dimension combinations retain the scalar continuation engine.
+#[derive(Copy, Clone, Debug)]
+pub struct DonnellyCyclicSimdFull<const BH: usize> {
+    core: DonnellyCore<BH>,
+}
+
+// Kept as compile-time tuning switches while the experimental strategy is
+// characterised. LLVM removes the unused reduction paths completely.
+const CYCLIC_FULL_SELECT_MIN_RD_CHILD: bool = false;
+const CYCLIC_FULL_CACHE_REMAINING_MIN_RD: bool = false;
+
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+fn cyclic_simd_full_arithmetic_query<
+    Tree,
+    A,
+    T,
+    O,
+    D,
+    QC,
+    LS,
+    const K: usize,
+    const B: usize,
+    const BH: usize,
+>(
+    tree: &Tree,
+    query_ctx: &mut QC,
+    stack: &mut SimdQueryStack<
+        O,
+        DonnellyCyclicSimdFull<BH>,
+        CYCLIC_SIMD_FULL_INLINE_QUERY_STACK_CAPACITY,
+    >,
+    mut process_leaf: impl FnMut(usize, &[O; K], &mut QC),
+) where
+    Tree: KdTreeAccessor<A, T, DonnellyCyclicSimdFull<BH>, LS, K, B>
+        + KdTreeQueryOps<A, T, DonnellyCyclicSimdFull<BH>, LS, K, B>,
+    A: Axis<Coord = A>,
+    T: Content,
+    O: Axis<Coord = O>
+        + SimdPrune
+        + crate::stem_strategy::SimdSelectBestChildBlock3
+        + super::simd_full::BacktrackBlock3
+        + super::simd_full::BacktrackBlock4,
+    D: DistanceMetric<A, Output = O>,
+    QC: QueryContext<A, O, K>,
+    LS: LeafStrategy<A, T, DonnellyCyclicSimdFull<BH>, K, B>,
+    DonnellyCyclicSimdFull<BH>: StemStrategy<
+        DeferredState = DonnellyCoreDeferred,
+        StackContext<O> = CyclicSimdFullQueryStackContext<O, DonnellyCoreDeferred>,
+        Stack<O> = SimdQueryStack<
+            O,
+            DonnellyCyclicSimdFull<BH>,
+            CYCLIC_SIMD_FULL_INLINE_QUERY_STACK_CAPACITY,
+        >,
+    >,
+{
+    let native_backend = cfg!(all(
+        feature = "simd",
+        target_arch = "x86_64",
+        target_feature = "avx512f",
+        target_feature = "fma"
+    ));
+    let native_f64 = BH == 3
+        && K == 3
+        && TypeId::of::<A>() == TypeId::of::<f64>()
+        && TypeId::of::<O>() == TypeId::of::<f64>();
+    let native_f32 = BH == 4
+        && K == 4
+        && TypeId::of::<A>() == TypeId::of::<f32>()
+        && TypeId::of::<O>() == TypeId::of::<f32>();
+    #[cfg(all(feature = "simd", target_feature = "avx512f"))]
+    let native_metric = (native_f64
+        && TypeId::of::<<D as DistanceMetricAvx512<A>>::Avx512F64Ops>()
+            != TypeId::of::<UnsupportedAvx512F64LeafOps>())
+        || (native_f32
+            && TypeId::of::<<D as DistanceMetricAvx512<A>>::Avx512F32Ops>()
+                != TypeId::of::<UnsupportedAvx512F32LeafOps>());
+    #[cfg(not(all(feature = "simd", target_feature = "avx512f")))]
+    let native_metric = false;
+    if !native_backend || !native_metric || !(native_f64 || native_f32) {
+        tree.arithmetic_query_with_scratch_impl::<QC, O, D>(query_ctx, stack, process_leaf);
+        return;
+    }
+    if tree.size() == 0 {
+        return;
+    }
+
+    let query = *query_ctx.query();
+    let mut query_wide = [O::zero(); K];
+    let mut dim = 0usize;
+    while dim < K {
+        query_wide[dim] = D::widen_coord(query[dim]);
+        dim += 1;
+    }
+
+    let stems = tree.stems();
+    let stems_ptr = NonNull::new(stems.as_ptr() as *mut u8).expect("non-empty stem storage");
+    let root = DonnellyCore::<BH>::new(stems_ptr);
+    let root_off = [O::zero(); 4];
+    let full_mask = ((1u32 << (1usize << BH)) - 1) as u16;
+
+    stack.clear();
+
+    macro_rules! descend_near_to_leaf {
+        ($root:expr, $root_off:expr) => {{
+            let mut current = $root;
+            let mut current_off = $root_off;
+            loop {
+                let near_child =
+                    A::compare_cyclic_block::<BH, K>(stems, &query, current.stem_idx(), 0);
+                let pending_mask = full_mask & !(1u16 << near_child);
+                stack.push(CyclicSimdFullQueryStackContext::pending(
+                    current.deferred_state(),
+                    pending_mask,
+                    current_off,
+                    O::zero(),
+                ));
+
+                let (next_off, _) = selected_cyclic_child_offsets::<A, O, D, K, BH>(
+                    stems,
+                    current.stem_idx(),
+                    &query,
+                    &current_off,
+                    near_child,
+                )
+                .expect("the query-selected path cannot enter padded right space");
+                current_off = next_off;
+                current.traverse_block::<K>(near_child, BH as u32);
+                if current.level() > tree.max_stem_level() {
+                    break current.leaf_idx();
+                }
+            }
+        }};
+    }
+
+    let first_leaf = descend_near_to_leaf!(root, root_off);
+    process_leaf(first_leaf, &query_wide, query_ctx);
+
+    while let Some(frame) = stack.pop() {
+        let CyclicSimdFullQueryStackContext::Pending {
+            base_state,
+            pending_mask,
+            off: parent_off,
+            min_rd,
+        } = frame
+        else {
+            unreachable!("native cyclic SIMD-full traversal only pushes pending block frames")
+        };
+        let mut base = DonnellyCore::<BH>::new(stems_ptr);
+        base.rehydrate_deferred_state(base_state);
+        let max_dist = query_ctx.max_dist();
+        if O::cmp(min_rd, O::zero()) != std::cmp::Ordering::Equal {
+            let min_ordering = O::cmp(min_rd, max_dist);
+            if min_ordering == std::cmp::Ordering::Greater
+                || (query_ctx.prune_on_equal_max_dist()
+                    && min_ordering == std::cmp::Ordering::Equal)
+            {
+                continue;
+            }
+        }
+
+        // Launching a full vector kernel for one live child cannot amortise its
+        // setup. All wider masks stay SIMD, including the final tree block.
+        let selection = if pending_mask.is_power_of_two() {
+            select_single_cyclic_child::<A, O, D, K, BH>(
+                stems,
+                base.stem_idx(),
+                &query,
+                &parent_off,
+                pending_mask,
+                max_dist,
+                query_ctx.prune_on_equal_max_dist(),
+            )
+        } else {
+            select_cyclic_child::<A, O, D, K, BH>(
+                stems,
+                base.stem_idx(),
+                &query,
+                &parent_off,
+                pending_mask,
+                max_dist,
+                query_ctx.prune_on_equal_max_dist(),
+            )
+        };
+        let Some(selection) = selection else {
+            continue;
+        };
+        if selection.remaining_mask != 0 {
+            stack.push(CyclicSimdFullQueryStackContext::pending(
+                base_state,
+                selection.remaining_mask,
+                parent_off,
+                selection.remaining_min_rd,
+            ));
+        }
+
+        base.traverse_block::<K>(selection.child_idx, BH as u32);
+        if base.level() > tree.max_stem_level() {
+            process_leaf(base.leaf_idx(), &query_wide, query_ctx);
+        } else {
+            let leaf_idx = descend_near_to_leaf!(base, selection.child_off);
+            process_leaf(leaf_idx, &query_wide, query_ctx);
+        }
+    }
+}
+
+macro_rules! impl_cyclic_simd_full {
+    (
+        $strategy:ident,
+        $bh:literal,
+        $block_base_bias:literal,
+        $stack_context:ty,
+        $stack_type:ty,
+        $tree:ident,
+        $query_ctx:ident,
+        $stack:ident,
+        $process_leaf:ident,
+        $arithmetic:block
+    ) => {
+        impl StemStrategy for $strategy<$bh> {
+            const ROOT_IDX: usize = 0;
+            const BLOCK_SIZE: usize = $bh;
+            const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
+            const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;
+            const USES_SIMD_BLOCK_DESCENT: bool = true;
+            const USES_PREPARED_BLOCK_QUERY: bool = true;
+
+            type DeferredState = DonnellyCoreDeferred;
+            type StackContext<A> = $stack_context;
+            type Stack<A> = $stack_type;
+
+            #[inline(always)]
+            fn new(stems_ptr: NonNull<u8>) -> Self {
+                Self {
+                    core: DonnellyCore::new(stems_ptr),
+                }
+            }
+
+            #[inline(always)]
+            fn stem_idx(&self) -> usize {
+                self.core.stem_idx()
+            }
+            #[inline(always)]
+            fn deferred_state(&self) -> Self::DeferredState {
+                self.core.deferred_state()
+            }
+            #[inline(always)]
+            fn rehydrate_deferred_state(&mut self, state: Self::DeferredState) {
+                self.core.rehydrate_deferred_state(state);
+            }
+            #[inline(always)]
+            fn leaf_idx(&self) -> usize {
+                self.core.leaf_idx()
+            }
+            #[inline(always)]
+            fn dim<const K: usize>(&self) -> usize {
+                self.core.dim::<K>()
+            }
+            #[inline(always)]
+            fn construction_dim<const K: usize>(&self) -> usize {
+                self.core.dim::<K>()
+            }
+
+            #[inline(always)]
+            fn select_block_child<A: Axis<Coord = A>, const K: usize>(
+                &self,
+                stems: &[A],
+                query: &[A; K],
+                start_dim: usize,
+            ) -> u8 {
+                A::compare_cyclic_block::<$bh, K>(stems, query, self.stem_idx(), start_dim)
+            }
+
+            #[inline(always)]
+            fn prepare_block_query<A: Axis<Coord = A>, const K: usize>(
+                query: &[A; K],
+            ) -> PreparedBlockQuery<A, K> {
+                prepare_query_lanes::<A, $bh, K>(query)
+            }
+
+            #[inline(always)]
+            fn select_prepared_block_child<A: Axis<Coord = A>, const K: usize>(
+                &self,
+                stems: &[A],
+                _query: &[A; K],
+                prepared: &PreparedBlockQuery<A, K>,
+                start_dim: usize,
+            ) -> u8 {
+                A::compare_prepared_cyclic_block::<$bh>(
+                    stems,
+                    &prepared[start_dim],
+                    self.stem_idx(),
+                )
+            }
+
+            #[inline(always)]
+            fn level(&self) -> i32 {
+                self.core.level()
+            }
+            #[inline(always)]
+            fn traverse<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+                self.core.traverse::<A, K>(is_right);
+            }
+            #[inline(always)]
+            fn traverse_head<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+                self.core.traverse_head::<A, K>(is_right);
+            }
+            #[inline(always)]
+            fn traverse_tail<A: Axis<Coord = A>, const K: usize>(&mut self, is_right: bool) {
+                self.core
+                    .traverse_tail_with_block_size::<A, K>(is_right, $bh as u32);
+            }
+            #[inline(always)]
+            fn branch<A: Axis<Coord = A>, const K: usize>(&mut self) -> Self {
+                Self {
+                    core: self.core.branch::<A, K>(),
+                }
+            }
+            #[inline(always)]
+            fn branch_relative<A: Axis<Coord = A>, const K: usize>(
+                &mut self,
+                is_right: bool,
+            ) -> Self {
+                Self {
+                    core: self.core.branch_relative::<A, K>(is_right),
+                }
+            }
+            #[inline(always)]
+            fn branch_relative_head<A: Axis<Coord = A>, const K: usize>(
+                &mut self,
+                is_right: bool,
+            ) -> Self {
+                Self {
+                    core: self.core.branch_relative_head::<A, K>(is_right),
+                }
+            }
+            #[inline(always)]
+            fn branch_relative_tail<A: Axis<Coord = A>, const K: usize>(
+                &mut self,
+                is_right: bool,
+            ) -> Self {
+                Self {
+                    core: self.core.branch_relative_tail::<A, K>(is_right),
+                }
+            }
+            #[inline(always)]
+            fn child_indices<A: Axis<Coord = A>>(&self) -> (usize, usize) {
+                self.core.child_indices::<A>()
+            }
+
+            fn get_stem_node_count_from_leaf_node_count(leaf_node_count: usize) -> usize {
+                if leaf_node_count < 2 {
+                    0
+                } else {
+                    leaf_node_count.next_power_of_two() - 1
+                }
+            }
+            fn stem_node_padding_factor() -> usize {
+                50
+            }
+
+            fn trim_unneeded_stems<A: Axis<Coord = A>, const K: usize>(
+                stems: &mut AVec<A>,
+                max_stem_level: usize,
+            ) {
+                if stems.is_empty() {
+                    return;
+                }
+                let ptr = NonNull::new(stems.as_ptr() as *mut u8).unwrap();
+                let mut ordering = Self::new(ptr);
+                loop {
+                    let is_right = !A::is_max_value(stems[ordering.stem_idx()]);
+                    ordering.traverse::<A, K>(is_right);
+                    if ordering.level() as usize == max_stem_level {
+                        break;
+                    }
+                }
+                stems.truncate(ordering.stem_idx() + 1);
+            }
+
+            fn get_leaf_idx<A: Axis<Coord = A>, const K: usize>(
+                stems: &[A],
+                query: &[A; K],
+                max_stem_level: i32,
+            ) -> usize {
+                let total_levels = (max_stem_level + 1).max(0) as usize;
+                let native_bh = (64 / A::VALUE_WIDTH_BYTES as u32).ilog2() as usize;
+                if native_bh == $bh && total_levels.is_multiple_of($bh) {
+                    let mut block_base = 0u32;
+                    let mut start_dim = 0usize;
+                    let prepared = prepare_query_lanes::<A, $bh, K>(query);
+                    for _ in 0..(total_levels / $bh) {
+                        let child = A::compare_prepared_cyclic_block::<$bh>(
+                            stems,
+                            &prepared[start_dim],
+                            block_base as usize,
+                        );
+                        block_base = block_base
+                            .wrapping_add($block_base_bias)
+                            .wrapping_add(child as u32)
+                            .wrapping_shl($bh as u32);
+                        start_dim = (start_dim + $bh) % K;
+                    }
+                    return leaf_idx_from_block_base::<$bh>(block_base, total_levels);
+                }
+
+                let ptr = NonNull::new(stems.as_ptr() as *mut u8).unwrap();
+                let mut ordering = Self::new(ptr);
+                while ordering.level() <= max_stem_level {
+                    let dim = ordering.dim::<K>();
+                    let pivot = unsafe { *stems.get_unchecked(ordering.stem_idx()) };
+                    let is_right = unsafe { *query.get_unchecked(dim) } >= pivot;
+                    ordering.traverse::<A, K>(is_right);
+                }
+                ordering.leaf_idx()
+            }
+
+            #[inline(always)]
+            fn arithmetic_query_with_scratch<
+                Tree,
+                A,
+                T,
+                O,
+                D,
+                QC,
+                LS,
+                const K2: usize,
+                const B: usize,
+            >(
+                $tree: &Tree,
+                $query_ctx: &mut QC,
+                $stack: &mut Self::Stack<O>,
+                $process_leaf: impl FnMut(usize, &[O; K2], &mut QC),
+            ) where
+                Self: Sized,
+                Tree: KdTreeAccessor<A, T, Self, LS, K2, B>
+                    + KdTreeQueryOps<A, T, Self, LS, K2, B>,
+                A: Axis<Coord = A>,
+                T: Content,
+                O: Axis<Coord = O>
+                    + SimdPrune
+                    + crate::stem_strategy::SimdSelectBestChildBlock3
+                    + super::simd_full::BacktrackBlock3
+                    + super::simd_full::BacktrackBlock4,
+                D: DistanceMetric<A, Output = O>,
+                QC: QueryContext<A, O, K2>,
+                LS: LeafStrategy<A, T, Self, K2, B>,
+                Self::Stack<O>: crate::kd_tree::query_stack::StackTrait<O, Self>,
+            $arithmetic
+        }
+    };
+}
+
+impl_cyclic_simd_full!(
+    DonnellyCyclicSimdFull,
+    3,
+    1,
+    CyclicSimdFullQueryStackContext<A, Self::DeferredState>,
+    SimdQueryStack<A, Self, CYCLIC_SIMD_FULL_INLINE_QUERY_STACK_CAPACITY>,
+    tree,
+    query_ctx,
+    stack,
+    process_leaf,
+    {
+        cyclic_simd_full_arithmetic_query::<Tree, A, T, O, D, QC, LS, K2, B, 3>(
+            tree,
+            query_ctx,
+            stack,
+            process_leaf,
+        );
+    }
+);
+impl_cyclic_simd_full!(
+    DonnellyCyclicSimdFull,
+    4,
+    7,
+    CyclicSimdFullQueryStackContext<A, Self::DeferredState>,
+    SimdQueryStack<A, Self, CYCLIC_SIMD_FULL_INLINE_QUERY_STACK_CAPACITY>,
+    tree,
+    query_ctx,
+    stack,
+    process_leaf,
+    {
+        cyclic_simd_full_arithmetic_query::<Tree, A, T, O, D, QC, LS, K2, B, 4>(
+            tree,
+            query_ctx,
+            stack,
+            process_leaf,
+        );
+    }
+);
+
+#[cfg(feature = "cargo_asm")]
+mod cargo_asm {
+    use super::select_cyclic_child;
+    use crate::SquaredEuclidean;
+
+    #[inline(never)]
+    #[unsafe(no_mangle)]
+    pub fn donnelly_cyclic_full_block3_f64_cargo_asm_hook(
+        stems: &[f64],
+        query: &[f64; 3],
+        block_base: usize,
+        off: &[f64; 4],
+        max_dist: f64,
+        child_off: &mut [f64; 4],
+    ) -> u32 {
+        let Some(selection) = select_cyclic_child::<f64, f64, SquaredEuclidean<f64>, 3, 3>(
+            stems, block_base, query, off, 0xff, max_dist, true,
+        ) else {
+            return u32::MAX;
+        };
+        *child_off = selection.child_off;
+        u32::from(selection.child_idx) | (u32::from(selection.remaining_mask) << 8)
+    }
+
+    #[inline(never)]
+    #[unsafe(no_mangle)]
+    pub fn donnelly_cyclic_full_block4_f32_cargo_asm_hook(
+        stems: &[f32],
+        query: &[f32; 4],
+        block_base: usize,
+        off: &[f32; 4],
+        max_dist: f32,
+        child_off: &mut [f32; 4],
+    ) -> u32 {
+        let Some(selection) = select_cyclic_child::<f32, f32, SquaredEuclidean<f32>, 4, 4>(
+            stems, block_base, query, off, 0xffff, max_dist, true,
+        ) else {
+            return u32::MAX;
+        };
+        *child_off = selection.child_off;
+        u32::from(selection.child_idx) | (u32::from(selection.remaining_mask) << 8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_f64_block3_selection_kernel_matches_scalar_reference() {
+        let stems = [
+            0.5,
+            0.25,
+            f64::INFINITY,
+            0.1,
+            0.4,
+            f64::INFINITY,
+            f64::INFINITY,
+            f64::INFINITY,
+        ];
+        let query = [0.32, 0.61, 0.18];
+        let off = [0.11, 0.07, 0.13, 0.0];
+        let actual = select_cyclic_child::<f64, f64, crate::SquaredEuclidean<f64>, 3, 3>(
+            &stems,
+            0,
+            &query,
+            &off,
+            0xff,
+            f64::INFINITY,
+            true,
+        )
+        .unwrap();
+        let expected = select_cyclic_child_scalar::<f64, f64, crate::SquaredEuclidean<f64>, 3, 3>(
+            &stems,
+            0,
+            &query,
+            &off,
+            0xff,
+            f64::INFINITY,
+            true,
+        )
+        .unwrap();
+
+        let expected_candidates = expected.remaining_mask | (1u16 << expected.child_idx);
+        assert_eq!(actual.child_idx, expected_candidates.trailing_zeros() as u8);
+        assert_eq!(
+            actual.remaining_mask,
+            expected_candidates & !(1u16 << actual.child_idx)
+        );
+        let expected_selected = selected_cyclic_child_offsets::<
+            f64,
+            f64,
+            crate::SquaredEuclidean<f64>,
+            3,
+            3,
+        >(&stems, 0, &query, &off, actual.child_idx)
+        .unwrap();
+        for dim in 0..4 {
+            assert!((actual.child_off[dim] - expected_selected.0[dim]).abs() <= 1.0e-14);
+        }
+        assert_eq!(actual.remaining_min_rd, 0.0);
+    }
+
+    #[test]
+    fn native_f32_block4_selection_kernel_matches_scalar_reference() {
+        let stems = [
+            0.5,
+            0.25,
+            0.75,
+            0.1,
+            0.4,
+            0.6,
+            0.9,
+            0.05,
+            0.2,
+            0.3,
+            0.45,
+            0.55,
+            0.7,
+            0.8,
+            0.95,
+            f32::INFINITY,
+        ];
+        let query = [0.32, 0.61, 0.18, 0.73];
+        let off = [0.11, 0.07, 0.13, 0.09];
+        let actual = select_cyclic_child::<f32, f32, crate::SquaredEuclidean<f32>, 4, 4>(
+            &stems,
+            0,
+            &query,
+            &off,
+            0xffff,
+            f32::INFINITY,
+            true,
+        )
+        .unwrap();
+        let expected = select_cyclic_child_scalar::<f32, f32, crate::SquaredEuclidean<f32>, 4, 4>(
+            &stems,
+            0,
+            &query,
+            &off,
+            0xffff,
+            f32::INFINITY,
+            true,
+        )
+        .unwrap();
+
+        let expected_candidates = expected.remaining_mask | (1u16 << expected.child_idx);
+        assert_eq!(actual.child_idx, expected_candidates.trailing_zeros() as u8);
+        assert_eq!(
+            actual.remaining_mask,
+            expected_candidates & !(1u16 << actual.child_idx)
+        );
+        let expected_selected = selected_cyclic_child_offsets::<
+            f32,
+            f32,
+            crate::SquaredEuclidean<f32>,
+            4,
+            4,
+        >(&stems, 0, &query, &off, actual.child_idx)
+        .unwrap();
+        for dim in 0..4 {
+            assert!((actual.child_off[dim] - expected_selected.0[dim]).abs() <= 1.0e-6);
+        }
+        assert_eq!(actual.remaining_min_rd, 0.0);
+    }
+}

--- a/src/stem_strategy/donnelly/cyclic_simd_full.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_full.rs
@@ -202,13 +202,7 @@ unsafe fn select_cyclic_block3_f64<Ops: Avx512F64LeafOps>(
         return u32::MAX;
     }
 
-    let child = if CYCLIC_FULL_SELECT_MIN_RD_CHILD {
-        let min_rd = _mm512_mask_reduce_min_pd(candidates, rd);
-        let best_mask = candidates & _mm512_cmp_pd_mask(rd, _mm512_set1_pd(min_rd), _CMP_EQ_OQ);
-        best_mask.trailing_zeros() as u8
-    } else {
-        candidates.trailing_zeros() as u8
-    };
+    let child = candidates.trailing_zeros() as u8;
     let lane = _mm512_set1_epi64(i64::from(child));
     *child_off = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_x)));
     *child_off.add(1) = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_y)));
@@ -293,13 +287,7 @@ unsafe fn select_cyclic_block4_f32<Ops: Avx512F32LeafOps>(
         return u32::MAX;
     }
 
-    let child = if CYCLIC_FULL_SELECT_MIN_RD_CHILD {
-        let min_rd = _mm512_mask_reduce_min_ps(candidates, rd);
-        let best_mask = candidates & _mm512_cmp_ps_mask(rd, _mm512_set1_ps(min_rd), _CMP_EQ_OQ);
-        best_mask.trailing_zeros() as u8
-    } else {
-        candidates.trailing_zeros() as u8
-    };
+    let child = candidates.trailing_zeros() as u8;
     let lane = _mm512_set1_epi32(i32::from(child));
     *child_off = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_x)));
     *child_off.add(1) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_y)));
@@ -407,10 +395,6 @@ where
 pub struct DonnellyCyclicSimdFull<const BH: usize> {
     core: DonnellyCore<BH>,
 }
-
-// Kept as compile-time tuning switches while the experimental strategy is
-// characterised. LLVM removes the unused reduction paths completely.
-const CYCLIC_FULL_SELECT_MIN_RD_CHILD: bool = false;
 
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
@@ -897,7 +881,13 @@ mod cargo_asm {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "simd",
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "fma"
+))]
 mod tests {
     use super::*;
 

--- a/src/stem_strategy/donnelly/cyclic_simd_full.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_full.rs
@@ -33,7 +33,6 @@ use super::cyclic_simd_descent::prepare_query_lanes;
 struct CyclicChildSelection<O> {
     child_idx: u8,
     remaining_mask: u16,
-    remaining_min_rd: O,
     child_off: [O; 4],
 }
 
@@ -133,19 +132,9 @@ where
         }
     }
     let remaining_mask = candidate_mask & !(1u16 << best);
-    let mut remaining_min_rd = O::max_value();
-    let mut live = remaining_mask;
-    while live != 0 {
-        let child = live.trailing_zeros() as usize;
-        live &= live - 1;
-        if O::cmp(rd_values[child], remaining_min_rd) == std::cmp::Ordering::Less {
-            remaining_min_rd = rd_values[child];
-        }
-    }
     Some(CyclicChildSelection {
         child_idx: best as u8,
         remaining_mask,
-        remaining_min_rd,
         child_off: off_values[best],
     })
 }
@@ -168,7 +157,7 @@ unsafe fn cyclic_axis_offsets_f64(
     let query = _mm512_set1_pd(query);
     let query_right = _mm512_cmp_pd_mask(query, pivots, _CMP_GE_OQ);
     let opposite = right_mask ^ query_right;
-    let diff = _mm512_max_pd(_mm512_sub_pd(query, pivots), _mm512_sub_pd(pivots, query));
+    let diff = _mm512_andnot_pd(_mm512_set1_pd(-0.0), _mm512_sub_pd(query, pivots));
     let off = _mm512_mask_mov_pd(_mm512_set1_pd(parent_off), opposite, diff);
     let real_pivot = _mm512_cmp_pd_mask(pivots, _mm512_set1_pd(f64::INFINITY), _CMP_LT_OQ);
     (off, (!right_mask) | real_pivot)
@@ -190,7 +179,6 @@ unsafe fn select_cyclic_block3_f64<Ops: Avx512F64LeafOps>(
     max_dist: f64,
     prune_equal: bool,
     child_off: *mut f64,
-    remaining_min_rd: *mut f64,
 ) -> u32 {
     use std::arch::x86_64::*;
 
@@ -221,21 +209,13 @@ unsafe fn select_cyclic_block3_f64<Ops: Avx512F64LeafOps>(
     } else {
         candidates.trailing_zeros() as u8
     };
-    let chosen_mask = 1u8 << child;
     let lane = _mm512_set1_epi64(i64::from(child));
     *child_off = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_x)));
     *child_off.add(1) = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_y)));
     *child_off.add(2) = _mm_cvtsd_f64(_mm512_castpd512_pd128(_mm512_permutexvar_pd(lane, off_z)));
     *child_off.add(3) = 0.0;
 
-    let remaining = candidates & !chosen_mask;
-    *remaining_min_rd = if !CYCLIC_FULL_CACHE_REMAINING_MIN_RD {
-        0.0
-    } else if remaining == 0 {
-        f64::INFINITY
-    } else {
-        _mm512_mask_reduce_min_pd(remaining, rd)
-    };
+    let remaining = candidates & candidates.wrapping_sub(1);
     u32::from(child) | (u32::from(remaining) << 8)
 }
 
@@ -257,7 +237,7 @@ unsafe fn cyclic_axis_offsets_f32(
     let query = _mm512_set1_ps(query);
     let query_right = _mm512_cmp_ps_mask(query, pivots, _CMP_GE_OQ);
     let opposite = right_mask ^ query_right;
-    let diff = _mm512_max_ps(_mm512_sub_ps(query, pivots), _mm512_sub_ps(pivots, query));
+    let diff = _mm512_andnot_ps(_mm512_set1_ps(-0.0), _mm512_sub_ps(query, pivots));
     let off = _mm512_mask_mov_ps(_mm512_set1_ps(parent_off), opposite, diff);
     let real_pivot = _mm512_cmp_ps_mask(pivots, _mm512_set1_ps(f32::INFINITY), _CMP_LT_OQ);
     (off, (!right_mask) | real_pivot)
@@ -279,7 +259,6 @@ unsafe fn select_cyclic_block4_f32<Ops: Avx512F32LeafOps>(
     max_dist: f32,
     prune_equal: bool,
     child_off: *mut f32,
-    remaining_min_rd: *mut f32,
 ) -> u32 {
     use std::arch::x86_64::*;
 
@@ -321,21 +300,13 @@ unsafe fn select_cyclic_block4_f32<Ops: Avx512F32LeafOps>(
     } else {
         candidates.trailing_zeros() as u8
     };
-    let chosen_mask = 1u16 << child;
     let lane = _mm512_set1_epi32(i32::from(child));
     *child_off = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_x)));
     *child_off.add(1) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_y)));
     *child_off.add(2) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_z)));
     *child_off.add(3) = _mm_cvtss_f32(_mm512_castps512_ps128(_mm512_permutexvar_ps(lane, off_w)));
 
-    let remaining = candidates & !chosen_mask;
-    *remaining_min_rd = if !CYCLIC_FULL_CACHE_REMAINING_MIN_RD {
-        0.0
-    } else if remaining == 0 {
-        f32::INFINITY
-    } else {
-        _mm512_mask_reduce_min_ps(remaining, rd)
-    };
+    let remaining = candidates & candidates.wrapping_sub(1);
     u32::from(child) | (u32::from(remaining) << 8)
 }
 
@@ -372,7 +343,6 @@ where
                 != TypeId::of::<UnsupportedAvx512F64LeafOps>()
         {
             let mut child_off = [O::zero(); 4];
-            let mut remaining_min_rd = O::max_value();
             let packed = select_cyclic_block3_f64::<<D as DistanceMetricAvx512<A>>::Avx512F64Ops>(
                 stems.as_ptr().cast(),
                 block_base_idx,
@@ -382,12 +352,10 @@ where
                 *(&max_dist as *const O).cast::<f64>(),
                 prune_equal,
                 child_off.as_mut_ptr().cast(),
-                (&mut remaining_min_rd as *mut O).cast(),
             );
             return (packed != u32::MAX).then_some(CyclicChildSelection {
                 child_idx: packed as u8,
                 remaining_mask: (packed >> 8) as u16,
-                remaining_min_rd,
                 child_off,
             });
         }
@@ -399,7 +367,6 @@ where
                 != TypeId::of::<UnsupportedAvx512F32LeafOps>()
         {
             let mut child_off = [O::zero(); 4];
-            let mut remaining_min_rd = O::max_value();
             let packed = select_cyclic_block4_f32::<<D as DistanceMetricAvx512<A>>::Avx512F32Ops>(
                 stems.as_ptr().cast(),
                 block_base_idx,
@@ -409,12 +376,10 @@ where
                 *(&max_dist as *const O).cast::<f32>(),
                 prune_equal,
                 child_off.as_mut_ptr().cast(),
-                (&mut remaining_min_rd as *mut O).cast(),
             );
             return (packed != u32::MAX).then_some(CyclicChildSelection {
                 child_idx: packed as u8,
                 remaining_mask: (packed >> 8) as u16,
-                remaining_min_rd,
                 child_off,
             });
         }
@@ -429,44 +394,6 @@ where
         max_dist,
         prune_equal,
     )
-}
-
-#[inline(always)]
-fn select_single_cyclic_child<A, O, D, const K: usize, const BH: usize>(
-    stems: &[A],
-    block_base_idx: usize,
-    query: &[A; K],
-    parent_off: &[O; 4],
-    pending_mask: u16,
-    max_dist: O,
-    prune_equal: bool,
-) -> Option<CyclicChildSelection<O>>
-where
-    A: Axis<Coord = A>,
-    O: Axis<Coord = O>,
-    D: DistanceMetric<A, Output = O>,
-{
-    debug_assert!(pending_mask.is_power_of_two());
-    let child_idx = pending_mask.trailing_zeros() as u8;
-    let (child_off, rd) = selected_cyclic_child_offsets::<A, O, D, K, BH>(
-        stems,
-        block_base_idx,
-        query,
-        parent_off,
-        child_idx,
-    )?;
-    let ordering = O::cmp(rd, max_dist);
-    if ordering == std::cmp::Ordering::Greater
-        || (prune_equal && ordering == std::cmp::Ordering::Equal)
-    {
-        return None;
-    }
-    Some(CyclicChildSelection {
-        child_idx,
-        remaining_mask: 0,
-        remaining_min_rd: O::max_value(),
-        child_off,
-    })
 }
 
 /// Cyclic-axis SIMD descent plus native block-level pruning and backtracking.
@@ -484,7 +411,6 @@ pub struct DonnellyCyclicSimdFull<const BH: usize> {
 // Kept as compile-time tuning switches while the experimental strategy is
 // characterised. LLVM removes the unused reduction paths completely.
 const CYCLIC_FULL_SELECT_MIN_RD_CHILD: bool = false;
-const CYCLIC_FULL_CACHE_REMAINING_MIN_RD: bool = false;
 
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
@@ -581,27 +507,18 @@ fn cyclic_simd_full_arithmetic_query<
     macro_rules! descend_near_to_leaf {
         ($root:expr, $root_off:expr) => {{
             let mut current = $root;
-            let mut current_off = $root_off;
+            let current_off = $root_off;
             loop {
                 let near_child =
                     A::compare_cyclic_block::<BH, K>(stems, &query, current.stem_idx(), 0);
                 let pending_mask = full_mask & !(1u16 << near_child);
-                stack.push(CyclicSimdFullQueryStackContext::pending(
-                    current.deferred_state(),
-                    pending_mask,
-                    current_off,
-                    O::zero(),
-                ));
-
-                let (next_off, _) = selected_cyclic_child_offsets::<A, O, D, K, BH>(
-                    stems,
-                    current.stem_idx(),
-                    &query,
-                    &current_off,
-                    near_child,
-                )
-                .expect("the query-selected path cannot enter padded right space");
-                current_off = next_off;
+                unsafe {
+                    stack.push_inline_unchecked(CyclicSimdFullQueryStackContext::pending(
+                        current.deferred_state(),
+                        pending_mask,
+                        current_off,
+                    ));
+                }
                 current.traverse_block::<K>(near_child, BH as u32);
                 if current.level() > tree.max_stem_level() {
                     break current.leaf_idx();
@@ -613,62 +530,31 @@ fn cyclic_simd_full_arithmetic_query<
     let first_leaf = descend_near_to_leaf!(root, root_off);
     process_leaf(first_leaf, &query_wide, query_ctx);
 
-    while let Some(frame) = stack.pop() {
-        let CyclicSimdFullQueryStackContext::Pending {
-            base_state,
-            pending_mask,
-            off: parent_off,
-            min_rd,
-        } = frame
-        else {
-            unreachable!("native cyclic SIMD-full traversal only pushes pending block frames")
-        };
+    while let Some(frame) = unsafe { stack.pop_inline_unchecked() } {
+        let (base_state, pending_mask, parent_off) = unsafe { frame.into_pending_unchecked() };
         let mut base = DonnellyCore::<BH>::new(stems_ptr);
         base.rehydrate_deferred_state(base_state);
         let max_dist = query_ctx.max_dist();
-        if O::cmp(min_rd, O::zero()) != std::cmp::Ordering::Equal {
-            let min_ordering = O::cmp(min_rd, max_dist);
-            if min_ordering == std::cmp::Ordering::Greater
-                || (query_ctx.prune_on_equal_max_dist()
-                    && min_ordering == std::cmp::Ordering::Equal)
-            {
-                continue;
-            }
-        }
-
-        // Launching a full vector kernel for one live child cannot amortise its
-        // setup. All wider masks stay SIMD, including the final tree block.
-        let selection = if pending_mask.is_power_of_two() {
-            select_single_cyclic_child::<A, O, D, K, BH>(
-                stems,
-                base.stem_idx(),
-                &query,
-                &parent_off,
-                pending_mask,
-                max_dist,
-                query_ctx.prune_on_equal_max_dist(),
-            )
-        } else {
-            select_cyclic_child::<A, O, D, K, BH>(
-                stems,
-                base.stem_idx(),
-                &query,
-                &parent_off,
-                pending_mask,
-                max_dist,
-                query_ctx.prune_on_equal_max_dist(),
-            )
-        };
+        let selection = select_cyclic_child::<A, O, D, K, BH>(
+            stems,
+            base.stem_idx(),
+            &query,
+            &parent_off,
+            pending_mask,
+            max_dist,
+            query_ctx.prune_on_equal_max_dist(),
+        );
         let Some(selection) = selection else {
             continue;
         };
         if selection.remaining_mask != 0 {
-            stack.push(CyclicSimdFullQueryStackContext::pending(
-                base_state,
-                selection.remaining_mask,
-                parent_off,
-                selection.remaining_min_rd,
-            ));
+            unsafe {
+                stack.push_inline_unchecked(CyclicSimdFullQueryStackContext::pending(
+                    base_state,
+                    selection.remaining_mask,
+                    parent_off,
+                ));
+            }
         }
 
         base.traverse_block::<K>(selection.child_idx, BH as u32);
@@ -1067,7 +953,6 @@ mod tests {
         for dim in 0..4 {
             assert!((actual.child_off[dim] - expected_selected.0[dim]).abs() <= 1.0e-14);
         }
-        assert_eq!(actual.remaining_min_rd, 0.0);
     }
 
     #[test]
@@ -1130,6 +1015,5 @@ mod tests {
         for dim in 0..4 {
             assert!((actual.child_off[dim] - expected_selected.0[dim]).abs() <= 1.0e-6);
         }
-        assert_eq!(actual.remaining_min_rd, 0.0);
     }
 }

--- a/src/stem_strategy/donnelly/mod.rs
+++ b/src/stem_strategy/donnelly/mod.rs
@@ -42,7 +42,7 @@ pub mod core;
 pub mod simd_full;
 
 #[doc(inline)]
-pub use cyclic_simd_descent::DonnellyCyclicSimdDescent;
+pub use cyclic_simd_descent::{DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull};
 #[doc(inline)]
 pub use no_pf::DonnellyNoPf;
 #[doc(inline)]

--- a/src/stem_strategy/donnelly/mod.rs
+++ b/src/stem_strategy/donnelly/mod.rs
@@ -23,6 +23,8 @@
 //!   descent, but still uses scalar backtracking and pruning.
 //! - [`DonnellyCyclicSimdDescent`] performs the same SIMD child selection with
 //!   per-depth query lanes, preserving the ordinary cyclic axis cadence.
+//! - [`DonnellyCyclicSimdFull`] builds on cyclic SIMD descent with native
+//!   block-level SIMD pruning and backtracking.
 //! - [`DonnellySimdFull`] takes the same block-at-once descent idea and also
 //!   uses SIMD-aware backtracking and pruning.
 //!
@@ -30,6 +32,7 @@
 //! and `simd_full` for the reusable SIMD comparison and backtrack machinery.
 
 pub(crate) mod cyclic_simd_descent;
+mod cyclic_simd_full;
 mod no_pf;
 mod scalar;
 mod simd_descent;
@@ -42,7 +45,9 @@ pub mod core;
 pub mod simd_full;
 
 #[doc(inline)]
-pub use cyclic_simd_descent::{DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull};
+pub use cyclic_simd_descent::DonnellyCyclicSimdDescent;
+#[doc(inline)]
+pub use cyclic_simd_full::DonnellyCyclicSimdFull;
 #[doc(inline)]
 pub use no_pf::DonnellyNoPf;
 #[doc(inline)]

--- a/src/stem_strategy/donnelly/simd_full/prune_traits.rs
+++ b/src/stem_strategy/donnelly/simd_full/prune_traits.rs
@@ -28,6 +28,45 @@ pub trait SimdPrune: Axis<Coord = Self> + sealed::Sealed {
     /// * `max_dist` - Maximum distance threshold
     /// * `sibling_mask` - Pre-computed mask of valid siblings
     fn simd_prune_block3(rd_values: &[Self; 8], max_dist: Self, sibling_mask: u8) -> u8;
+
+    /// Compare 16 Block4 child distances against `max_dist`.
+    #[inline(always)]
+    fn simd_prune_block4(rd_values: &[Self; 16], max_dist: Self, sibling_mask: u16) -> u16 {
+        let mut mask = 0u16;
+        let mut lane = 0usize;
+        while lane < 16 {
+            if rd_values[lane] <= max_dist {
+                mask |= 1u16 << lane;
+            }
+            lane += 1;
+        }
+        mask & sibling_mask
+    }
+
+    /// Select the live Block4 child with the smallest rectangle distance.
+    #[inline(always)]
+    fn simd_select_best_child_block4(rd_values: &[Self; 16], candidate_mask: u16) -> Option<u8> {
+        if candidate_mask == 0 {
+            return None;
+        }
+
+        let mut remaining = candidate_mask;
+        let first = remaining.trailing_zeros() as usize;
+        let mut best_idx = first;
+        let mut best_rd = rd_values[first];
+        remaining &= remaining - 1;
+
+        while remaining != 0 {
+            let idx = remaining.trailing_zeros() as usize;
+            if Self::cmp(rd_values[idx], best_rd) == std::cmp::Ordering::Less {
+                best_idx = idx;
+                best_rd = rd_values[idx];
+            }
+            remaining &= remaining - 1;
+        }
+
+        Some(best_idx as u8)
+    }
 }
 
 /// Select the child with the smallest lower-bound distance among the live Block3 lanes.
@@ -152,6 +191,32 @@ impl SimdPrune for f64 {
             autovec_fallback!(8, u8, rd_values, max_dist, sibling_mask)
         }
     }
+
+    #[inline(always)]
+    fn simd_prune_block4(rd_values: &[f64; 16], max_dist: f64, sibling_mask: u16) -> u16 {
+        #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+        unsafe {
+            use std::arch::x86_64::*;
+
+            let max_dist = _mm512_set1_pd(max_dist);
+            let low = _mm512_loadu_pd(rd_values.as_ptr());
+            let high = _mm512_loadu_pd(rd_values.as_ptr().add(8));
+            let low_mask = _mm512_cmp_pd_mask(low, max_dist, _CMP_LE_OQ) as u16;
+            let high_mask = _mm512_cmp_pd_mask(high, max_dist, _CMP_LE_OQ) as u16;
+            (low_mask | (high_mask << 8)) & sibling_mask
+        }
+
+        #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
+        {
+            let mut mask = 0u16;
+            for (lane, &rd) in rd_values.iter().enumerate() {
+                if rd <= max_dist {
+                    mask |= 1u16 << lane;
+                }
+            }
+            mask & sibling_mask
+        }
+    }
 }
 
 impl SimdSelectBestChildBlock3 for f64 {
@@ -234,6 +299,68 @@ impl SimdPrune for f32 {
         )))]
         {
             autovec_fallback!(8, u8, rd_values, max_dist, sibling_mask)
+        }
+    }
+
+    #[inline(always)]
+    fn simd_prune_block4(rd_values: &[f32; 16], max_dist: f32, sibling_mask: u16) -> u16 {
+        #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+        unsafe {
+            use std::arch::x86_64::*;
+
+            let rd = _mm512_loadu_ps(rd_values.as_ptr());
+            let max_dist = _mm512_set1_ps(max_dist);
+            _mm512_cmp_ps_mask(rd, max_dist, _CMP_LE_OQ) & sibling_mask
+        }
+
+        #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
+        {
+            let mut mask = 0u16;
+            for (lane, &rd) in rd_values.iter().enumerate() {
+                if rd <= max_dist {
+                    mask |= 1u16 << lane;
+                }
+            }
+            mask & sibling_mask
+        }
+    }
+
+    #[inline(always)]
+    fn simd_select_best_child_block4(rd_values: &[f32; 16], candidate_mask: u16) -> Option<u8> {
+        #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+        unsafe {
+            use std::arch::x86_64::*;
+
+            if candidate_mask == 0 {
+                return None;
+            }
+
+            let rd = _mm512_loadu_ps(rd_values.as_ptr());
+            let masked = _mm512_mask_mov_ps(_mm512_set1_ps(f32::INFINITY), candidate_mask, rd);
+            let min = _mm512_reduce_min_ps(masked);
+            let minima = _mm512_cmp_ps_mask(masked, _mm512_set1_ps(min), _CMP_EQ_OQ);
+            Some((minima & candidate_mask).trailing_zeros() as u8)
+        }
+
+        #[cfg(not(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f")))]
+        {
+            if candidate_mask == 0 {
+                return None;
+            }
+
+            let mut remaining = candidate_mask;
+            let mut best_idx = remaining.trailing_zeros() as usize;
+            let mut best_rd = rd_values[best_idx];
+            remaining &= remaining - 1;
+            while remaining != 0 {
+                let idx = remaining.trailing_zeros() as usize;
+                if rd_values[idx] < best_rd {
+                    best_idx = idx;
+                    best_rd = rd_values[idx];
+                }
+                remaining &= remaining - 1;
+            }
+            Some(best_idx as u8)
         }
     }
 }

--- a/src/stem_strategy/mod.rs
+++ b/src/stem_strategy/mod.rs
@@ -11,8 +11,8 @@ pub use donnelly::simd_full::{CompareBlock3, CompareBlock4, SimdPrune, SimdSelec
 pub use donnelly::Donnelly;
 #[doc(hidden)]
 pub use donnelly::{
-    DonnellyCyclicSimdDescent, DonnellyNoPf, DonnellySimdDescent, DonnellySimdFull,
-    DonnellyUnrolled, DonnellyUnrolledBlockDim,
+    DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, DonnellyNoPf, DonnellySimdDescent,
+    DonnellySimdFull, DonnellyUnrolled, DonnellyUnrolledBlockDim,
 };
 
 #[doc(hidden)]

--- a/src/traits/axis.rs
+++ b/src/traits/axis.rs
@@ -31,6 +31,7 @@ pub trait Axis:
     + AddAssign<Self>
     + Debug
     + Display
+    + 'static
     + crate::stem_strategy::CompareBlock3
     + crate::stem_strategy::CompareBlock4
 {
@@ -114,7 +115,6 @@ macro_rules! impl_axis_float {
     ($t:ty) => {
         impl Axis for $t {
             const IS_SIGNED: bool = true;
-
             type Coord = $t;
 
             #[inline(always)]

--- a/src/traits/axis.rs
+++ b/src/traits/axis.rs
@@ -1,5 +1,6 @@
 use num_traits::ConstZero;
 use std::fmt::{Debug, Display};
+use std::mem::MaybeUninit;
 use std::ops::{AddAssign, Sub};
 
 use fixed::types::extra::{U0, U16, U8};
@@ -84,6 +85,20 @@ pub trait Axis:
             std::any::type_name::<Self>()
         )
     }
+
+    /// Select a cyclic path using query lanes prepared once per query.
+    #[doc(hidden)]
+    #[inline(always)]
+    fn compare_prepared_cyclic_block<const BH: usize>(
+        _stems: &[Self],
+        _query_lanes: &[MaybeUninit<Self>; 16],
+        _block_base_idx: usize,
+    ) -> u8 {
+        unimplemented!(
+            "axis {} does not support prepared cyclic SIMD block comparison",
+            std::any::type_name::<Self>()
+        )
+    }
 }
 
 /// Macro to implement AxisUnified for floating-point types.
@@ -164,6 +179,19 @@ macro_rules! impl_axis_float {
                     query,
                     block_base_idx,
                     start_dim,
+                )
+            }
+
+            #[inline(always)]
+            fn compare_prepared_cyclic_block<const BH: usize>(
+                stems: &[Self],
+                query_lanes: &[MaybeUninit<Self>; 16],
+                block_base_idx: usize,
+            ) -> u8 {
+                <Self as crate::stem_strategy::donnelly::cyclic_simd_descent::CyclicBlockCompare>::compare_prepared_cyclic_block::<BH>(
+                    stems,
+                    query_lanes,
+                    block_base_idx,
                 )
             }
         }

--- a/src/traits/stem_strategy.rs
+++ b/src/traits/stem_strategy.rs
@@ -1,4 +1,5 @@
 use aligned_vec::AVec;
+use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 
 use crate::kd_tree::query_stack::{ScalarStackContext, StackTrait};
@@ -6,6 +7,21 @@ use crate::stem_strategy::donnelly::simd_full::{BacktrackBlock3, BacktrackBlock4
 use crate::{Axis, Content};
 
 const MAX_MUTABLE_STEM_LEVEL_SLACK: usize = 4;
+
+/// Cache-line-aligned, phase-specific SIMD query lanes. Strategies initialize
+/// only phases and lanes their traversal can reach.
+#[doc(hidden)]
+#[repr(C, align(64))]
+pub struct PreparedBlockQuery<A, const K: usize>(pub [[MaybeUninit<A>; 16]; K]);
+
+impl<A, const K: usize> std::ops::Index<usize> for PreparedBlockQuery<A, K> {
+    type Output = [MaybeUninit<A>; 16];
+
+    #[inline(always)]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 /// Trait that needs to be implemented by any potential stem ordering
 /// algorithm used by a KdTree.
@@ -43,6 +59,11 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
     /// root-to-terminal path before replaying that path through the ordinary
     /// scalar continuation machinery.
     const USES_SIMD_BLOCK_DESCENT: bool = false;
+
+    /// Whether the strategy prepares phase-specific SIMD query lanes once per
+    /// query and reuses them for every complete block.
+    #[doc(hidden)]
+    const USES_PREPARED_BLOCK_QUERY: bool = false;
 
     /// Whether SIMD block selection is also used after entering a deferred far
     /// subtree. Initial descent is always eligible when
@@ -124,6 +145,29 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
         _start_dim: usize,
     ) -> u8 {
         unreachable!("strategy does not implement SIMD block descent")
+    }
+
+    /// Prepare phase-specific SIMD query lanes once for this query.
+    #[doc(hidden)]
+    #[inline(always)]
+    fn prepare_block_query<A: Axis<Coord = A>, const K: usize>(
+        _query: &[A; K],
+    ) -> PreparedBlockQuery<A, K> {
+        PreparedBlockQuery([[MaybeUninit::uninit(); 16]; K])
+    }
+
+    /// Select a terminal block child using a query representation prepared by
+    /// [`Self::prepare_block_query`].
+    #[doc(hidden)]
+    #[inline(always)]
+    fn select_prepared_block_child<A: Axis<Coord = A>, const K: usize>(
+        &self,
+        stems: &[A],
+        query: &[A; K],
+        _prepared: &PreparedBlockQuery<A, K>,
+        start_dim: usize,
+    ) -> u8 {
+        self.select_block_child(stems, query, start_dim)
     }
 
     /// Get the current level

--- a/src/traits/stem_strategy.rs
+++ b/src/traits/stem_strategy.rs
@@ -539,7 +539,11 @@ pub trait StemStrategy: Clone + Sync + Send + 'static {
             + crate::kd_tree::KdTreeQueryOps<A, T, Self, LS, K2, B>,
         A: Axis<Coord = A>,
         T: Content,
-        O: Axis<Coord = O> + BacktrackBlock3 + BacktrackBlock4,
+        O: Axis<Coord = O>
+            + crate::stem_strategy::SimdPrune
+            + crate::stem_strategy::SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4,
         D: crate::dist::DistanceMetric<A, Output = O>,
         QC: crate::kd_tree::query_context::QueryContext<A, O, K2>,
         LS: crate::LeafStrategy<A, T, Self, K2, B>,

--- a/tests/donnelly_simd_regressions.rs
+++ b/tests/donnelly_simd_regressions.rs
@@ -7,7 +7,9 @@ use kiddo::kd_tree::KdTree;
 #[cfg(feature = "simd")]
 use kiddo::leaf_strategy::FlatVec;
 #[cfg(feature = "simd")]
-use kiddo::stem_strategy::{Donnelly, DonnellySimdFull};
+use kiddo::stem_strategy::{
+    Donnelly, DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, DonnellySimdFull,
+};
 #[cfg(feature = "simd")]
 use kiddo::BestQueryResultItem;
 #[cfg(feature = "simd")]
@@ -31,6 +33,78 @@ const POINT_COUNT: usize = 1_022;
 const REL_EPS_F32: f32 = 1.0e-6;
 #[cfg(feature = "simd")]
 const REL_EPS_F64: f64 = 1.0e-12;
+
+#[test]
+#[cfg(feature = "simd")]
+fn cyclic_simd_handles_f32_k3_with_root_padding() {
+    const K: usize = 3;
+    const B: usize = 8;
+    let points: Vec<[f32; K]> = (0..33)
+        .map(|i| {
+            let x = i as f32 / 37.0;
+            [x, (x * 1.7).fract(), (x * 2.9).fract()]
+        })
+        .collect();
+    let tree: KdTree<f32, usize, DonnellyCyclicSimdDescent<4>, FlatVec<f32, usize, K, B>, K, B> =
+        KdTree::new_from_slice(&points).unwrap();
+
+    assert_eq!(tree.max_stem_level(), 3);
+    for (expected_item, point) in points.iter().enumerate() {
+        let result = tree
+            .query(point)
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        assert_eq!(result.distance, 0.0);
+        assert_eq!(result.item, expected_item);
+    }
+
+    let full_tree: KdTree<f32, usize, DonnellyCyclicSimdFull<4>, FlatVec<f32, usize, K, B>, K, B> =
+        KdTree::new_from_slice(&points).unwrap();
+    for (expected_item, point) in points.iter().enumerate() {
+        let result = full_tree
+            .query(point)
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        assert_eq!(result.distance, 0.0);
+        assert_eq!(result.item, expected_item);
+    }
+}
+
+#[test]
+#[cfg(feature = "simd")]
+fn cyclic_simd_handles_f64_k4_with_two_root_padding_levels() {
+    const K: usize = 4;
+    const B: usize = 8;
+    let points: Vec<[f64; K]> = (0..65)
+        .map(|i| {
+            let x = i as f64 / 71.0;
+            [x, (x * 1.7).fract(), (x * 2.9).fract(), (x * 4.3).fract()]
+        })
+        .collect();
+    let tree: KdTree<f64, usize, DonnellyCyclicSimdDescent<3>, FlatVec<f64, usize, K, B>, K, B> =
+        KdTree::new_from_slice(&points).unwrap();
+
+    assert_eq!(tree.max_stem_level(), 5);
+    for (expected_item, point) in points.iter().enumerate() {
+        let result = tree
+            .query(point)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        assert_eq!(result.distance, 0.0);
+        assert_eq!(result.item, expected_item);
+    }
+
+    let full_tree: KdTree<f64, usize, DonnellyCyclicSimdFull<3>, FlatVec<f64, usize, K, B>, K, B> =
+        KdTree::new_from_slice(&points).unwrap();
+    for (expected_item, point) in points.iter().enumerate() {
+        let result = full_tree
+            .query(point)
+            .nearest_one::<SquaredEuclidean<f64>>()
+            .execute();
+        assert_eq!(result.distance, 0.0);
+        assert_eq!(result.item, expected_item);
+    }
+}
 
 #[cfg(feature = "simd")]
 fn build_points_f32_k2() -> Vec<[f32; 2]> {

--- a/tests/donnelly_simd_regressions.rs
+++ b/tests/donnelly_simd_regressions.rs
@@ -13,7 +13,7 @@ use kiddo::stem_strategy::{
 #[cfg(feature = "simd")]
 use kiddo::BestQueryResultItem;
 #[cfg(feature = "simd")]
-use kiddo::SquaredEuclidean;
+use kiddo::{Chebyshev, Manhattan, Minkowski, SquaredEuclidean};
 #[cfg(feature = "simd")]
 use rand::rngs::StdRng;
 #[cfg(feature = "simd")]
@@ -104,6 +104,90 @@ fn cyclic_simd_handles_f64_k4_with_two_root_padding_levels() {
         assert_eq!(result.distance, 0.0);
         assert_eq!(result.item, expected_item);
     }
+}
+
+#[test]
+#[cfg(feature = "simd")]
+fn cyclic_simd_full_native_f64_k3_metrics_match_linear_search() {
+    const K: usize = 3;
+    const B: usize = 8;
+    let mut rng = StdRng::seed_from_u64(CONTENT_SEED);
+    let points: Vec<[f64; K]> = (0..777)
+        .map(|_| std::array::from_fn(|_| rng.random_range(-1.0..1.0)))
+        .collect();
+    let tree: KdTree<f64, usize, DonnellyCyclicSimdFull<3>, FlatVec<f64, usize, K, B>, K, B> =
+        KdTree::new_from_slice(&points).unwrap();
+    assert_eq!((tree.max_stem_level() + 1) % 3, 0);
+
+    macro_rules! assert_metric {
+        ($metric:ty) => {{
+            let mut query_rng = StdRng::seed_from_u64(QUERY_SEED);
+            for _ in 0..256 {
+                let query = std::array::from_fn(|_| query_rng.random_range(-1.0..1.0));
+                let expected = points
+                    .iter()
+                    .enumerate()
+                    .map(|(item, point)| {
+                        (
+                            <$metric as DistanceMetricScalar<f64>>::dist_raw(&query, point),
+                            item,
+                        )
+                    })
+                    .min_by(|lhs, rhs| lhs.0.partial_cmp(&rhs.0).unwrap())
+                    .unwrap();
+                let actual = tree.query(&query).nearest_one::<$metric>().execute();
+                assert_float_relative_eq!(actual.distance, expected.0, REL_EPS_F64);
+                assert_eq!(actual.item, expected.1);
+            }
+        }};
+    }
+
+    assert_metric!(SquaredEuclidean<f64>);
+    assert_metric!(Manhattan<f64>);
+    assert_metric!(Chebyshev<f64>);
+    assert_metric!(Minkowski<3, f64>);
+}
+
+#[test]
+#[cfg(feature = "simd")]
+fn cyclic_simd_full_native_f32_k4_metrics_match_linear_search() {
+    const K: usize = 4;
+    const B: usize = 8;
+    let mut rng = StdRng::seed_from_u64(CONTENT_SEED);
+    let points: Vec<[f32; K]> = (0..777)
+        .map(|_| std::array::from_fn(|_| rng.random_range(-1.0..1.0)))
+        .collect();
+    let tree: KdTree<f32, usize, DonnellyCyclicSimdFull<4>, FlatVec<f32, usize, K, B>, K, B> =
+        KdTree::new_from_slice(&points).unwrap();
+    assert_eq!((tree.max_stem_level() + 1) % 4, 0);
+
+    macro_rules! assert_metric {
+        ($metric:ty) => {{
+            let mut query_rng = StdRng::seed_from_u64(QUERY_SEED);
+            for _ in 0..256 {
+                let query = std::array::from_fn(|_| query_rng.random_range(-1.0..1.0));
+                let expected = points
+                    .iter()
+                    .enumerate()
+                    .map(|(item, point)| {
+                        (
+                            <$metric as DistanceMetricScalar<f32>>::dist_raw(&query, point),
+                            item,
+                        )
+                    })
+                    .min_by(|lhs, rhs| lhs.0.partial_cmp(&rhs.0).unwrap())
+                    .unwrap();
+                let actual = tree.query(&query).nearest_one::<$metric>().execute();
+                assert_float_relative_eq!(actual.distance, expected.0, REL_EPS_F32);
+                assert_eq!(actual.item, expected.1);
+            }
+        }};
+    }
+
+    assert_metric!(SquaredEuclidean<f32>);
+    assert_metric!(Manhattan<f32>);
+    assert_metric!(Chebyshev<f32>);
+    assert_metric!(Minkowski<3, f32>);
 }
 
 #[cfg(feature = "simd")]


### PR DESCRIPTION
Extend the recent `DonnellyCyclicSimdDescent` stem strategy (Enables Donnelly block-at-once SIMD evaluation for standard dimension schedule, ie XYZXYZXYZ rather than prior single-dim block-at-once XXXYYYZZZ, by using specially crafted query vectors rather than simple broadcast-one-axis-to-all-lanes) with re-written SIMD pruning / backtracking code.

Initial tests show this to be the fastest variant yet tested, beating Eytzinger in almost all situations for exact nearest one, often quite substantially - as well as extending the performance lead for ANN.