### PR TITLE
feat: single-session, all-four-strategy competitor benchmark scripts

### DIFF
--- a/benches/cpp_shims/nanoflann_shim.cpp
+++ b/benches/cpp_shims/nanoflann_shim.cpp
@@ -5,8 +5,19 @@
 // Euclidean, radius arguments are squared radii, and within_radius results
 // are written into a caller-provided buffer up to `cap` entries while the
 // true (possibly larger) match count is always returned.
+//
+// Dimension is a compile-time template parameter on nanoflann's Index (its
+// whole performance case rests on the compiler unrolling per-dimension
+// arithmetic), so two dimensions are compiled in rather than one: 3, for the
+// f64 comparisons, and 4, for f32 -- the two block heights the cyclic
+// Donnelly strategies are native to. `build` picks the matching
+// specialization at runtime from the `dim` argument and tags the returned
+// handle with it; every other entry point switches on that tag once per call
+// to recover the concrete type. Any dimension other than 3 or 4 aborts,
+// since nothing else is compiled in.
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -28,56 +39,92 @@ struct FlatCloud {
     bool kdtree_get_bbox(BBox&) const { return false; }
 };
 
-template <typename Scalar>
-struct Handle {
+template <typename Scalar, int Dim>
+struct HandleT {
     using Cloud = FlatCloud<Scalar>;
     using Adaptor = nanoflann::L2_Simple_Adaptor<Scalar, Cloud, Scalar, uint64_t>;
-    using Index = nanoflann::KDTreeSingleIndexAdaptor<Adaptor, Cloud, 3, uint64_t>;
+    using Index = nanoflann::KDTreeSingleIndexAdaptor<Adaptor, Cloud, Dim, uint64_t>;
 
     Cloud cloud;
     Index index;
 
-    Handle(const Scalar* points, uint64_t n, uint32_t dim)
+    HandleT(const Scalar* points, uint64_t n, uint32_t dim)
         : cloud{points, static_cast<std::size_t>(n), static_cast<std::size_t>(dim)},
           index(dim, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(32)) {
         index.buildIndex();
     }
 };
 
+// Type-erased, dimension-tagged handle. `inner` points at a HandleT<Scalar,
+// 3> or HandleT<Scalar, 4>, decided by `dim` at construction and read back by
+// every call below -- the tag, not the pointer's static type, is what makes
+// this safe.
+template <typename Scalar>
+struct Handle {
+    uint32_t dim;
+    void* inner;
+};
+
+// Recovers the concrete HandleT and calls `f` on it, so each query function
+// below is one line instead of a repeated switch.
+template <typename Scalar, typename F>
+auto dispatch(Handle<Scalar>* handle, F&& f) {
+    switch (handle->dim) {
+        case 3: return f(*static_cast<HandleT<Scalar, 3>*>(handle->inner));
+        case 4: return f(*static_cast<HandleT<Scalar, 4>*>(handle->inner));
+        default: std::abort();
+    }
+}
+
 template <typename Scalar>
 void* build(const Scalar* points, uint64_t n, uint32_t dim) {
-    return new Handle<Scalar>(points, n, dim);
+    void* inner;
+    switch (dim) {
+        case 3: inner = new HandleT<Scalar, 3>(points, n, dim); break;
+        case 4: inner = new HandleT<Scalar, 4>(points, n, dim); break;
+        default: std::abort();
+    }
+    return new Handle<Scalar>{dim, inner};
 }
 
 template <typename Scalar>
 void free_handle(void* h) {
-    delete static_cast<Handle<Scalar>*>(h);
+    auto* handle = static_cast<Handle<Scalar>*>(h);
+    switch (handle->dim) {
+        case 3: delete static_cast<HandleT<Scalar, 3>*>(handle->inner); break;
+        case 4: delete static_cast<HandleT<Scalar, 4>*>(handle->inner); break;
+        default: std::abort();
+    }
+    delete handle;
 }
 
 template <typename Scalar>
 void nearest_one(void* h, const Scalar* q, uint64_t* out_idx, Scalar* out_dist2) {
-    auto* handle = static_cast<Handle<Scalar>*>(h);
-    handle->index.knnSearch(q, 1, out_idx, out_dist2);
+    dispatch(static_cast<Handle<Scalar>*>(h), [&](auto& handle) {
+        handle.index.knnSearch(q, 1, out_idx, out_dist2);
+    });
 }
 
 template <typename Scalar>
 uint64_t nearest_n(void* h, const Scalar* q, uint64_t k, uint64_t* out_idx, Scalar* out_dist2) {
-    auto* handle = static_cast<Handle<Scalar>*>(h);
-    return static_cast<uint64_t>(handle->index.knnSearch(q, static_cast<std::size_t>(k), out_idx, out_dist2));
+    return dispatch(static_cast<Handle<Scalar>*>(h), [&](auto& handle) {
+        return static_cast<uint64_t>(handle.index.knnSearch(q, static_cast<std::size_t>(k), out_idx, out_dist2));
+    });
 }
 
 template <typename Scalar>
 uint64_t within_radius(
     void* h, const Scalar* q, Scalar radius2, uint64_t* out_idx, Scalar* out_dist2, uint64_t cap) {
-    auto* handle = static_cast<Handle<Scalar>*>(h);
-    std::vector<nanoflann::ResultItem<uint64_t, Scalar>> matches;
-    const uint64_t total = static_cast<uint64_t>(handle->index.radiusSearch(q, radius2, matches));
-    const uint64_t copy_n = total < cap ? total : cap;
-    for (uint64_t i = 0; i < copy_n; ++i) {
-        out_idx[i] = matches[i].first;
-        out_dist2[i] = matches[i].second;
-    }
-    return total;
+    return dispatch(static_cast<Handle<Scalar>*>(h), [&](auto& handle) {
+        std::vector<nanoflann::ResultItem<uint64_t, Scalar>> matches;
+        const uint64_t total = static_cast<uint64_t>(handle.index.radiusSearch(q, radius2, matches));
+        const uint64_t copy_n = total < cap ? total : cap;
+        for (uint64_t i = 0; i < copy_n; ++i) {
+            out_idx[i] = matches[i].first;
+            out_dist2[i] = matches[i].second;
+        }
+        return total;
+    });
 }
 
 }  // namespace

--- a/benches/cpp_shims/pkdtree_shim.cpp
+++ b/benches/cpp_shims/pkdtree_shim.cpp
@@ -21,8 +21,19 @@
 // Point indices are recovered by pointer arithmetic against the (build()
 // reorders points in place) stored point array, since cpdd::PointType
 // carries no id field of its own.
+//
+// cpdd::PointType and k_nearest's DIM argument are both compile-time-shaped
+// around a fixed dimension (Pkd-tree's whole performance case rests on the
+// compiler unrolling per-dimension arithmetic), so two dimensions are
+// compiled in rather than one: 3, for the f64 comparisons, and 4, for f32 --
+// the two block heights the cyclic Donnelly strategies are native to.
+// `build` picks the matching specialization at runtime from the `dim`
+// argument and tags the returned handle with it; every other entry point
+// switches on that tag once per call to recover the concrete type. Any
+// dimension other than 3 or 4 aborts, since nothing else is compiled in.
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <vector>
@@ -31,85 +42,136 @@
 
 namespace {
 
-template <typename Scalar>
-using Point = cpdd::PointType<Scalar, 3>;
+template <typename Scalar, int Dim>
+using Point = cpdd::PointType<Scalar, Dim>;
 
-template <typename Scalar>
-using Tree = cpdd::ParallelKDtree<Point<Scalar>>;
+template <typename Scalar, int Dim>
+using Tree = cpdd::ParallelKDtree<Point<Scalar, Dim>>;
 
-template <typename Scalar>
-using NNPair = std::pair<std::reference_wrapper<Point<Scalar>>, Scalar>;
+template <typename Scalar, int Dim>
+using NNPair = std::pair<std::reference_wrapper<Point<Scalar, Dim>>, Scalar>;
 
-template <typename Scalar>
-struct Handle {
-    Tree<Scalar> tree;
-    typename Tree<Scalar>::points wp;
-    typename Tree<Scalar>::node* root = nullptr;
-    typename Tree<Scalar>::box root_box;
+template <typename Scalar, int Dim>
+struct HandleT {
+    Tree<Scalar, Dim> tree;
+    typename Tree<Scalar, Dim>::points wp;
+    typename Tree<Scalar, Dim>::node* root = nullptr;
+    typename Tree<Scalar, Dim>::box root_box;
 
-    explicit Handle(const Scalar* points, uint64_t n, uint32_t dim)
-        : wp(Tree<Scalar>::points::uninitialized(n)) {
+    explicit HandleT(const Scalar* points, uint64_t n)
+        : wp(Tree<Scalar, Dim>::points::uninitialized(n)) {
         for (uint64_t i = 0; i < n; ++i) {
-            wp[i] = Point<Scalar>(const_cast<Scalar*>(points + i * dim));
+            wp[i] = Point<Scalar, Dim>(const_cast<Scalar*>(points + i * Dim));
         }
-        tree.build(parlay::make_slice(wp), static_cast<uint_fast8_t>(dim));
+        tree.build(parlay::make_slice(wp), static_cast<uint_fast8_t>(Dim));
         root = tree.get_root();
         root_box = tree.get_root_box();
     }
 
-    uint64_t index_of(const Point<Scalar>& p) const {
+    uint64_t index_of(const Point<Scalar, Dim>& p) const {
         return static_cast<uint64_t>(&p - &wp[0]);
     }
 };
 
+// Type-erased, dimension-tagged handle. `inner` points at a HandleT<Scalar,
+// 3> or HandleT<Scalar, 4>, decided by `dim` at construction and read back by
+// every call below -- the tag, not the pointer's static type, is what makes
+// this safe.
+template <typename Scalar>
+struct Handle {
+    uint32_t dim;
+    void* inner;
+};
+
+// Recovers the concrete HandleT and calls `f` on it, so each entry point
+// below is one line instead of a repeated switch.
+template <typename Scalar, typename F>
+auto dispatch(Handle<Scalar>* handle, F&& f) {
+    switch (handle->dim) {
+        case 3: return f(*static_cast<HandleT<Scalar, 3>*>(handle->inner));
+        case 4: return f(*static_cast<HandleT<Scalar, 4>*>(handle->inner));
+        default: std::abort();
+    }
+}
+
 template <typename Scalar>
 void* build(const Scalar* points, uint64_t n, uint32_t dim) {
-    return new Handle<Scalar>(points, n, dim);
+    void* inner;
+    switch (dim) {
+        case 3: inner = new HandleT<Scalar, 3>(points, n); break;
+        case 4: inner = new HandleT<Scalar, 4>(points, n); break;
+        default: std::abort();
+    }
+    return new Handle<Scalar>{dim, inner};
 }
 
 template <typename Scalar>
 void free_handle(void* h) {
-    delete static_cast<Handle<Scalar>*>(h);
+    auto* handle = static_cast<Handle<Scalar>*>(h);
+    switch (handle->dim) {
+        case 3: delete static_cast<HandleT<Scalar, 3>*>(handle->inner); break;
+        case 4: delete static_cast<HandleT<Scalar, 4>*>(handle->inner); break;
+        default: std::abort();
+    }
+    delete handle;
 }
 
 // One query, composed exactly as cpdd's own single-query benchmark does.
-template <typename Scalar>
-uint64_t single_query(Handle<Scalar>* h, const Scalar* q, uint64_t k, uint64_t* out_idx, Scalar* out_dist2) {
-    Point<Scalar> query(const_cast<Scalar*>(q));
-    std::vector<NNPair<Scalar>> storage(k, NNPair<Scalar>(std::ref(h->wp[0]), Scalar(0)));
-    cpdd::kBoundedQueue<Point<Scalar>, NNPair<Scalar>> bq(parlay::make_slice(storage.data(), storage.data() + k));
+template <typename Scalar, int Dim>
+uint64_t single_query_impl(
+    HandleT<Scalar, Dim>& h, const Scalar* q, uint64_t k, uint64_t* out_idx, Scalar* out_dist2) {
+    Point<Scalar, Dim> query(const_cast<Scalar*>(q));
+    std::vector<NNPair<Scalar, Dim>> storage(k, NNPair<Scalar, Dim>(std::ref(h.wp[0]), Scalar(0)));
+    cpdd::kBoundedQueue<Point<Scalar, Dim>, NNPair<Scalar, Dim>> bq(
+        parlay::make_slice(storage.data(), storage.data() + k));
     size_t visited = 0;
-    h->tree.k_nearest(h->root, query, 3, bq, h->root_box, visited);
+    h.tree.k_nearest(h.root, query, Dim, bq, h.root_box, visited);
 
     const uint64_t found = static_cast<uint64_t>(bq.m_count);
     for (uint64_t i = 0; i < found; ++i) {
-        out_idx[i] = h->index_of(storage[i].first.get());
+        out_idx[i] = h.index_of(storage[i].first.get());
         out_dist2[i] = storage[i].second;
     }
     return found;
 }
 
-// All queries at once, parallel across every core via parlay::parallel_for.
 template <typename Scalar>
-void batch_query(
-    Handle<Scalar>* h, const Scalar* queries_flat, uint64_t num_queries, uint64_t k, uint64_t* out_idx,
+uint64_t single_query(Handle<Scalar>* h, const Scalar* q, uint64_t k, uint64_t* out_idx, Scalar* out_dist2) {
+    return dispatch(h, [&](auto& handle) { return single_query_impl(handle, q, k, out_idx, out_dist2); });
+}
+
+// All queries at once, parallel across every core via parlay::parallel_for.
+template <typename Scalar, int Dim>
+void batch_query_impl(
+    HandleT<Scalar, Dim>& h, const Scalar* queries_flat, uint64_t num_queries, uint64_t k, uint64_t* out_idx,
     Scalar* out_dist2) {
     parlay::parallel_for(0, num_queries, [&](size_t qi) {
-        Point<Scalar> query(const_cast<Scalar*>(queries_flat + qi * 3));
-        std::vector<NNPair<Scalar>> storage(k, NNPair<Scalar>(std::ref(h->wp[0]), Scalar(0)));
-        cpdd::kBoundedQueue<Point<Scalar>, NNPair<Scalar>> bq(parlay::make_slice(storage.data(), storage.data() + k));
+        Point<Scalar, Dim> query(const_cast<Scalar*>(queries_flat + qi * Dim));
+        std::vector<NNPair<Scalar, Dim>> storage(k, NNPair<Scalar, Dim>(std::ref(h.wp[0]), Scalar(0)));
+        cpdd::kBoundedQueue<Point<Scalar, Dim>, NNPair<Scalar, Dim>> bq(
+            parlay::make_slice(storage.data(), storage.data() + k));
         size_t visited = 0;
-        h->tree.k_nearest(h->root, query, 3, bq, h->root_box, visited);
+        h.tree.k_nearest(h.root, query, Dim, bq, h.root_box, visited);
 
         const uint64_t found = static_cast<uint64_t>(bq.m_count);
         for (uint64_t i = 0; i < found; ++i) {
-            out_idx[qi * k + i] = h->index_of(storage[i].first.get());
+            out_idx[qi * k + i] = h.index_of(storage[i].first.get());
             out_dist2[qi * k + i] = storage[i].second;
         }
         for (uint64_t i = found; i < k; ++i) {
             out_idx[qi * k + i] = 0;
             out_dist2[qi * k + i] = Scalar(0);
         }
+    });
+}
+
+template <typename Scalar>
+void batch_query(
+    Handle<Scalar>* h, const Scalar* queries_flat, uint64_t num_queries, uint64_t k, uint64_t* out_idx,
+    Scalar* out_dist2) {
+    dispatch(h, [&](auto& handle) {
+        batch_query_impl(handle, queries_flat, num_queries, k, out_idx, out_dist2);
+        return 0;
     });
 }
 

--- a/benches/profile_cpp_competitors.rs
+++ b/benches/profile_cpp_competitors.rs
@@ -78,7 +78,9 @@ use criterion::{
 use kiddo::batch::Executor;
 use kiddo::kd_tree::KdTree;
 use kiddo::leaf_strategy::FlatVec;
-use kiddo::stem_strategy::{DonnellyCyclicSimdDescent, DonnellyUnrolled, Eytzinger};
+use kiddo::stem_strategy::{
+    DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull, DonnellyUnrolled, Eytzinger,
+};
 use kiddo::SquaredEuclidean;
 use kiddo::StemStrategy;
 use rand::{RngExt, SeedableRng};
@@ -87,7 +89,14 @@ use std::ffi::c_void;
 use std::hint::black_box;
 use std::num::NonZeroUsize;
 
-const K: usize = 3;
+// One dimensionality per scalar rather than one shared K: the cyclic
+// Donnelly strategies (DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull)
+// are native to block-height-3 for f64 and block-height-4 for f32, and
+// running every library at the block height its own strategies are native
+// to keeps every comparison in this file apples-to-apples per scalar,
+// rather than only the cyclic strategies getting their fast path.
+const K_F32: usize = 4;
+const K_F64: usize = 3;
 const DEFAULT_QUERY_COUNT: usize = 1_000;
 const DEFAULT_MIN_LOG2_POINTS: u32 = 16;
 const DEFAULT_MAX_LOG2_POINTS: u32 = 24;
@@ -133,41 +142,66 @@ const F32: &str = "f32";
 const F64: &str = "f64";
 const ALL_SCALARS: [&str; 2] = [F32, F64];
 
+const STRATEGY_EYTZINGER: &str = "eytzinger";
+const STRATEGY_DONNELLY_UNROLLED: &str = "donnelly_unrolled";
+const STRATEGY_DONNELLY_CYCLIC_SIMD_DESCENT: &str = "donnelly_cyclic_simd_descent";
+const STRATEGY_DONNELLY_CYCLIC_SIMD_FULL: &str = "donnelly_cyclic_simd_full";
+// Same four names and order as profile_v6_cyclic_query_pool.rs's
+// KIDDO_CYCLIC_STRATEGIES, so a results file from either bench sorts and
+// reads the same way.
+const ALL_STRATEGIES: [&str; 4] = [
+    STRATEGY_EYTZINGER,
+    STRATEGY_DONNELLY_UNROLLED,
+    STRATEGY_DONNELLY_CYCLIC_SIMD_DESCENT,
+    STRATEGY_DONNELLY_CYCLIC_SIMD_FULL,
+];
+
 // Pkd-tree's build_recursive has a box-containment assertion that fails for
 // f32 from 2^22 points upward: 2^21 builds, 2^22 and 2^23 abort, and f64 is
 // unaffected at least through 2^24. The assertion aborts the process rather
 // than returning an error, which would take every later benchmark in the same
 // run down with it, so oversized f32 Pkd-tree cells are skipped up front.
+// Reconfirmed at K_F32=4 (originally measured at the shared K=3 this file
+// used before the cyclic strategies needed a per-scalar dimension): 2^21
+// still builds cleanly.
 const PKDTREE_MAX_LOG2_POINTS_F32: u32 = 21;
 
 /// Asserts that the experimental Donnelly cyclic SIMD descent answers exactly
 /// as the Eytzinger baseline does on this tree, so a throughput win can never
 /// be a wrong-answer win. Checked once per run, at the smallest size.
-fn validate_kiddo_strategies_f64(points: &[PointF64], queries: &[PointF64]) {
-    let eytzinger: KiddoF64 = KdTree::new_from_slice(points).unwrap();
-    let donnelly: KiddoF64<DonnellyCyclicSimdDescent<3>> = KdTree::new_from_slice(points).unwrap();
+/// Checks one strategy's answers against the Eytzinger baseline it was built
+/// alongside, for both query shapes. `label` names the strategy in a panic
+/// message, since the whole point of this check is to fail loudly and
+/// specifically rather than let a throughput win be a wrong-answer win.
+fn assert_strategy_matches_baseline_f64<S: StemStrategy>(
+    label: &str,
+    baseline: &KiddoF64,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    let candidate: KiddoF64<S> = KdTree::new_from_slice(points).unwrap();
     let max_qty = NonZeroUsize::new(*MAX_QTYS.last().unwrap()).unwrap();
 
     for (index, query) in queries.iter().enumerate() {
-        let expected = eytzinger
+        let expected = baseline
             .query(query)
             .nearest_one::<SquaredEuclidean<f64>>()
             .execute();
-        let actual = donnelly
+        let actual = candidate
             .query(query)
             .nearest_one::<SquaredEuclidean<f64>>()
             .execute();
         assert_eq!(
             (actual.item, actual.distance),
             (expected.item, expected.distance),
-            "Donnelly cyclic SIMD nearest_one disagrees with Eytzinger at query {index}"
+            "{label} nearest_one disagrees with Eytzinger at query {index}"
         );
 
-        let expected = eytzinger
+        let expected = baseline
             .query(query)
             .nearest_n::<SquaredEuclidean<f64>>(max_qty)
             .execute();
-        let actual = donnelly
+        let actual = candidate
             .query(query)
             .nearest_n::<SquaredEuclidean<f64>>(max_qty)
             .execute();
@@ -175,9 +209,102 @@ fn validate_kiddo_strategies_f64(points: &[PointF64], queries: &[PointF64]) {
         let actual: Vec<_> = actual.iter().map(|r| (r.item, r.distance)).collect();
         assert_eq!(
             actual, expected,
-            "Donnelly cyclic SIMD nearest_n disagrees with Eytzinger at query {index}"
+            "{label} nearest_n disagrees with Eytzinger at query {index}"
         );
     }
+}
+
+/// Asserts that every non-Eytzinger strategy answers exactly as the
+/// Eytzinger baseline does on this tree, so a throughput win can never be a
+/// wrong-answer win. Checked once per run, at the smallest size. f64-only:
+/// f64/K_F64 is the combination every strategy here is exercised at, so this
+/// is the one tree all four can be cross-checked on at once.
+fn validate_kiddo_strategies_f64(points: &[PointF64], queries: &[PointF64]) {
+    let eytzinger: KiddoF64 = KdTree::new_from_slice(points).unwrap();
+    assert_strategy_matches_baseline_f64::<DonnellyUnrolled<3>>(
+        "DonnellyUnrolled",
+        &eytzinger,
+        points,
+        queries,
+    );
+    assert_strategy_matches_baseline_f64::<DonnellyCyclicSimdDescent<3>>(
+        "DonnellyCyclicSimdDescent",
+        &eytzinger,
+        points,
+        queries,
+    );
+    assert_strategy_matches_baseline_f64::<DonnellyCyclicSimdFull<3>>(
+        "DonnellyCyclicSimdFull",
+        &eytzinger,
+        points,
+        queries,
+    );
+}
+
+/// f32 counterpart of [`assert_strategy_matches_baseline_f64`].
+fn assert_strategy_matches_baseline_f32<S: StemStrategy>(
+    label: &str,
+    baseline: &KiddoF32,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    let candidate: KiddoF32<S> = KdTree::new_from_slice(points).unwrap();
+    let max_qty = NonZeroUsize::new(*MAX_QTYS.last().unwrap()).unwrap();
+
+    for (index, query) in queries.iter().enumerate() {
+        let expected = baseline
+            .query(query)
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        let actual = candidate
+            .query(query)
+            .nearest_one::<SquaredEuclidean<f32>>()
+            .execute();
+        assert_eq!(
+            (actual.item, actual.distance),
+            (expected.item, expected.distance),
+            "{label} nearest_one disagrees with Eytzinger at query {index}"
+        );
+
+        let expected = baseline
+            .query(query)
+            .nearest_n::<SquaredEuclidean<f32>>(max_qty)
+            .execute();
+        let actual = candidate
+            .query(query)
+            .nearest_n::<SquaredEuclidean<f32>>(max_qty)
+            .execute();
+        let expected: Vec<_> = expected.iter().map(|r| (r.item, r.distance)).collect();
+        let actual: Vec<_> = actual.iter().map(|r| (r.item, r.distance)).collect();
+        assert_eq!(
+            actual, expected,
+            "{label} nearest_n disagrees with Eytzinger at query {index}"
+        );
+    }
+}
+
+/// f32 counterpart of [`validate_kiddo_strategies_f64`]; f32/K_F32 is the
+/// combination every f32 strategy here is exercised at.
+fn validate_kiddo_strategies_f32(points: &[PointF32], queries: &[PointF32]) {
+    let eytzinger: KiddoF32 = KdTree::new_from_slice(points).unwrap();
+    assert_strategy_matches_baseline_f32::<DonnellyUnrolled<4>>(
+        "DonnellyUnrolled",
+        &eytzinger,
+        points,
+        queries,
+    );
+    assert_strategy_matches_baseline_f32::<DonnellyCyclicSimdDescent<4>>(
+        "DonnellyCyclicSimdDescent",
+        &eytzinger,
+        points,
+        queries,
+    );
+    assert_strategy_matches_baseline_f32::<DonnellyCyclicSimdFull<4>>(
+        "DonnellyCyclicSimdFull",
+        &eytzinger,
+        points,
+        queries,
+    );
 }
 
 /// The executors charted side by side in the batch-throughput suite.
@@ -216,14 +343,17 @@ fn pkdtree_f32_selected(libraries: &Selection, point_count: usize) -> bool {
     true
 }
 
-type PointF32 = [f32; K];
-type PointF64 = [f64; K];
+type PointF32 = [f32; K_F32];
+type PointF64 = [f64; K_F64];
 const B: usize = 32;
-type KiddoF32<S = Eytzinger> = KdTree<f32, u32, S, FlatVec<f32, u32, K, B>, K, B>;
-type KiddoF64<S = Eytzinger> = KdTree<f64, u32, S, FlatVec<f64, u32, K, B>, K, B>;
-// DonnellyCyclicSimdDescent's AVX-512 path asserts BH == K, and is implemented
-// only for f64/3D/BH3 and f32/4D/BH4. These benchmarks are 3D for every
-// library, so f64 gets the SIMD descent and f32 (K=3) cannot have it at all.
+type KiddoF32<S = Eytzinger> = KdTree<f32, u32, S, FlatVec<f32, u32, K_F32, B>, K_F32, B>;
+type KiddoF64<S = Eytzinger> = KdTree<f64, u32, S, FlatVec<f64, u32, K_F64, B>, K_F64, B>;
+// DonnellyCyclicSimdDescent and DonnellyCyclicSimdFull each panic unless
+// BH matches the AVX-512 specialization compiled in for the scalar type: 3
+// for f64, 4 for f32 (independent of tree dimensionality, which is why
+// K_F32 and K_F64 differ above -- picking them to equal their scalar's block
+// height, rather than leaving both at a shared K=3, is what gives both
+// scalars their native fast path instead of only f64).
 
 mod ffi {
     use std::ffi::c_void;
@@ -465,6 +595,10 @@ fn scalar_selection() -> Selection {
     Selection::from_env("KIDDO_CPP_SCALARS", &ALL_SCALARS, &ALL_SCALARS)
 }
 
+fn strategy_selection() -> Selection {
+    Selection::from_env("KIDDO_STRATEGIES", &ALL_STRATEGIES, &ALL_STRATEGIES)
+}
+
 fn build_points_f32(point_count: usize) -> Vec<PointF32> {
     let mut rng = ChaCha8Rng::seed_from_u64(POINT_SEED);
     (0..point_count).map(|_| rng.random()).collect()
@@ -605,7 +739,7 @@ fn validate_implementations_f32(
             let handle = NanoflannF32(ffi::nanoflann_build_f32(
                 points.as_ptr().cast(),
                 points.len() as u64,
-                K as u32,
+                K_F32 as u32,
             ));
             let n = ffi::nanoflann_nearest_n_f32(
                 handle.0,
@@ -635,7 +769,7 @@ fn validate_implementations_f32(
             let handle = PkdtreeF32(ffi::pkdtree_build_f32(
                 points.as_ptr().cast(),
                 points.len() as u64,
-                K as u32,
+                K_F32 as u32,
             ));
             let n = ffi::pkdtree_single_query_f32(
                 handle.0,
@@ -679,7 +813,7 @@ fn validate_implementations_f64(
             let handle = NanoflannF64(ffi::nanoflann_build_f64(
                 points.as_ptr().cast(),
                 points.len() as u64,
-                K as u32,
+                K_F64 as u32,
             ));
             let n = ffi::nanoflann_nearest_n_f64(
                 handle.0,
@@ -707,7 +841,7 @@ fn validate_implementations_f64(
             let handle = AlglibF64(ffi::alglib_build_f64(
                 points.as_ptr().cast(),
                 points.len() as u64,
-                K as u32,
+                K_F64 as u32,
             ));
             let n = ffi::alglib_nearest_n_f64(
                 handle.0,
@@ -735,7 +869,8 @@ fn validate_implementations_f64(
             // Returns null if the globals are already occupied or a coordinate
             // is outside the quantisable range; both are silent-wrong-answer
             // hazards, so treat null as a hard failure rather than a skip.
-            let raw = ffi::skdtree_build_f64(points.as_ptr().cast(), points.len() as u64, K as u32);
+            let raw =
+                ffi::skdtree_build_f64(points.as_ptr().cast(), points.len() as u64, K_F64 as u32);
             assert!(
                 !raw.is_null(),
                 "skd-tree refused to build; see skdtree_shim.cpp"
@@ -754,7 +889,7 @@ fn validate_implementations_f64(
             let handle = PkdtreeF64(ffi::pkdtree_build_f64(
                 points.as_ptr().cast(),
                 points.len() as u64,
-                K as u32,
+                K_F64 as u32,
             ));
             let n = ffi::pkdtree_single_query_f64(
                 handle.0,
@@ -780,7 +915,7 @@ fn bench_nanoflann_f32(
         NanoflannF32(ffi::nanoflann_build_f32(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F32 as u32,
         ))
     };
 
@@ -876,7 +1011,7 @@ fn bench_nanoflann_f64(
         NanoflannF64(ffi::nanoflann_build_f64(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F64 as u32,
         ))
     };
 
@@ -972,7 +1107,7 @@ fn bench_alglib_f64(
         AlglibF64(ffi::alglib_build_f64(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F64 as u32,
         ))
     };
 
@@ -1066,7 +1201,7 @@ fn bench_pkdtree_f32(
         PkdtreeF32(ffi::pkdtree_build_f32(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F32 as u32,
         ))
     };
 
@@ -1135,8 +1270,9 @@ fn bench_skdtree_f64(
     points: &[PointF64],
     queries: &[PointF64],
 ) {
-    let raw =
-        unsafe { ffi::skdtree_build_f64(points.as_ptr().cast(), points.len() as u64, K as u32) };
+    let raw = unsafe {
+        ffi::skdtree_build_f64(points.as_ptr().cast(), points.len() as u64, K_F64 as u32)
+    };
     assert!(
         !raw.is_null(),
         "skd-tree refused to build at {point_count} points; see skdtree_shim.cpp"
@@ -1179,7 +1315,7 @@ fn bench_pkdtree_f64(
         PkdtreeF64(ffi::pkdtree_build_f64(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F64 as u32,
         ))
     };
 
@@ -1239,15 +1375,16 @@ fn bench_pkdtree_f64(
     }
 }
 
-fn bench_kiddo_single_f32(
+fn bench_kiddo_single_f32<S: StemStrategy>(
     group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
     point_count: usize,
     points: &[PointF32],
     queries: &[PointF32],
 ) {
-    let tree: KiddoF32 = KdTree::new_from_slice(points).unwrap();
+    let tree: KiddoF32<S> = KdTree::new_from_slice(points).unwrap();
 
-    group.bench_function(id("kiddo", "nearest_one", point_count), |b| {
+    group.bench_function(id(label, "nearest_one", point_count), |b| {
         b.iter(|| {
             let mut distance = 0.0f32;
             let mut item = 0u64;
@@ -1266,7 +1403,7 @@ fn bench_kiddo_single_f32(
     for max_qty in MAX_QTYS {
         let k = NonZeroUsize::new(max_qty).unwrap();
         group.bench_function(
-            id("kiddo", &format!("nearest_n_k{max_qty}"), point_count),
+            id(label, &format!("nearest_n_k{max_qty}"), point_count),
             |b| {
                 b.iter(|| {
                     let mut len = 0u64;
@@ -1290,15 +1427,16 @@ fn bench_kiddo_single_f32(
     }
 }
 
-fn bench_kiddo_single_f64(
+fn bench_kiddo_single_f64<S: StemStrategy>(
     group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
     point_count: usize,
     points: &[PointF64],
     queries: &[PointF64],
 ) {
-    let tree: KiddoF64 = KdTree::new_from_slice(points).unwrap();
+    let tree: KiddoF64<S> = KdTree::new_from_slice(points).unwrap();
 
-    group.bench_function(id("kiddo", "nearest_one", point_count), |b| {
+    group.bench_function(id(label, "nearest_one", point_count), |b| {
         b.iter(|| {
             let mut distance = 0.0f64;
             let mut item = 0u64;
@@ -1317,7 +1455,7 @@ fn bench_kiddo_single_f64(
     for max_qty in MAX_QTYS {
         let k = NonZeroUsize::new(max_qty).unwrap();
         group.bench_function(
-            id("kiddo", &format!("nearest_n_k{max_qty}"), point_count),
+            id(label, &format!("nearest_n_k{max_qty}"), point_count),
             |b| {
                 b.iter(|| {
                     let mut len = 0u64;
@@ -1341,6 +1479,91 @@ fn bench_kiddo_single_f64(
     }
 }
 
+/// Dispatches every selected strategy for one f32 tree size, each building
+/// and dropping its own tree in turn so only one is resident at a time.
+/// Labels match the batch suite's convention (`kiddo`, `kiddo_donnelly_*`).
+fn bench_kiddo_single_strategies_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    strategies: &Selection,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    if strategies.contains(STRATEGY_EYTZINGER) {
+        bench_kiddo_single_f32::<Eytzinger>(group, "kiddo", point_count, points, queries);
+    }
+    // BH=4 throughout: K_F32 is chosen to equal it, so every Donnelly variant
+    // here gets its native block height, not just the cyclic ones.
+    if strategies.contains(STRATEGY_DONNELLY_UNROLLED) {
+        bench_kiddo_single_f32::<DonnellyUnrolled<4>>(
+            group,
+            "kiddo_donnelly_unrolled",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_DESCENT) {
+        bench_kiddo_single_f32::<DonnellyCyclicSimdDescent<4>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_descent",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_FULL) {
+        bench_kiddo_single_f32::<DonnellyCyclicSimdFull<4>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_full",
+            point_count,
+            points,
+            queries,
+        );
+    }
+}
+
+/// f64 counterpart of [`bench_kiddo_single_strategies_f32`]; BH=3 throughout,
+/// matching K_F64.
+fn bench_kiddo_single_strategies_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    strategies: &Selection,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    if strategies.contains(STRATEGY_EYTZINGER) {
+        bench_kiddo_single_f64::<Eytzinger>(group, "kiddo", point_count, points, queries);
+    }
+    if strategies.contains(STRATEGY_DONNELLY_UNROLLED) {
+        bench_kiddo_single_f64::<DonnellyUnrolled<3>>(
+            group,
+            "kiddo_donnelly_unrolled",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_DESCENT) {
+        bench_kiddo_single_f64::<DonnellyCyclicSimdDescent<3>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_descent",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_FULL) {
+        bench_kiddo_single_f64::<DonnellyCyclicSimdFull<3>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_full",
+            point_count,
+            points,
+            queries,
+        );
+    }
+}
+
 fn kiddo_vs_pkdtree_single(c: &mut Criterion) {
     let suites = suite_selection();
     if !suites.contains(SUITE_KIDDO_VS_PKDTREE) {
@@ -1348,6 +1571,7 @@ fn kiddo_vs_pkdtree_single(c: &mut Criterion) {
     }
     let libraries = library_selection();
     let scalars = scalar_selection();
+    let strategies = strategy_selection();
     if !libraries.any(&[KIDDO, PKDTREE]) {
         return;
     }
@@ -1360,9 +1584,10 @@ fn kiddo_vs_pkdtree_single(c: &mut Criterion) {
     let max_log2_points = read_u32_env("KIDDO_LARGE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
 
     eprintln!(
-        "benchmarking kiddo vs Pkd-tree only, single-threaded per-query: scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count}",
+        "benchmarking kiddo vs Pkd-tree only, single-threaded per-query: scalars={} libraries={} strategies={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count}",
         scalars.list(),
-        libraries.list()
+        libraries.list(),
+        strategies.list()
     );
 
     if scalars.contains(F32) {
@@ -1373,7 +1598,19 @@ fn kiddo_vs_pkdtree_single(c: &mut Criterion) {
             let point_count = 1usize << log2_points;
             let points = build_points_f32(point_count);
             if libraries.contains(KIDDO) {
-                bench_kiddo_single_f32(&mut group, point_count, &points, &queries_f32);
+                if log2_points == min_log2_points {
+                    validate_kiddo_strategies_f32(
+                        &points,
+                        &queries_f32[..queries_f32.len().min(64)],
+                    );
+                }
+                bench_kiddo_single_strategies_f32(
+                    &mut group,
+                    &strategies,
+                    point_count,
+                    &points,
+                    &queries_f32,
+                );
             }
             if pkdtree_f32_selected(&libraries, point_count) {
                 bench_pkdtree_f32(&mut group, point_count, &points, &queries_f32);
@@ -1390,7 +1627,19 @@ fn kiddo_vs_pkdtree_single(c: &mut Criterion) {
             let point_count = 1usize << log2_points;
             let points = build_points_f64(point_count);
             if libraries.contains(KIDDO) {
-                bench_kiddo_single_f64(&mut group, point_count, &points, &queries_f64);
+                if log2_points == min_log2_points {
+                    validate_kiddo_strategies_f64(
+                        &points,
+                        &queries_f64[..queries_f64.len().min(64)],
+                    );
+                }
+                bench_kiddo_single_strategies_f64(
+                    &mut group,
+                    &strategies,
+                    point_count,
+                    &points,
+                    &queries_f64,
+                );
             }
             if libraries.contains(PKDTREE) {
                 bench_pkdtree_f64(&mut group, point_count, &points, &queries_f64);
@@ -1413,7 +1662,7 @@ fn bench_pkdtree_batch_f32(
         PkdtreeF32(ffi::pkdtree_build_f32(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F32 as u32,
         ))
     };
     let flat_queries: Vec<f32> = queries.iter().flatten().copied().collect();
@@ -1452,7 +1701,7 @@ fn bench_pkdtree_batch_f64(
         PkdtreeF64(ffi::pkdtree_build_f64(
             points.as_ptr().cast(),
             points.len() as u64,
-            K as u32,
+            K_F64 as u32,
         ))
     };
     let flat_queries: Vec<f64> = queries.iter().flatten().copied().collect();
@@ -1590,6 +1839,88 @@ fn bench_kiddo_batch_f64<S: StemStrategy>(
     }
 }
 
+/// Dispatches every selected strategy's batch benchmarks for one f32 tree
+/// size. BH=4 throughout, matching K_F32.
+fn bench_kiddo_batch_strategies_f32(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    strategies: &Selection,
+    point_count: usize,
+    points: &[PointF32],
+    queries: &[PointF32],
+) {
+    if strategies.contains(STRATEGY_EYTZINGER) {
+        bench_kiddo_batch_f32::<Eytzinger>(group, "kiddo_batch", point_count, points, queries);
+    }
+    if strategies.contains(STRATEGY_DONNELLY_UNROLLED) {
+        bench_kiddo_batch_f32::<DonnellyUnrolled<4>>(
+            group,
+            "kiddo_donnelly_unrolled_batch",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_DESCENT) {
+        bench_kiddo_batch_f32::<DonnellyCyclicSimdDescent<4>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_descent_batch",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_FULL) {
+        bench_kiddo_batch_f32::<DonnellyCyclicSimdFull<4>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_full_batch",
+            point_count,
+            points,
+            queries,
+        );
+    }
+}
+
+/// f64 counterpart of [`bench_kiddo_batch_strategies_f32`]; BH=3 throughout,
+/// matching K_F64.
+fn bench_kiddo_batch_strategies_f64(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    strategies: &Selection,
+    point_count: usize,
+    points: &[PointF64],
+    queries: &[PointF64],
+) {
+    if strategies.contains(STRATEGY_EYTZINGER) {
+        bench_kiddo_batch_f64::<Eytzinger>(group, "kiddo_batch", point_count, points, queries);
+    }
+    if strategies.contains(STRATEGY_DONNELLY_UNROLLED) {
+        bench_kiddo_batch_f64::<DonnellyUnrolled<3>>(
+            group,
+            "kiddo_donnelly_unrolled_batch",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_DESCENT) {
+        bench_kiddo_batch_f64::<DonnellyCyclicSimdDescent<3>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_descent_batch",
+            point_count,
+            points,
+            queries,
+        );
+    }
+    if strategies.contains(STRATEGY_DONNELLY_CYCLIC_SIMD_FULL) {
+        bench_kiddo_batch_f64::<DonnellyCyclicSimdFull<3>>(
+            group,
+            "kiddo_donnelly_cyclic_simd_full_batch",
+            point_count,
+            points,
+            queries,
+        );
+    }
+}
+
 fn pkdtree_batch(c: &mut Criterion) {
     let suites = suite_selection();
     if !suites.contains(SUITE_PKDTREE_BATCH) {
@@ -1597,6 +1928,7 @@ fn pkdtree_batch(c: &mut Criterion) {
     }
     let libraries = library_selection();
     let scalars = scalar_selection();
+    let strategies = strategy_selection();
     if !libraries.any(&[KIDDO, PKDTREE]) {
         return;
     }
@@ -1608,9 +1940,10 @@ fn pkdtree_batch(c: &mut Criterion) {
     let max_log2_points = read_u32_env("KIDDO_LARGE_MAX_LOG2_POINTS", DEFAULT_MAX_LOG2_POINTS);
 
     eprintln!(
-        "benchmarking batch-parallel throughput (kiddo serial+parallel executors, Pkd-tree parallel_for): scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} (all submitted at once)",
+        "benchmarking batch-parallel throughput (kiddo serial+parallel executors, Pkd-tree parallel_for): scalars={} libraries={} strategies={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} (all submitted at once)",
         scalars.list(),
-        libraries.list()
+        libraries.list(),
+        strategies.list()
     );
 
     if scalars.contains(F32) {
@@ -1621,20 +1954,15 @@ fn pkdtree_batch(c: &mut Criterion) {
             let point_count = 1usize << log2_points;
             let points = build_points_f32(point_count);
             if libraries.contains(KIDDO) {
-                bench_kiddo_batch_f32::<Eytzinger>(
+                if log2_points == min_log2_points {
+                    validate_kiddo_strategies_f32(
+                        &points,
+                        &queries_f32[..queries_f32.len().min(64)],
+                    );
+                }
+                bench_kiddo_batch_strategies_f32(
                     &mut group,
-                    "kiddo_batch",
-                    point_count,
-                    &points,
-                    &queries_f32,
-                );
-                // f32/3D cannot use DonnellyCyclicSimdDescent, whose AVX-512
-                // path requires BH == K == 4. DonnellyUnrolled has no such
-                // constraint, so f32 still gets the Donnelly memory layout,
-                // just with scalar rather than block-at-once descent.
-                bench_kiddo_batch_f32::<DonnellyUnrolled<4>>(
-                    &mut group,
-                    "kiddo_donnelly_batch",
+                    &strategies,
                     point_count,
                     &points,
                     &queries_f32,
@@ -1661,18 +1989,9 @@ fn pkdtree_batch(c: &mut Criterion) {
                         &queries_f64[..queries_f64.len().min(64)],
                     );
                 }
-                bench_kiddo_batch_f64::<Eytzinger>(
+                bench_kiddo_batch_strategies_f64(
                     &mut group,
-                    "kiddo_batch",
-                    point_count,
-                    &points,
-                    &queries_f64,
-                );
-                // Each strategy builds and drops its own tree in turn, so only
-                // one is resident at a time.
-                bench_kiddo_batch_f64::<DonnellyCyclicSimdDescent<3>>(
-                    &mut group,
-                    "kiddo_donnelly_batch",
+                    &strategies,
                     point_count,
                     &points,
                     &queries_f64,
@@ -1716,7 +2035,7 @@ fn cpp_competitors(c: &mut Criterion) {
     );
 
     eprintln!(
-        "benchmarking C++ k-d trees: dims={K} scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} nearest_n={MAX_QTYS:?} radius={radius_f64} point_seed={POINT_SEED} query_seed={QUERY_SEED}",
+        "benchmarking C++ k-d trees: dims=f32:{K_F32}/f64:{K_F64} scalars={} libraries={} tree_sizes=2^{min_log2_points}..2^{max_log2_points} queries={query_count} nearest_n={MAX_QTYS:?} radius={radius_f64} point_seed={POINT_SEED} query_seed={QUERY_SEED}",
         scalars.list(),
         libraries.list()
     );
@@ -1815,7 +2134,7 @@ fn pkdtree_f64_probe(c: &mut Criterion) {
             PkdtreeF64(ffi::pkdtree_build_f64(
                 points.as_ptr().cast(),
                 points.len() as u64,
-                K as u32,
+                K_F64 as u32,
             ))
         };
         let query = build_queries_f64(1);

--- a/scripts/chart_kiddo_vs_pkdtree_results.py
+++ b/scripts/chart_kiddo_vs_pkdtree_results.py
@@ -24,12 +24,29 @@ from typing import Any
 GROUP = "profile_kiddo_vs_pkdtree"
 SCALARS = ("f32", "f64")
 SAFE_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+:-]*$")
+# More specific strategy prefixes must precede the bare "kiddo_" one: matching
+# is first-wins, and every strategy label below also starts with "kiddo_".
 LIBRARY_PREFIXES = (
-    ("kiddo_", "kiddo"),
+    ("kiddo_donnelly_cyclic_simd_full_", "kiddo DonnellyCyclicSimdFull"),
+    ("kiddo_donnelly_cyclic_simd_descent_", "kiddo DonnellyCyclicSimdDescent"),
+    ("kiddo_donnelly_unrolled_", "kiddo DonnellyUnrolled"),
+    ("kiddo_", "kiddo Eytzinger"),
     ("pkdtree_", "Pkd-tree"),
 )
-LIBRARY_ORDER = ("kiddo", "Pkd-tree")
-COLORS = {"kiddo": "#3264a8", "Pkd-tree": "#8e44ad"}
+LIBRARY_ORDER = (
+    "kiddo DonnellyCyclicSimdFull",
+    "kiddo DonnellyCyclicSimdDescent",
+    "kiddo DonnellyUnrolled",
+    "kiddo Eytzinger",
+    "Pkd-tree",
+)
+COLORS = {
+    "kiddo DonnellyCyclicSimdFull": "#0f6b48",
+    "kiddo DonnellyCyclicSimdDescent": "#8c5a1f",
+    "kiddo DonnellyUnrolled": "#7a1f8c",
+    "kiddo Eytzinger": "#3264a8",
+    "Pkd-tree": "#8e44ad",
+}
 
 
 @dataclass(frozen=True)

--- a/scripts/chart_pkdtree_batch_results.py
+++ b/scripts/chart_pkdtree_batch_results.py
@@ -26,33 +26,58 @@ from typing import Any
 
 GROUP = "profile_pkdtree_batch"
 SCALARS = ("f32", "f64")
-# Donnelly prefixes must precede the Eytzinger ones: "kiddo_batch_" is a
-# prefix of nothing else, but matching is first-wins, and a future rename
-# could easily make one stem's prefix shadow another's.
+# Longer, more specific prefixes must precede shorter ones that would
+# otherwise shadow them: "kiddo_donnelly_cyclic_simd_full_batch_" is also
+# matched by "kiddo_donnelly_batch_" (it isn't, in this table, since none of
+# these strategy names are prefixes of each other -- but matching is
+# first-wins, so keep it that way deliberately as strategies are added).
 LIBRARY_PREFIXES = (
-    ("kiddo_donnelly_batch_tuned_", "kiddo Donnelly (tuned)"),
-    ("kiddo_donnelly_batch_parallel_", "kiddo Donnelly (parallel)"),
-    ("kiddo_donnelly_batch_serial_", "kiddo Donnelly (serial)"),
+    ("kiddo_donnelly_cyclic_simd_full_batch_tuned_", "kiddo DonnellyCyclicSimdFull (tuned)"),
+    ("kiddo_donnelly_cyclic_simd_full_batch_parallel_", "kiddo DonnellyCyclicSimdFull (parallel)"),
+    ("kiddo_donnelly_cyclic_simd_full_batch_serial_", "kiddo DonnellyCyclicSimdFull (serial)"),
+    ("kiddo_donnelly_cyclic_simd_descent_batch_tuned_", "kiddo DonnellyCyclicSimdDescent (tuned)"),
+    ("kiddo_donnelly_cyclic_simd_descent_batch_parallel_", "kiddo DonnellyCyclicSimdDescent (parallel)"),
+    ("kiddo_donnelly_cyclic_simd_descent_batch_serial_", "kiddo DonnellyCyclicSimdDescent (serial)"),
+    ("kiddo_donnelly_unrolled_batch_tuned_", "kiddo DonnellyUnrolled (tuned)"),
+    ("kiddo_donnelly_unrolled_batch_parallel_", "kiddo DonnellyUnrolled (parallel)"),
+    ("kiddo_donnelly_unrolled_batch_serial_", "kiddo DonnellyUnrolled (serial)"),
+    # Legacy label from before the strategy was renamed with an explicit
+    # "cyclic_simd_descent" infix; kept so older result files still chart.
+    ("kiddo_donnelly_batch_tuned_", "kiddo DonnellyCyclicSimdDescent (tuned)"),
+    ("kiddo_donnelly_batch_parallel_", "kiddo DonnellyCyclicSimdDescent (parallel)"),
+    ("kiddo_donnelly_batch_serial_", "kiddo DonnellyCyclicSimdDescent (serial)"),
     ("kiddo_batch_tuned_", "kiddo Eytzinger (tuned)"),
     ("kiddo_batch_parallel_", "kiddo Eytzinger (parallel)"),
     ("kiddo_batch_serial_", "kiddo Eytzinger (serial)"),
     ("pkdtree_batch_", "Pkd-tree"),
 )
 LIBRARY_ORDER = (
-    "kiddo Donnelly (tuned)",
-    "kiddo Donnelly (parallel)",
+    "kiddo DonnellyCyclicSimdFull (tuned)",
+    "kiddo DonnellyCyclicSimdFull (parallel)",
+    "kiddo DonnellyCyclicSimdDescent (tuned)",
+    "kiddo DonnellyCyclicSimdDescent (parallel)",
+    "kiddo DonnellyUnrolled (tuned)",
+    "kiddo DonnellyUnrolled (parallel)",
     "kiddo Eytzinger (tuned)",
     "kiddo Eytzinger (parallel)",
-    "kiddo Donnelly (serial)",
+    "kiddo DonnellyCyclicSimdFull (serial)",
+    "kiddo DonnellyCyclicSimdDescent (serial)",
+    "kiddo DonnellyUnrolled (serial)",
     "kiddo Eytzinger (serial)",
     "Pkd-tree",
 )
 COLORS = {
-    "kiddo Donnelly (tuned)": "#0f6b48",
-    "kiddo Donnelly (parallel)": "#1a7f5a",
+    "kiddo DonnellyCyclicSimdFull (tuned)": "#0f6b48",
+    "kiddo DonnellyCyclicSimdFull (parallel)": "#1a7f5a",
+    "kiddo DonnellyCyclicSimdFull (serial)": "#7fc4a8",
+    "kiddo DonnellyCyclicSimdDescent (tuned)": "#8c5a1f",
+    "kiddo DonnellyCyclicSimdDescent (parallel)": "#a8703a",
+    "kiddo DonnellyCyclicSimdDescent (serial)": "#d9a878",
+    "kiddo DonnellyUnrolled (tuned)": "#7a1f8c",
+    "kiddo DonnellyUnrolled (parallel)": "#973aa8",
+    "kiddo DonnellyUnrolled (serial)": "#c78cd9",
     "kiddo Eytzinger (tuned)": "#1f4e8c",
     "kiddo Eytzinger (parallel)": "#3264a8",
-    "kiddo Donnelly (serial)": "#7fc4a8",
     "kiddo Eytzinger (serial)": "#7fa8d9",
     "Pkd-tree": "#8e44ad",
 }

--- a/scripts/lib_bench_profile_matrix.sh
+++ b/scripts/lib_bench_profile_matrix.sh
@@ -1,0 +1,444 @@
+# shellcheck shell=bash
+#
+# Shared machinery for the three run_*_strategy_matrix.sh scripts (single-core,
+# multi-core, unlimited). Sourced, never executed directly.
+#
+# Split out because the three scripts share almost everything except which
+# boot profile they require, which CPUs they use, and which suite(s) they
+# select -- duplicating ~500 lines of environment validation, IRQ accounting
+# and retry logic three times over would make the one thing that must stay in
+# sync (the isolcpus=domain canary in validate_environment) three times as
+# likely to drift.
+#
+# Callers set PHASE, REQUIRED_PROFILE, EXPECT_VERB, BENCH_CPUS, STRICT_ISOLATION
+# before sourcing, then call the functions below.
+
+contains() {
+    local needle=$1
+    shift
+    local value
+    for value in "$@"; do
+        [[ "$value" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+validate_unique_positive_list() {
+    local label=$1
+    shift
+    local -a values=("$@")
+    local i j value
+    ((${#values[@]} > 0)) || {
+        echo "$label must not be empty" >&2
+        exit 2
+    }
+    for value in "${values[@]}"; do
+        [[ "$value" =~ ^[1-9][0-9]*$ ]] || {
+            echo "$label contains an invalid positive integer: $value" >&2
+            exit 2
+        }
+    done
+    for ((i = 0; i < ${#values[@]}; i++)); do
+        for ((j = i + 1; j < ${#values[@]}; j++)); do
+            [[ "${values[i]}" != "${values[j]}" ]] || {
+                echo "$label contains a duplicate: ${values[i]}" >&2
+                exit 2
+            }
+        done
+    done
+}
+
+expand_cpu_list() {
+    local spec=$1 segment start end cpu
+    local -a segments
+    IFS=',' read -r -a segments <<<"$spec"
+    for segment in "${segments[@]}"; do
+        if [[ "$segment" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+            start=${BASH_REMATCH[1]}
+            end=${BASH_REMATCH[2]}
+            ((start <= end)) || return 1
+            for ((cpu = start; cpu <= end; cpu++)); do printf '%s\n' "$cpu"; done
+        elif [[ "$segment" =~ ^[0-9]+$ ]]; then
+            printf '%s\n' "$segment"
+        else
+            return 1
+        fi
+    done
+}
+
+online_cpu_list() {
+    local candidate cpu online
+    for candidate in /sys/devices/system/cpu/cpu[0-9]*; do
+        cpu=${candidate##*/cpu}
+        [[ "$cpu" =~ ^[0-9]+$ ]] || continue
+        online=1
+        [[ -r "$candidate/online" ]] && online=$(<"$candidate/online")
+        ((online == 1)) && printf '%s\n' "$cpu"
+    done | sort -n
+}
+
+# Every kiddo strategy this repository's bench file knows how to build, and
+# the tree-native block height for each scalar. DonnellyCyclicSimdDescent and
+# DonnellyCyclicSimdFull both panic unless BH matches this exactly (3 for
+# f64, 4 for f32) -- see profile_cpp_competitors.rs's K_F32/K_F64 comment.
+readonly ALL_STRATEGIES="eytzinger,donnelly_unrolled,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full"
+
+log() {
+    printf '%s\n' "$*" | tee -a "$LOG_FILE"
+}
+
+require_commands() {
+    local command_name
+    for command_name in "$@"; do
+        command -v "$command_name" >/dev/null || {
+            echo "Required command is unavailable: $command_name" >&2
+            exit 2
+        }
+    done
+}
+
+# --- environment validation -------------------------------------------------
+
+validate_environment() {
+    local status_file=$1
+    local failures=0 cpu isolated online governor siblings sibling
+    local -a isolated_cpus
+
+    # In relaxed (unlimited) mode nothing below can hold: the point is to use
+    # every core, so isolation/sibling/housekeeping gates downgrade to
+    # warnings rather than failing a run that was never meant to isolate.
+    local verdict=FAIL
+    ((STRICT_ISOLATION == 1)) || verdict=WARN
+
+    {
+        echo "phase: $PHASE (boot profile: ${BOOT_PROFILE:-none})"
+        echo "benchmark CPUs: $BENCH_CPUS ($WORKER_COUNT workers)"
+        echo "kernel cmdline: $(cat /proc/cmdline)"
+    } >"$status_file"
+
+    isolated=$(cat /sys/devices/system/cpu/isolated 2>/dev/null || true)
+    mapfile -t isolated_cpus < <(expand_cpu_list "${isolated:-}" 2>/dev/null || true)
+
+    for cpu in "${bench_cpus[@]}"; do
+        online=1
+        if [[ -r "/sys/devices/system/cpu/cpu$cpu/online" ]]; then
+            online=$(<"/sys/devices/system/cpu/cpu$cpu/online")
+        fi
+        if ((online != 1)); then
+            echo "FAIL: cpu$cpu is offline" >>"$status_file"
+            failures=$((failures + 1))
+            continue
+        fi
+
+        if contains "$cpu" "${isolated_cpus[@]}"; then
+            echo "PASS: cpu$cpu isolated" >>"$status_file"
+        else
+            echo "$verdict: cpu$cpu is not in isolcpus (${isolated:-none})" >>"$status_file"
+            ((STRICT_ISOLATION == 1)) && failures=$((failures + 1))
+        fi
+
+        governor=$(cat "/sys/devices/system/cpu/cpu$cpu/cpufreq/scaling_governor" 2>/dev/null || echo unknown)
+        if [[ "$governor" == performance ]]; then
+            echo "PASS: cpu$cpu governor performance" >>"$status_file"
+        else
+            echo "FAIL: cpu$cpu governor is $governor (fix: sudo cpupower -c $BENCH_CPUS frequency-set -g performance)" >>"$status_file"
+            failures=$((failures + 1))
+        fi
+
+        # An online SMT sibling outside the set would let unrelated work share
+        # the core's execution resources, which shows up as throughput noise.
+        siblings=$(cat "/sys/devices/system/cpu/cpu$cpu/topology/thread_siblings_list" 2>/dev/null || echo "$cpu")
+        while read -r sibling; do
+            [[ -n "$sibling" && "$sibling" != "$cpu" ]] || continue
+            online=1
+            if [[ -r "/sys/devices/system/cpu/cpu$sibling/online" ]]; then
+                online=$(<"/sys/devices/system/cpu/cpu$sibling/online")
+            fi
+            if ((online == 1)) && ! contains "$sibling" "${bench_cpus[@]}"; then
+                echo "$verdict: cpu$cpu has online SMT sibling cpu$sibling outside BENCH_CPUS" >>"$status_file"
+                ((STRICT_ISOLATION == 1)) && failures=$((failures + 1))
+            fi
+        done < <(expand_cpu_list "$siblings" 2>/dev/null || true)
+    done
+
+    # Something has to service interrupts and run kernel threads.
+    local housekeeping=0 candidate
+    for candidate in /sys/devices/system/cpu/cpu[0-9]*; do
+        cpu=${candidate##*/cpu}
+        [[ "$cpu" =~ ^[0-9]+$ ]] || continue
+        online=1
+        if [[ -r "$candidate/online" ]]; then
+            online=$(<"$candidate/online")
+        fi
+        ((online == 1)) || continue
+        contains "$cpu" "${bench_cpus[@]}" || housekeeping=$((housekeeping + 1))
+    done
+    if ((housekeeping > 0)); then
+        echo "PASS: $housekeeping online housekeeping CPUs outside BENCH_CPUS" >>"$status_file"
+    else
+        echo "$verdict: no online CPU outside BENCH_CPUS to take IRQs" >>"$status_file"
+        ((STRICT_ISOLATION == 1)) && failures=$((failures + 1))
+    fi
+
+    # bench-profile-status is the authority when installed: it asserts this
+    # profile's whole desired CPU state, and -- for multi-core/unlimited --
+    # runs the parallel-dispatch canary, the only check that would have caught
+    # the isolcpus=domain collapse that silently invalidated an earlier
+    # version of this matrix. The inline checks above are the fallback for
+    # machines without it.
+    if command -v bench-profile-status >/dev/null; then
+        echo "--- bench-profile-status $EXPECT_VERB ---" >>"$status_file"
+        if bench-profile-status "$EXPECT_VERB" >>"$status_file" 2>&1; then
+            echo "PASS: bench-profile-status $EXPECT_VERB" >>"$status_file"
+        else
+            echo "FAIL: the machine is not in the '$REQUIRED_PROFILE' benchmark state." >>"$status_file"
+            echo "      Boot the '... benchmark $REQUIRED_PROFILE' entry; bench-prep.service" >>"$status_file"
+            echo "      applies the policy, or run 'sudo bench-prep' by hand." >>"$status_file"
+            # Always fatal, regardless of STRICT_ISOLATION: that flag relaxes
+            # isolation-specific checks that cannot hold by construction in
+            # the unlimited profile (siblings/isolcpus/housekeeping), not
+            # whether the machine is booted into the right profile at all. A
+            # normal desktop boot must never be mistaken for the unlimited
+            # benchmark profile just because both leave isolation off.
+            failures=$((failures + 1))
+        fi
+    else
+        echo "NOTE: bench-profile-status is not installed; relying on the inline checks" >>"$status_file"
+        echo "      above, which cannot detect a collapsed thread pool." >>"$status_file"
+        echo "      Install from https://github.com/sdd/bench-profile" >>"$status_file"
+    fi
+
+    if ((failures > 0)); then
+        cat "$status_file" >&2
+        echo "Benchmark environment validation failed with $failures problems." >&2
+        return 1
+    fi
+    cat "$status_file" >>"$LOG_FILE"
+}
+
+# --- IRQ accounting ---------------------------------------------------------
+
+# Total hardware interrupts delivered to the given CPUs so far.
+interrupt_total() {
+    local -a cpus=("$@")
+    local cpu_csv
+    cpu_csv=$(
+        IFS=,
+        echo "${cpus[*]}"
+    )
+    awk -v cpus="$cpu_csv" '
+        BEGIN {
+            split(cpus, wanted, ",")
+            for (i in wanted) target["CPU" wanted[i]] = 1
+        }
+        NR == 1 {
+            for (field = 1; field <= NF; field++)
+                if ($field in target) column[field + 1] = 1
+            next
+        }
+        $1 ~ /^[0-9]+:$/ {
+            for (field in column)
+                if (field <= NF && $field ~ /^[0-9]+$/) total += $field
+        }
+        END { print total + 0 }
+    ' /proc/interrupts
+}
+
+# --- build & preconditions ---------------------------------------------------
+
+# Builds profile_cpp_competitors and resolves its executable path. Validates
+# the two build-time preconditions the cyclic Donnelly strategies need: an
+# opt-level-3 bench profile (a hand-written SIMD kernel measured a level below
+# release is not representative) and native AVX-512F support (without it every
+# cyclic strategy panics on the very first tree it builds).
+build_benchmark() {
+    log "Building profile_cpp_competitors (features: $FEATURES)"
+    benchmark_exe="$(
+        cd -- "$REPO_DIR"
+        RUSTC_WRAPPER= RUSTFLAGS='-C target-cpu=native' \
+            cargo bench --bench profile_cpp_competitors \
+            --features "$FEATURES" --no-run --message-format=json |
+            jq -r 'select(.reason == "compiler-artifact" and .target.name == "profile_cpp_competitors") | .executable // empty' |
+            tail -n 1
+    )"
+    [[ -n "$benchmark_exe" && -x "$benchmark_exe" ]] || {
+        echo "Could not resolve profile_cpp_competitors executable" >&2
+        exit 1
+    }
+
+    local opt_level
+    opt_level=$(
+        cd -- "$REPO_DIR" && python3 - <<'PY'
+import re, pathlib
+text = pathlib.Path("Cargo.toml").read_text()
+section = re.search(r"\[profile\.bench\](.*?)(?=\n\[|\Z)", text, re.S)
+match = re.search(r"opt-level\s*=\s*(\d+)", section.group(1)) if section else None
+print(match.group(1) if match else "unset")
+PY
+    )
+    [[ "$opt_level" == 3 ]] || {
+        echo "profile.bench opt-level is $opt_level; hand-written SIMD kernels must be measured at 3" >&2
+        exit 2
+    }
+
+    local native_cfg
+    native_cfg=$(rustc --print cfg -C target-cpu=native)
+    [[ "$native_cfg" == *'target_feature="avx512f"'* ]] || {
+        echo "The cyclic Donnelly strategies require native AVX-512F support" >&2
+        exit 2
+    }
+}
+
+# --- cell execution ----------------------------------------------------------
+#
+# run_cell and run_single_cell both retry a cell up to IRQ_RETRIES times if a
+# hardware IRQ landed on the benchmark CPUs during the measurement window --
+# bench-profile-run's 125 convention, reimplemented here rather than reused
+# because that wrapper pins to the profile's whole benchmark set, which is
+# wrong for run_single_cell's one-CPU pin.
+
+# run_cell <criterion-suite> <extra-env-string> <scalar> <height> <query-count> <role> [warmup] [measurement] [sample-size] [output-dir]
+#
+# extra-env-string is a space-separated list of NAME=value pairs appended to
+# the env invocation, so callers can select KIDDO_CPP_SUITES/LIBRARIES/
+# STRATEGIES without this function needing to know about all three.
+run_cell() {
+    local criterion_group=$1 extra_env=$2 scalar=$3 height=$4 query_count=$5 role=$6
+    local warmup=${7:-$CRITERION_WARMUP}
+    local measurement=${8:-$CRITERION_MEASUREMENT}
+    local sample_size=${9:-$CRITERION_SAMPLE_SIZE}
+    local output_dir=${10:-$RUN_DIR}
+    local attempt=0 status result_key result_path tmp_dir irq_before irq_after
+    local -a extra_env_array
+    read -ra extra_env_array <<<"$extra_env"
+
+    result_key="$SUITE_LABEL-$PHASE-$role-$scalar-2p$height-q$query_count"
+    local group_slug="${criterion_group#profile_}"
+    group_slug="${group_slug//_/-}"
+    result_path="$output_dir/bench_result-$group_slug-$result_key.json"
+
+    while true; do
+        tmp_dir="$(mktemp -d /dev/shm/kiddo-matrix.XXXXXX)"
+        cp -- "$benchmark_exe" "$tmp_dir/benchmark"
+        chmod 0755 "$tmp_dir/benchmark"
+
+        irq_before=$(interrupt_total "${bench_cpus[@]}")
+        set +e
+        "${pin_command[@]}" env \
+            CRITERION_HOME="$tmp_dir/criterion" \
+            RAYON_NUM_THREADS="$WORKER_COUNT" \
+            PARLAY_NUM_THREADS="$WORKER_COUNT" \
+            KIDDO_PROFILE_QUERIES="$query_count" \
+            KIDDO_LARGE_MIN_LOG2_POINTS="$height" \
+            KIDDO_LARGE_MAX_LOG2_POINTS="$height" \
+            "${extra_env_array[@]}" \
+            "$tmp_dir/benchmark" \
+            "$criterion_group" \
+            --warm-up-time "$warmup" \
+            --measurement-time "$measurement" \
+            --sample-size "$sample_size" \
+            --noplot --bench 2>&1 | tee -a "$LOG_FILE" >&2
+        status=${PIPESTATUS[0]}
+        set -e
+        irq_after=$(interrupt_total "${bench_cpus[@]}")
+
+        if ((status == 0 && irq_after > irq_before)); then
+            echo "Cell $role $scalar 2^$height q$query_count saw $((irq_after - irq_before)) hardware IRQs on the benchmark CPUs" |
+                tee -a "$LOG_FILE" >&2
+            # Only a controlled run can promise an IRQ-free interval.
+            ((STRICT_ISOLATION == 1)) && status=125
+        fi
+
+        if ((status == 0)); then
+            (
+                cd -- "$REPO_DIR"
+                cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+                    "$tmp_dir/criterion" "$result_path" "$criterion_group" >&2
+            )
+            rm -rf -- "$tmp_dir"
+            printf '%s\n' "$result_path"
+            return 0
+        fi
+
+        rm -rf -- "$tmp_dir"
+        if ((status != 125 || attempt >= IRQ_RETRIES)); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying invalidated cell $role $scalar 2^$height q$query_count ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE" >&2
+    done
+}
+
+# run_single_cell <criterion-suite> <extra-env-string> <scalar> <height> <role> [warmup] [measurement] [sample-size] [output-dir]
+#
+# Sequential-latency counterpart of run_cell: pins to ONE CPU
+# (single_bench_cpus[0]) rather than the whole benchmark set, since a
+# sequential query cannot be made faster by adding cores and pinning to more
+# than one would only expose the measurement to interference.
+run_single_cell() {
+    local criterion_group=$1 extra_env=$2 scalar=$3 height=$4 role=$5
+    local warmup=${6:-$CRITERION_WARMUP}
+    local measurement=${7:-$CRITERION_MEASUREMENT}
+    local sample_size=${8:-$CRITERION_SAMPLE_SIZE}
+    local output_dir=${9:-$RUN_DIR}
+    local attempt=0 status result_key result_path tmp_dir irq_before irq_after
+    local -a extra_env_array
+    read -ra extra_env_array <<<"$extra_env"
+
+    result_key="$SUITE_LABEL-$PHASE-single-$role-$scalar-2p$height"
+    local group_slug="${criterion_group#profile_}"
+    group_slug="${group_slug//_/-}"
+    result_path="$output_dir/bench_result-$group_slug-$result_key.json"
+
+    while true; do
+        tmp_dir="$(mktemp -d /dev/shm/kiddo-single.XXXXXX)"
+        cp -- "$benchmark_exe" "$tmp_dir/benchmark"
+        chmod 0755 "$tmp_dir/benchmark"
+
+        irq_before=$(interrupt_total "${single_bench_cpus[@]}")
+        set +e
+        "${single_pin_command[@]}" env \
+            CRITERION_HOME="$tmp_dir/criterion" \
+            RAYON_NUM_THREADS=1 \
+            PARLAY_NUM_THREADS=1 \
+            KIDDO_PROFILE_QUERIES="$SINGLE_QUERY_COUNT" \
+            KIDDO_LARGE_MIN_LOG2_POINTS="$height" \
+            KIDDO_LARGE_MAX_LOG2_POINTS="$height" \
+            "${extra_env_array[@]}" \
+            "$tmp_dir/benchmark" \
+            "$criterion_group" \
+            --warm-up-time "$warmup" \
+            --measurement-time "$measurement" \
+            --sample-size "$sample_size" \
+            --noplot --bench 2>&1 | tee -a "$LOG_FILE" >&2
+        status=${PIPESTATUS[0]}
+        set -e
+        irq_after=$(interrupt_total "${single_bench_cpus[@]}")
+
+        if ((status == 0 && irq_after > irq_before)); then
+            echo "Single cell $role $scalar 2^$height saw $((irq_after - irq_before)) hardware IRQs" |
+                tee -a "$LOG_FILE" >&2
+            ((STRICT_ISOLATION == 1)) && status=125
+        fi
+
+        if ((status == 0)); then
+            (
+                cd -- "$REPO_DIR"
+                cargo run --quiet --manifest-path tools/criterion-export/Cargo.toml -- \
+                    "$tmp_dir/criterion" "$result_path" "$criterion_group" >&2
+            )
+            rm -rf -- "$tmp_dir"
+            printf '%s\n' "$result_path"
+            return 0
+        fi
+
+        rm -rf -- "$tmp_dir"
+        if ((status != 125 || attempt >= IRQ_RETRIES)); then
+            return "$status"
+        fi
+        attempt=$((attempt + 1))
+        echo "Retrying invalidated single cell $role $scalar 2^$height ($attempt/$IRQ_RETRIES)" |
+            tee -a "$LOG_FILE" >&2
+    done
+}

--- a/scripts/run_multicore_strategy_matrix.sh
+++ b/scripts/run_multicore_strategy_matrix.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Controlled parallel-throughput comparison: every kiddo batch executor
+# (serial/parallel/tuned) across every kiddo stem strategy, against Pkd-tree's
+# parallel_for, confined to one core complex.
+#
+# Requires the MULTI-CORE bench-profile boot entry
+# (https://github.com/sdd/bench-profile): the whole benchmark CPU set
+# isolated with scheduler load balancing left ON (unlike the single-core
+# profile's isolcpus=domain), which is what lets a thread pool actually
+# spread across it. Gated on `bench-profile-status expect-multi-core`, which
+# also runs the parallel-dispatch canary -- the check that would have caught
+# an earlier version of this matrix silently running every "parallel" cell on
+# one core because it used the wrong (single-core) boot profile.
+#
+# Kiddo stem strategies (KIDDO_STRATEGIES, comma-separated):
+#   eytzinger                     baseline
+#   donnelly_unrolled              Donnelly memory layout, scalar descent
+#   donnelly_cyclic_simd_descent   block-at-once AVX-512 descent
+#   donnelly_cyclic_simd_full      + AVX-512 rectangle pruning/backtracking
+#
+# Both runtimes are pinned to the same worker count under taskset: ParlayLib
+# falls back to hardware_concurrency(), which ignores the affinity mask,
+# while rayon's available_parallelism() honours it. Left alone, Pkd-tree
+# would oversubscribe the benchmark cores while kiddo did not, and the
+# comparison would be meaningless.
+#
+# Tree sizes are chosen so the stem height (log2(points) - log2(leaf
+# capacity), leaf capacity is 32 = 2^5) is an EXACT multiple of the block
+# height, for now -- see run_single_core_strategy_matrix.sh's longer
+# explanation. That gives log2(points) = 5 + m*BH:
+#   f64 (BH=3): 8, 11, 14, ..., 20, 23, 26, 29
+#   f32 (BH=4): 9, 13, 17, ..., 21, 25, 29
+# f64 defaults stop at 26 rather than 29 (~13GB resident, too large to build
+# once per strategy per query-count in a matrix this size). f32 stops at 21,
+# Pkd-tree's f32 build-assertion limit -- 25 and 29 are otherwise exact
+# heights but not usable here while Pkd-tree stays in LIBRARIES.
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib_bench_profile_matrix.sh
+source "$SCRIPT_DIR/lib_bench_profile_matrix.sh"
+
+readonly PHASE=parallel
+readonly REQUIRED_PROFILE=multi-core
+readonly EXPECT_VERB=expect-multi-core
+readonly STRICT_ISOLATION=1
+
+LIBRARIES=${LIBRARIES:-kiddo,pkdtree}
+STRATEGIES=${STRATEGIES:-$ALL_STRATEGIES}
+BENCH_CPUS=${BENCH_CPUS:-8-15}
+F64_HEIGHTS=${F64_HEIGHTS:-20,23,26}
+F32_HEIGHTS=${F32_HEIGHTS:-21}
+QUERY_COUNTS=${QUERY_COUNTS:-1000,4096,16384,100000}
+SCALARS=${SCALARS:-f64,f32}
+CRITERION_WARMUP=${CRITERION_WARMUP:-3}
+CRITERION_MEASUREMENT=${CRITERION_MEASUREMENT:-8}
+CRITERION_SAMPLE_SIZE=${CRITERION_SAMPLE_SIZE:-30}
+IRQ_RETRIES=${IRQ_RETRIES:-2}
+FEATURES=${FEATURES:-cpp_competitors,test_utils,logging_off,simd}
+OUTPUT_BASE=${OUTPUT_BASE:-$REPO_DIR/cpp-competitor-results}
+CHART_BASE=${CHART_BASE:-$REPO_DIR/cpp-competitor-charts}
+SUITE_LABEL=${SUITE_LABEL:-multicore-strategy-matrix-$(date -u +%Y%m%dT%H%M%SZ)}
+
+readonly RUN_DIR="$OUTPUT_BASE/$SUITE_LABEL"
+readonly CHART_DIR="$CHART_BASE/$SUITE_LABEL"
+readonly LOG_FILE="$RUN_DIR/run.log"
+
+require_commands cargo jq mktemp python3 rustc taskset
+[[ "$SUITE_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]] || {
+    echo "SUITE_LABEL contains unsupported characters: $SUITE_LABEL" >&2
+    exit 2
+}
+[[ ! -e "$RUN_DIR" && ! -e "$CHART_DIR" ]] || {
+    echo "Refusing to overwrite existing suite $SUITE_LABEL" >&2
+    exit 2
+}
+
+booted_profile() {
+    local token
+    for token in $(</proc/cmdline); do
+        case "$token" in
+            systemd.setenv=BENCH_PROFILE=*)
+                printf '%s\n' "${token#systemd.setenv=BENCH_PROFILE=}"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+BOOT_PROFILE=$(booted_profile || true)
+readonly BOOT_PROFILE
+# Unconditional: an empty BOOT_PROFILE (a normal desktop boot has no
+# BENCH_PROFILE marker at all) must refuse exactly like a wrong one. These
+# are single-purpose scripts with no override, so there is no legitimate
+# case where an unlabeled boot should be allowed through.
+if [[ "$BOOT_PROFILE" != "$REQUIRED_PROFILE" ]]; then
+    echo "This script needs the '$REQUIRED_PROFILE' boot profile, but this machine is" >&2
+    echo "booted into '${BOOT_PROFILE:-a normal, non-benchmark boot}'." >&2
+    echo "Reboot into the '... benchmark $REQUIRED_PROFILE' entry." >&2
+    exit 2
+fi
+
+IFS=',' read -r -a f64_heights <<<"$F64_HEIGHTS"
+IFS=',' read -r -a f32_heights <<<"$F32_HEIGHTS"
+IFS=',' read -r -a query_counts <<<"$QUERY_COUNTS"
+IFS=',' read -r -a scalars <<<"$SCALARS"
+IFS=',' read -r -a strategies <<<"$STRATEGIES"
+
+validate_unique_positive_list QUERY_COUNTS "${query_counts[@]}"
+(( ${#scalars[@]} > 0 )) || { echo "SCALARS must not be empty" >&2; exit 2; }
+for scalar in "${scalars[@]}"; do
+    case "$scalar" in
+        f32|f64) ;;
+        *) echo "SCALARS entries must be f32 or f64: $scalar" >&2; exit 2 ;;
+    esac
+done
+contains f64 "${scalars[@]}" && validate_unique_positive_list F64_HEIGHTS "${f64_heights[@]}"
+contains f32 "${scalars[@]}" && validate_unique_positive_list F32_HEIGHTS "${f32_heights[@]}"
+
+readonly -a supported_strategies=(eytzinger donnelly_unrolled donnelly_cyclic_simd_descent donnelly_cyclic_simd_full)
+(( ${#strategies[@]} > 0 )) || { echo "STRATEGIES must not be empty" >&2; exit 2; }
+for strategy in "${strategies[@]}"; do
+    contains "$strategy" "${supported_strategies[@]}" || {
+        echo "Unsupported strategy: $strategy (supported: ${supported_strategies[*]})" >&2
+        exit 2
+    }
+done
+
+# Pkd-tree's f32 build asserts above 2^21 points, aborting the process.
+if contains f32 "${scalars[@]}" && [[ "$LIBRARIES" == *pkdtree* ]]; then
+    for height in "${f32_heights[@]}"; do
+        (( height <= 21 )) || {
+            echo "F32_HEIGHTS entry $height exceeds Pkd-tree's f32 build limit of 2^21" >&2
+            exit 2
+        }
+    done
+fi
+
+mapfile -t bench_cpus < <(expand_cpu_list "$BENCH_CPUS") || {
+    echo "BENCH_CPUS is not a valid CPU list: $BENCH_CPUS" >&2
+    exit 2
+}
+(( ${#bench_cpus[@]} > 1 )) || {
+    echo "This script measures parallel throughput; BENCH_CPUS must name more than one CPU" >&2
+    exit 2
+}
+readonly WORKER_COUNT=${#bench_cpus[@]}
+pin_command=(taskset --cpu-list "$BENCH_CPUS")
+readonly pin_command
+
+mkdir -p -- "$RUN_DIR" "$CHART_DIR"
+
+build_benchmark
+validate_environment "$RUN_DIR/environment-before.txt"
+
+# --- preflight ---------------------------------------------------------------
+
+readonly PREFLIGHT_DIR="$(mktemp -d /dev/shm/kiddo-multicore-preflight.XXXXXX)"
+cleanup_preflight() { rm -rf -- "$PREFLIGHT_DIR"; }
+trap cleanup_preflight EXIT INT TERM
+
+log "Preflight: f64 2^14, 256 queries"
+preflight_result=$(run_cell profile_pkdtree_batch \
+    "KIDDO_CPP_SUITES=pkdtree_batch KIDDO_CPP_LIBRARIES=$LIBRARIES KIDDO_CPP_SCALARS=f64 KIDDO_STRATEGIES=$STRATEGIES" \
+    f64 14 256 preflight 0.5 1 10 "$PREFLIGHT_DIR")
+(( $(jq '.results | length' "$preflight_result") > 0 )) || {
+    echo "Preflight produced no results" >&2
+    exit 1
+}
+python3 "$SCRIPT_DIR/chart_pkdtree_batch_results.py" all \
+    --result "$preflight_result" --result-label "$SUITE_LABEL-preflight" \
+    --output-dir "$PREFLIGHT_DIR/charts" --html-name preflight.html
+cleanup_preflight
+trap - EXIT INT TERM
+
+# --- matrix --------------------------------------------------------------
+
+planned=0
+for scalar in "${scalars[@]}"; do
+    if [[ "$scalar" == f64 ]]; then
+        planned=$((planned + ${#f64_heights[@]} * ${#query_counts[@]}))
+    else
+        planned=$((planned + ${#f32_heights[@]} * ${#query_counts[@]}))
+    fi
+done
+log "Phase: parallel (boot profile: ${BOOT_PROFILE:-none}, gate: $EXPECT_VERB, cpus: $BENCH_CPUS, $WORKER_COUNT workers)"
+log "Libraries: $LIBRARIES  strategies: $STRATEGIES  scalars: $SCALARS"
+log "Planned cells: $planned"
+
+batch_results=()
+completed=0
+
+log "=== pkdtree_batch: kiddo ($STRATEGIES, serial/parallel/tuned) vs Pkd-tree parallel_for ==="
+for scalar in "${scalars[@]}"; do
+    if [[ "$scalar" == f64 ]]; then
+        heights=("${f64_heights[@]}")
+    else
+        heights=("${f32_heights[@]}")
+    fi
+    for height in "${heights[@]}"; do
+        for query_count in "${query_counts[@]}"; do
+            completed=$((completed + 1))
+            log "[$completed/$planned] parallel $scalar 2^$height, $query_count queries"
+            batch_results+=("$(run_cell profile_pkdtree_batch \
+                "KIDDO_CPP_SUITES=pkdtree_batch KIDDO_CPP_LIBRARIES=$LIBRARIES KIDDO_CPP_SCALARS=$scalar KIDDO_STRATEGIES=$STRATEGIES" \
+                "$scalar" "$height" "$query_count" matrix)")
+        done
+    done
+done
+
+validate_environment "$RUN_DIR/environment-after.txt"
+
+# --- charts --------------------------------------------------------------
+
+if (( ${#batch_results[@]} > 0 )); then
+    chart_args=()
+    for result in "${batch_results[@]}"; do
+        chart_args+=(--result "$result")
+    done
+    python3 "$SCRIPT_DIR/chart_pkdtree_batch_results.py" all \
+        "${chart_args[@]}" \
+        --result-label "$SUITE_LABEL" \
+        --output-dir "$CHART_DIR" \
+        --html-name "$SUITE_LABEL-batch.html"
+    log "Batch charts: $CHART_DIR/$SUITE_LABEL-batch.html"
+fi
+
+log "Suite complete: ${#batch_results[@]} result files in $RUN_DIR"

--- a/scripts/run_single_core_strategy_matrix.sh
+++ b/scripts/run_single_core_strategy_matrix.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Single-threaded per-query comparison: nanoflann and Pkd-tree against every
+# kiddo stem strategy, in one session so the numbers are genuinely comparable
+# -- addresses the gap in the earlier competitor matrix, where kiddo's numbers
+# came from a different session collected on a different day, and the
+# nanoflann/Pkd-tree comparison never included kiddo at all.
+#
+# Requires the SINGLE-CORE bench-profile boot entry
+# (https://github.com/sdd/bench-profile): one isolated core, load balancing
+# off. Gated on `bench-profile-status expect-single-core`.
+#
+# Two Criterion suites, same session, same seeds, same per-scalar dimension
+# (see below), so the point clouds and queries are byte-identical across both
+# at a given size even though they are separate invocations:
+#
+#   kiddo_vs_pkdtree   kiddo (every stem strategy below) vs Pkd-tree,
+#                      sequential. The comparison that matters most; charted
+#                      automatically with chart_kiddo_vs_pkdtree_results.py.
+#   cpp_competitors    nanoflann alone. nanoflann is consistently the fastest
+#                      C++ competitor at these sizes, so it is the one worth
+#                      the extra FFI-build cost; ALGLIB and skd-tree are left
+#                      out by default (set LIBRARIES= to add them back).
+#                      Charted separately -- see the end of this script's
+#                      output for the command.
+#
+# Kiddo stem strategies (KIDDO_STRATEGIES, comma-separated):
+#   eytzinger                     baseline
+#   donnelly_unrolled              Donnelly memory layout, scalar descent
+#   donnelly_cyclic_simd_descent   block-at-once AVX-512 descent
+#   donnelly_cyclic_simd_full      + AVX-512 rectangle pruning/backtracking
+#
+# The cyclic strategies panic unless the tree's block height matches what
+# their AVX-512 code is compiled for: BH=3 for f64, BH=4 for f32. The bench
+# file's K_F32/K_F64 constants already pick each scalar's dimension to equal
+# its native block height, so this just works -- but see the height note
+# below for a caveat this script does still need to handle.
+#
+# Tree sizes are chosen so the stem height (log2(points) - log2(leaf
+# capacity), leaf capacity is 32 = 2^5) is an EXACT multiple of the block
+# height, for now: a stem that pads to a taller height than its content
+# needs is a different, currently-unmeasured performance regime, not a
+# methodology this script has validated. That gives log2(points) = 5 + m*BH:
+#   f64 (BH=3): 8, 11, 14, ..., 20, 23, 26, 29
+#   f32 (BH=4): 9, 13, 17, ..., 21, 25, 29
+# Defaults below use f64 up to 26 rather than 29 -- sequential per-query
+# timing at 2^29 points (~13GB resident for f64) is a slow way to spend a
+# single core repeatedly -- and f32 stops at 21 regardless, Pkd-tree's f32
+# build-assertion limit (25 and 29 are otherwise exact heights, but Pkd-tree
+# aborts the process above 2^21 for f32, so they are not usable here while
+# Pkd-tree stays in LIBRARIES). Override F64_HEIGHTS/F32_HEIGHTS for a wider
+# sweep, but keep every entry on the multiple-of-BH list above.
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib_bench_profile_matrix.sh
+source "$SCRIPT_DIR/lib_bench_profile_matrix.sh"
+
+readonly PHASE=single
+readonly REQUIRED_PROFILE=single-core
+readonly EXPECT_VERB=expect-single-core
+readonly STRICT_ISOLATION=1
+
+LIBRARIES=${LIBRARIES:-nanoflann,pkdtree,kiddo}
+STRATEGIES=${STRATEGIES:-$ALL_STRATEGIES}
+F64_HEIGHTS=${F64_HEIGHTS:-20,23,26}
+F32_HEIGHTS=${F32_HEIGHTS:-21}
+SCALARS=${SCALARS:-f64,f32}
+SINGLE_QUERY_COUNT=${SINGLE_QUERY_COUNT:-1000}
+RADIUS=${RADIUS:-0.05}
+BENCH_CPU=${BENCH_CPU:-8}
+CRITERION_WARMUP=${CRITERION_WARMUP:-3}
+CRITERION_MEASUREMENT=${CRITERION_MEASUREMENT:-8}
+CRITERION_SAMPLE_SIZE=${CRITERION_SAMPLE_SIZE:-30}
+IRQ_RETRIES=${IRQ_RETRIES:-2}
+FEATURES=${FEATURES:-cpp_competitors,test_utils,logging_off,simd}
+OUTPUT_BASE=${OUTPUT_BASE:-$REPO_DIR/cpp-competitor-results}
+CHART_BASE=${CHART_BASE:-$REPO_DIR/cpp-competitor-charts}
+SUITE_LABEL=${SUITE_LABEL:-single-core-strategy-matrix-$(date -u +%Y%m%dT%H%M%SZ)}
+
+readonly RUN_DIR="$OUTPUT_BASE/$SUITE_LABEL"
+readonly CHART_DIR="$CHART_BASE/$SUITE_LABEL"
+readonly LOG_FILE="$RUN_DIR/run.log"
+
+require_commands cargo jq mktemp python3 rustc taskset
+[[ "$SUITE_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]] || {
+    echo "SUITE_LABEL contains unsupported characters: $SUITE_LABEL" >&2
+    exit 2
+}
+[[ ! -e "$RUN_DIR" && ! -e "$CHART_DIR" ]] || {
+    echo "Refusing to overwrite existing suite $SUITE_LABEL" >&2
+    exit 2
+}
+
+# The bench-profile boot entries carry their identity on the kernel cmdline.
+booted_profile() {
+    local token
+    for token in $(</proc/cmdline); do
+        case "$token" in
+            systemd.setenv=BENCH_PROFILE=*)
+                printf '%s\n' "${token#systemd.setenv=BENCH_PROFILE=}"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+BOOT_PROFILE=$(booted_profile || true)
+readonly BOOT_PROFILE
+# Unconditional: an empty BOOT_PROFILE (a normal desktop boot has no
+# BENCH_PROFILE marker at all) must refuse exactly like a wrong one. These
+# are single-purpose scripts with no override, so there is no legitimate
+# case where an unlabeled boot should be allowed through.
+if [[ "$BOOT_PROFILE" != "$REQUIRED_PROFILE" ]]; then
+    echo "This script needs the '$REQUIRED_PROFILE' boot profile, but this machine is" >&2
+    echo "booted into '${BOOT_PROFILE:-a normal, non-benchmark boot}'." >&2
+    echo "Reboot into the '... benchmark $REQUIRED_PROFILE' entry." >&2
+    exit 2
+fi
+
+IFS=',' read -r -a f64_heights <<<"$F64_HEIGHTS"
+IFS=',' read -r -a f32_heights <<<"$F32_HEIGHTS"
+IFS=',' read -r -a scalars <<<"$SCALARS"
+IFS=',' read -r -a strategies <<<"$STRATEGIES"
+
+(( ${#scalars[@]} > 0 )) || { echo "SCALARS must not be empty" >&2; exit 2; }
+for scalar in "${scalars[@]}"; do
+    case "$scalar" in
+        f32|f64) ;;
+        *) echo "SCALARS entries must be f32 or f64: $scalar" >&2; exit 2 ;;
+    esac
+done
+contains f64 "${scalars[@]}" && validate_unique_positive_list F64_HEIGHTS "${f64_heights[@]}"
+contains f32 "${scalars[@]}" && validate_unique_positive_list F32_HEIGHTS "${f32_heights[@]}"
+
+readonly -a supported_strategies=(eytzinger donnelly_unrolled donnelly_cyclic_simd_descent donnelly_cyclic_simd_full)
+(( ${#strategies[@]} > 0 )) || { echo "STRATEGIES must not be empty" >&2; exit 2; }
+for strategy in "${strategies[@]}"; do
+    contains "$strategy" "${supported_strategies[@]}" || {
+        echo "Unsupported strategy: $strategy (supported: ${supported_strategies[*]})" >&2
+        exit 2
+    }
+done
+
+# Pkd-tree's build_recursive asserts above 2^21 points for f32, whatever K is
+# (reconfirmed at K_F32=4; see profile_cpp_competitors.rs).
+if contains f32 "${scalars[@]}" && [[ "$LIBRARIES" == *pkdtree* ]]; then
+    for height in "${f32_heights[@]}"; do
+        (( height <= 21 )) || {
+            echo "F32_HEIGHTS entry $height exceeds Pkd-tree's f32 build limit of 2^21" >&2
+            exit 2
+        }
+    done
+fi
+
+mapfile -t single_bench_cpus < <(expand_cpu_list "$BENCH_CPU") || {
+    echo "BENCH_CPU is not a valid CPU: $BENCH_CPU" >&2
+    exit 2
+}
+(( ${#single_bench_cpus[@]} == 1 )) || {
+    echo "This script measures sequential latency; BENCH_CPU must name exactly one CPU" >&2
+    exit 2
+}
+readonly WORKER_COUNT=1
+single_pin_command=(taskset --cpu-list "$BENCH_CPU")
+readonly single_pin_command
+# validate_environment (shared lib) reads bench_cpus/pin_command/BENCH_CPUS,
+# not the single_* names above -- alias them so it validates the one core
+# this script actually uses.
+bench_cpus=("${single_bench_cpus[@]}")
+readonly BENCH_CPUS="$BENCH_CPU"
+pin_command=("${single_pin_command[@]}")
+
+mkdir -p -- "$RUN_DIR" "$CHART_DIR"
+
+build_benchmark
+validate_environment "$RUN_DIR/environment-before.txt"
+
+# --- preflight ---------------------------------------------------------------
+
+readonly PREFLIGHT_DIR="$(mktemp -d /dev/shm/kiddo-single-preflight.XXXXXX)"
+cleanup_preflight() { rm -rf -- "$PREFLIGHT_DIR"; }
+trap cleanup_preflight EXIT INT TERM
+
+log "Preflight: kiddo_vs_pkdtree f64 2^14"
+preflight_kvp=$(run_single_cell profile_kiddo_vs_pkdtree \
+    "KIDDO_CPP_SUITES=kiddo_vs_pkdtree KIDDO_CPP_LIBRARIES=kiddo,pkdtree KIDDO_CPP_SCALARS=f64 KIDDO_STRATEGIES=$STRATEGIES" \
+    f64 14 preflight 0.5 1 10 "$PREFLIGHT_DIR")
+(( $(jq '.results | length' "$preflight_kvp") > 0 )) || {
+    echo "kiddo_vs_pkdtree preflight produced no results" >&2
+    exit 1
+}
+if [[ "$LIBRARIES" == *nanoflann* ]]; then
+    log "Preflight: cpp_competitors f64 2^14"
+    preflight_cpp=$(run_single_cell profile_cpp_competitors \
+        "KIDDO_CPP_SUITES=cpp_competitors KIDDO_CPP_LIBRARIES=nanoflann KIDDO_CPP_SCALARS=f64 KIDDO_PROFILE_RADIUS=$RADIUS" \
+        f64 14 preflight 0.5 1 10 "$PREFLIGHT_DIR")
+    (( $(jq '.results | length' "$preflight_cpp")  > 0 )) || {
+        echo "cpp_competitors preflight produced no results" >&2
+        exit 1
+    }
+fi
+cleanup_preflight
+trap - EXIT INT TERM
+
+# --- matrix --------------------------------------------------------------
+
+planned=0
+for scalar in "${scalars[@]}"; do
+    if [[ "$scalar" == f64 ]]; then
+        planned=$((planned + ${#f64_heights[@]}))
+    else
+        planned=$((planned + ${#f32_heights[@]}))
+    fi
+done
+if [[ "$LIBRARIES" == *nanoflann* ]]; then
+    planned=$((planned * 2))
+fi
+log "Phase: single (boot profile: ${BOOT_PROFILE:-none}, gate: $EXPECT_VERB, cpu: $BENCH_CPU)"
+log "Libraries: $LIBRARIES  strategies: $STRATEGIES  scalars: $SCALARS"
+log "Planned cells: $planned"
+
+kvp_results=()
+cpp_results=()
+completed=0
+
+log "=== kiddo_vs_pkdtree: kiddo ($STRATEGIES) vs Pkd-tree, cpu $BENCH_CPU ==="
+for scalar in "${scalars[@]}"; do
+    if [[ "$scalar" == f64 ]]; then
+        heights=("${f64_heights[@]}")
+    else
+        heights=("${f32_heights[@]}")
+    fi
+    for height in "${heights[@]}"; do
+        completed=$((completed + 1))
+        log "[$completed/$planned] kiddo_vs_pkdtree $scalar 2^$height"
+        kvp_results+=("$(run_single_cell profile_kiddo_vs_pkdtree \
+            "KIDDO_CPP_SUITES=kiddo_vs_pkdtree KIDDO_CPP_LIBRARIES=kiddo,pkdtree KIDDO_CPP_SCALARS=$scalar KIDDO_STRATEGIES=$STRATEGIES" \
+            "$scalar" "$height" matrix)")
+    done
+done
+
+if [[ "$LIBRARIES" == *nanoflann* ]]; then
+    log "=== cpp_competitors: nanoflann, cpu $BENCH_CPU ==="
+    for scalar in "${scalars[@]}"; do
+        if [[ "$scalar" == f64 ]]; then
+            heights=("${f64_heights[@]}")
+        else
+            heights=("${f32_heights[@]}")
+        fi
+        for height in "${heights[@]}"; do
+            completed=$((completed + 1))
+            log "[$completed/$planned] cpp_competitors $scalar 2^$height"
+            cpp_results+=("$(run_single_cell profile_cpp_competitors \
+                "KIDDO_CPP_SUITES=cpp_competitors KIDDO_CPP_LIBRARIES=nanoflann KIDDO_CPP_SCALARS=$scalar KIDDO_PROFILE_MIN_LOG2_POINTS=$height KIDDO_PROFILE_MAX_LOG2_POINTS=$height KIDDO_PROFILE_RADIUS=$RADIUS" \
+                "$scalar" "$height" matrix)")
+        done
+    done
+fi
+
+validate_environment "$RUN_DIR/environment-after.txt"
+
+# --- charts --------------------------------------------------------------
+
+if (( ${#kvp_results[@]} > 0 )); then
+    chart_args=()
+    for result in "${kvp_results[@]}"; do
+        chart_args+=(--result "$result")
+    done
+    python3 "$SCRIPT_DIR/chart_kiddo_vs_pkdtree_results.py" all \
+        "${chart_args[@]}" \
+        --result-label "$SUITE_LABEL" \
+        --output-dir "$CHART_DIR" \
+        --html-name "$SUITE_LABEL-kiddo-vs-pkdtree.html"
+    log "kiddo vs Pkd-tree charts: $CHART_DIR/$SUITE_LABEL-kiddo-vs-pkdtree.html"
+fi
+
+if (( ${#cpp_results[@]} > 0 )); then
+    log "nanoflann results (same session and sizes as the kiddo_vs_pkdtree results above,"
+    log "so byte-identical point clouds and queries at each size -- but a different"
+    log "Criterion group, so no existing chart script plots all three libraries"
+    log "together yet. chart_cpp_competitor_results.py's --kiddo-* flags want a"
+    log "profile_v6_* export, which is a still-separate session; do not use it here,"
+    log "that is the exact gap this script exists to close for kiddo vs Pkd-tree."
+    log "For now, compare the raw numbers below against the kiddo_vs_pkdtree chart,"
+    log "or merge the JSON exports (matching group_id/value_str) by hand."
+    log "  nanoflann result files:"
+    for result in "${cpp_results[@]}"; do
+        log "    $result"
+    done
+fi
+
+log "Suite complete: $((${#kvp_results[@]} + ${#cpp_results[@]})) result files in $RUN_DIR"

--- a/scripts/run_unlimited_strategy_matrix.sh
+++ b/scripts/run_unlimited_strategy_matrix.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# No-holds-barred parallel throughput: kiddo against Pkd-tree only, across
+# every kiddo stem strategy, with no CPU restrictions at all -- every thread,
+# SMT on, boost on. This settles who holds the crown for maximum achievable
+# parallel query rate on this machine, not implementation-detail comparisons,
+# which is why it is deliberately narrower than the controlled multi-core
+# matrix: two contenders, the largest safe tree size, the largest query
+# count.
+#
+# Requires the UNLIMITED bench-profile boot entry
+# (https://github.com/sdd/bench-profile): no isolation, so results are NOT
+# comparable with the controlled multi-core matrix's numbers -- housekeeping
+# and interrupts share these cores by design. Gated on
+# `bench-profile-status expect-unrestricted`, which still runs the
+# parallel-dispatch canary (gated on physical core count here, since an
+# ALU-bound probe gains little from SMT).
+#
+# Kiddo stem strategies (KIDDO_STRATEGIES, comma-separated):
+#   eytzinger                     baseline
+#   donnelly_unrolled              Donnelly memory layout, scalar descent
+#   donnelly_cyclic_simd_descent   block-at-once AVX-512 descent
+#   donnelly_cyclic_simd_full      + AVX-512 rectangle pruning/backtracking
+#
+# Both runtimes are pinned to the same worker count: without it, ParlayLib's
+# hardware_concurrency() and rayon's available_parallelism() could disagree
+# on how many threads "every core" means, and the comparison would be
+# meaningless. On an unlimited boot both already see the same online set, so
+# this matters less than in the multi-core profile, but it costs nothing to
+# still pin explicitly for the record.
+#
+# Tree size defaults to the largest EXACT stem-height size this repository's
+# scripts have used at the multi-core matrix's scale: see
+# run_single_core_strategy_matrix.sh for the full multiple-of-block-height
+# derivation (stem height = log2(points) - 5, leaf capacity 32). f64 (BH=3)
+# -> 2^26; f32 (BH=4) -> 2^21, capped there regardless by Pkd-tree's f32
+# build-assertion limit.
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=lib_bench_profile_matrix.sh
+source "$SCRIPT_DIR/lib_bench_profile_matrix.sh"
+
+readonly PHASE=unlimited
+readonly REQUIRED_PROFILE=unlimited
+readonly EXPECT_VERB=expect-unrestricted
+readonly STRICT_ISOLATION=0
+
+LIBRARIES=${LIBRARIES:-kiddo,pkdtree}
+STRATEGIES=${STRATEGIES:-$ALL_STRATEGIES}
+BENCH_CPUS=${BENCH_CPUS:-}
+F64_HEIGHTS=${F64_HEIGHTS:-26}
+F32_HEIGHTS=${F32_HEIGHTS:-21}
+QUERY_COUNTS=${QUERY_COUNTS:-100000}
+SCALARS=${SCALARS:-f64,f32}
+CRITERION_WARMUP=${CRITERION_WARMUP:-3}
+CRITERION_MEASUREMENT=${CRITERION_MEASUREMENT:-8}
+CRITERION_SAMPLE_SIZE=${CRITERION_SAMPLE_SIZE:-30}
+IRQ_RETRIES=${IRQ_RETRIES:-2}
+FEATURES=${FEATURES:-cpp_competitors,test_utils,logging_off,simd}
+OUTPUT_BASE=${OUTPUT_BASE:-$REPO_DIR/cpp-competitor-results}
+CHART_BASE=${CHART_BASE:-$REPO_DIR/cpp-competitor-charts}
+SUITE_LABEL=${SUITE_LABEL:-unlimited-strategy-matrix-$(date -u +%Y%m%dT%H%M%SZ)}
+
+readonly RUN_DIR="$OUTPUT_BASE/$SUITE_LABEL"
+readonly CHART_DIR="$CHART_BASE/$SUITE_LABEL"
+readonly LOG_FILE="$RUN_DIR/run.log"
+
+require_commands cargo jq mktemp python3 rustc taskset
+[[ "$SUITE_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._+:-]*$ ]] || {
+    echo "SUITE_LABEL contains unsupported characters: $SUITE_LABEL" >&2
+    exit 2
+}
+[[ ! -e "$RUN_DIR" && ! -e "$CHART_DIR" ]] || {
+    echo "Refusing to overwrite existing suite $SUITE_LABEL" >&2
+    exit 2
+}
+
+booted_profile() {
+    local token
+    for token in $(</proc/cmdline); do
+        case "$token" in
+            systemd.setenv=BENCH_PROFILE=*)
+                printf '%s\n' "${token#systemd.setenv=BENCH_PROFILE=}"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+BOOT_PROFILE=$(booted_profile || true)
+readonly BOOT_PROFILE
+# Unconditional: an empty BOOT_PROFILE (a normal desktop boot has no
+# BENCH_PROFILE marker at all) must refuse exactly like a wrong one. These
+# are single-purpose scripts with no override, so there is no legitimate
+# case where an unlabeled boot should be allowed through.
+if [[ "$BOOT_PROFILE" != "$REQUIRED_PROFILE" ]]; then
+    echo "This script needs the '$REQUIRED_PROFILE' boot profile, but this machine is" >&2
+    echo "booted into '${BOOT_PROFILE:-a normal, non-benchmark boot}'." >&2
+    echo "Reboot into the '... benchmark $REQUIRED_PROFILE' entry." >&2
+    exit 2
+fi
+
+online_cpu_list() {
+    local candidate cpu online
+    for candidate in /sys/devices/system/cpu/cpu[0-9]*; do
+        cpu=${candidate##*/cpu}
+        [[ "$cpu" =~ ^[0-9]+$ ]] || continue
+        online=1
+        [[ -r "$candidate/online" ]] && online=$(<"$candidate/online")
+        (( online == 1 )) && printf '%s\n' "$cpu"
+    done | sort -n
+}
+if [[ -z "$BENCH_CPUS" ]]; then
+    BENCH_CPUS=$(online_cpu_list | paste -sd, -)
+fi
+
+IFS=',' read -r -a f64_heights <<<"$F64_HEIGHTS"
+IFS=',' read -r -a f32_heights <<<"$F32_HEIGHTS"
+IFS=',' read -r -a query_counts <<<"$QUERY_COUNTS"
+IFS=',' read -r -a scalars <<<"$SCALARS"
+IFS=',' read -r -a strategies <<<"$STRATEGIES"
+
+validate_unique_positive_list QUERY_COUNTS "${query_counts[@]}"
+(( ${#scalars[@]} > 0 )) || { echo "SCALARS must not be empty" >&2; exit 2; }
+for scalar in "${scalars[@]}"; do
+    case "$scalar" in
+        f32|f64) ;;
+        *) echo "SCALARS entries must be f32 or f64: $scalar" >&2; exit 2 ;;
+    esac
+done
+contains f64 "${scalars[@]}" && validate_unique_positive_list F64_HEIGHTS "${f64_heights[@]}"
+contains f32 "${scalars[@]}" && validate_unique_positive_list F32_HEIGHTS "${f32_heights[@]}"
+
+readonly -a supported_strategies=(eytzinger donnelly_unrolled donnelly_cyclic_simd_descent donnelly_cyclic_simd_full)
+(( ${#strategies[@]} > 0 )) || { echo "STRATEGIES must not be empty" >&2; exit 2; }
+for strategy in "${strategies[@]}"; do
+    contains "$strategy" "${supported_strategies[@]}" || {
+        echo "Unsupported strategy: $strategy (supported: ${supported_strategies[*]})" >&2
+        exit 2
+    }
+done
+
+if contains f32 "${scalars[@]}" && [[ "$LIBRARIES" == *pkdtree* ]]; then
+    for height in "${f32_heights[@]}"; do
+        (( height <= 21 )) || {
+            echo "F32_HEIGHTS entry $height exceeds Pkd-tree's f32 build limit of 2^21" >&2
+            exit 2
+        }
+    done
+fi
+
+mapfile -t bench_cpus < <(expand_cpu_list "$BENCH_CPUS") || {
+    echo "BENCH_CPUS is not a valid CPU list: $BENCH_CPUS" >&2
+    exit 2
+}
+(( ${#bench_cpus[@]} > 1 )) || {
+    echo "This script measures parallel throughput; BENCH_CPUS must name more than one CPU" >&2
+    exit 2
+}
+readonly WORKER_COUNT=${#bench_cpus[@]}
+pin_command=(taskset --cpu-list "$BENCH_CPUS")
+readonly pin_command
+
+mkdir -p -- "$RUN_DIR" "$CHART_DIR"
+
+build_benchmark
+validate_environment "$RUN_DIR/environment-before.txt"
+
+# --- preflight ---------------------------------------------------------------
+
+readonly PREFLIGHT_DIR="$(mktemp -d /dev/shm/kiddo-unlimited-preflight.XXXXXX)"
+cleanup_preflight() { rm -rf -- "$PREFLIGHT_DIR"; }
+trap cleanup_preflight EXIT INT TERM
+
+log "Preflight: f64 2^14, 256 queries"
+preflight_result=$(run_cell profile_pkdtree_batch \
+    "KIDDO_CPP_SUITES=pkdtree_batch KIDDO_CPP_LIBRARIES=$LIBRARIES KIDDO_CPP_SCALARS=f64 KIDDO_STRATEGIES=$STRATEGIES" \
+    f64 14 256 preflight 0.5 1 10 "$PREFLIGHT_DIR")
+(( $(jq '.results | length' "$preflight_result") > 0 )) || {
+    echo "Preflight produced no results" >&2
+    exit 1
+}
+python3 "$SCRIPT_DIR/chart_pkdtree_batch_results.py" all \
+    --result "$preflight_result" --result-label "$SUITE_LABEL-preflight" \
+    --output-dir "$PREFLIGHT_DIR/charts" --html-name preflight.html
+cleanup_preflight
+trap - EXIT INT TERM
+
+# --- matrix --------------------------------------------------------------
+
+planned=0
+for scalar in "${scalars[@]}"; do
+    if [[ "$scalar" == f64 ]]; then
+        planned=$((planned + ${#f64_heights[@]} * ${#query_counts[@]}))
+    else
+        planned=$((planned + ${#f32_heights[@]} * ${#query_counts[@]}))
+    fi
+done
+log "Phase: unlimited (boot profile: ${BOOT_PROFILE:-none}, gate: $EXPECT_VERB, cpus: $BENCH_CPUS, $WORKER_COUNT workers)"
+log "Libraries: $LIBRARIES  strategies: $STRATEGIES  scalars: $SCALARS"
+log "Planned cells: $planned"
+log "NOTE: no CPU isolation in this profile -- these numbers are NOT comparable"
+log "      with the controlled multi-core matrix's, only with each other."
+
+batch_results=()
+completed=0
+
+log "=== pkdtree_batch (unrestricted): kiddo ($STRATEGIES) vs Pkd-tree parallel_for ==="
+for scalar in "${scalars[@]}"; do
+    if [[ "$scalar" == f64 ]]; then
+        heights=("${f64_heights[@]}")
+    else
+        heights=("${f32_heights[@]}")
+    fi
+    for height in "${heights[@]}"; do
+        for query_count in "${query_counts[@]}"; do
+            completed=$((completed + 1))
+            log "[$completed/$planned] unlimited $scalar 2^$height, $query_count queries"
+            batch_results+=("$(run_cell profile_pkdtree_batch \
+                "KIDDO_CPP_SUITES=pkdtree_batch KIDDO_CPP_LIBRARIES=$LIBRARIES KIDDO_CPP_SCALARS=$scalar KIDDO_STRATEGIES=$STRATEGIES" \
+                "$scalar" "$height" "$query_count" matrix)")
+        done
+    done
+done
+
+validate_environment "$RUN_DIR/environment-after.txt"
+
+# --- charts --------------------------------------------------------------
+
+if (( ${#batch_results[@]} > 0 )); then
+    chart_args=()
+    for result in "${batch_results[@]}"; do
+        chart_args+=(--result "$result")
+    done
+    python3 "$SCRIPT_DIR/chart_pkdtree_batch_results.py" all \
+        "${chart_args[@]}" \
+        --result-label "$SUITE_LABEL" \
+        --output-dir "$CHART_DIR" \
+        --html-name "$SUITE_LABEL-batch.html"
+    log "Batch charts: $CHART_DIR/$SUITE_LABEL-batch.html"
+fi
+
+log "Suite complete: ${#batch_results[@]} result files in $RUN_DIR"


### PR DESCRIPTION
## Summary

Three new boot-profile scripts, replacing the earlier competitor matrix's single-core phase, to fix two real problems that showed up when I tried to analyze its results:

1. **kiddo was never in the single-threaded comparison.** The earlier matrix ran nanoflann + Pkd-tree only in that phase; kiddo's numbers came from a separately-run, separately-dated session, forcing the analysis into a handicapped-bound argument instead of a direct one.
2. **Only two of kiddo's four stem strategies were exercised** (Eytzinger and one Donnelly variant), and only at a single shared 3D dimensionality — which turned out to put f32 outside the block height its own AVX-512 code is compiled for.

## The dimensionality fix

`DonnellyCyclicSimdDescent` and `DonnellyCyclicSimdFull` each panic unless the tree's block height matches the AVX-512 specialization compiled in for the scalar type: BH=3 for f64, BH=4 for f32 — independent of tree dimensionality. `profile_cpp_competitors.rs` built every tree at a single shared `K=3`, so f32 never got its native block height at all.

This PR splits that into `K_F32=4`/`K_F64=3`, so every scalar's dimension equals its own native block height. I verified this empirically rather than trusting the doc comments (which turned out to be stale in one direction and technically-true-but-incomplete in another):

- A synthetic 4-point tree segfaulted across several `(K, BH)` combinations that a realistic 65536-point tree did not — small-tree tests were misleading me.
- A comment claiming f32 "cannot use" the cyclic strategies turned out to describe a stale `BH=3`-for-f32 case; `BH=4`-for-f32 has always worked, confirmed against the Eytzinger baseline over 100 real queries per combination, both scalars, all four strategies.

Both `nanoflann_shim.cpp` and `pkdtree_shim.cpp` hardcoded dimension 3 as a **compile-time** template parameter — that's where their own per-dimension performance actually comes from (unrolled arithmetic, not a runtime dim check), so rather than lose that for either scalar, both shims now compile in `Dim=3` and `Dim=4` specializations and dispatch via a runtime tag on the opaque FFI handle. I checked this against the real vendored Pkd-tree source (via a live `cpp_competitors` build) rather than guessing — `cpdd::k_nearest` takes an explicit `DIM` parameter distinct from `PointType`'s own, which the shim had been passing as a second hardcoded `3`.

## The scripts

| Script | Boot profile | What it compares |
|---|---|---|
| `run_single_core_strategy_matrix.sh` | `benchmark single-core` | kiddo (4 strategies) + Pkd-tree, same session; nanoflann alongside, same seeds/sizes |
| `run_multicore_strategy_matrix.sh` | `benchmark multi-core` | kiddo (4 strategies × serial/parallel/tuned) vs Pkd-tree `parallel_for` |
| `run_unlimited_strategy_matrix.sh` | `benchmark unlimited` | kiddo (4 strategies) vs Pkd-tree, max achievable QPS, no isolation |

All three default `KIDDO_STRATEGIES` to `eytzinger,donnelly_unrolled,donnelly_cyclic_simd_descent,donnelly_cyclic_simd_full`.

Tree sizes default to sizes where the stem height (`log2(points) - log2(leaf capacity)`) is an **exact multiple** of the block height — `log2(points) = 5 + m·BH` — giving f64 (BH=3) `20,23,26` and f32 (BH=4) `21` (capped there by Pkd-tree's own build-assertion limit). A stem padded to a taller height than its content needs is a different, not-yet-measured regime, so this is deliberately conservative for now.

The three share environment validation, IRQ accounting and cell-retry logic via a new `scripts/lib_bench_profile_matrix.sh` rather than tripling ~500 lines of it — the `isolcpus=domain` canary check in particular is the one thing that must never drift between them.

## Two gating bugs caught by dry-running against a normal boot

I didn't just assume the gating logic was correct — I ran all three against this (non-benchmark) dev machine and checked they refused. Two didn't, at first:

- **`bench-profile-status` failing was only counted as fatal when `STRICT_ISOLATION==1`.** On the unlimited profile (`STRICT_ISOLATION=0` by design, since its isolation checks can't hold), a completely unrelated desktop boot with no `BENCH_PROFILE` marker at all sailed straight through `validate_environment` and started building and running benchmarks. Fixed: being booted into the right profile at all is now unconditionally fatal; `STRICT_ISOLATION` only relaxes the isolation-specific checks it was meant to.
- **The top-of-script boot-profile guard** used `[[ -n "$BOOT_PROFILE" && "$BOOT_PROFILE" != "$REQUIRED_PROFILE" ]]`, so an *empty* `BOOT_PROFILE` skipped the check entirely. These are single-purpose scripts with no `PHASE=` override to justify that leniency, so it's now unconditional.
- (Also caught in the same pass: `F32_HEIGHTS` defaulted to `21,25`, violating the Pkd-tree `<=21` cap the scripts enforce a few lines later. Fixed to `21`.)

All three now correctly exit 2 with a clear message on this machine's normal boot.

## Chart scripts

`chart_pkdtree_batch_results.py` and `chart_kiddo_vs_pkdtree_results.py` both matched library identity by function-id prefix, and the existing `"kiddo_"` prefixes would have either silently bucketed every new strategy into one "kiddo" series, or (the batch chart's more specific prefixes) raised `unsupported query identity` the first time a new strategy's results were charted. Extended both to recognise all four strategies, and verified against real exported result data — not just parsed for syntax — for both.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --bench profile_cpp_competitors --features cpp_competitors,test_utils,logging_off,simd --no-deps` — clean
- Real builds and runs against the live vendored C++ sources (network-fetched during this session): all 4 strategies × both scalars, single-threaded and batch, produced correct results with no crashes and no correctness-check failures
- Both updated chart scripts run against real exported result JSON, producing correct multi-series charts
- All three new scripts: `bash -n` clean, and confirmed to refuse correctly (exit 2) when not booted into their required profile
- None of the three has been run end-to-end against an actual bench-profile boot yet — that's the natural next step, on real hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8SWimtznixdAkNWTyvE1j