### PR TITLE
fix: verify v6.0.0 with supported release features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,21 @@ resolver = "2"
 ignored = ["log"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = [
+  "buffered_result_collection",
+  "csv",
+  "f16",
+  "fixed",
+  "huge_pages",
+  "las",
+  "leaf_nta_prefetch",
+  "logging_off",
+  "multi-threaded",
+  "rkyv_08",
+  "serde",
+  "simd",
+  "small_n_result_collectors",
+]
 
 [features]
 cargo_asm = ["dep:rand", "dep:rand_chacha"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,8 @@
 [workspace]
-changelog_config = "git-cliff.toml"             # use a custom git-cliff configuration
-dependencies_update = true                      # update dependencies with `cargo update`
-git_release_type = "auto"                       # SemVer pre-release in the version will mark the release as not ready for prod
-pr_labels = ["release"]                         # add the `release` label to the release Pull Request
+changelog_config = "git-cliff.toml" # use a custom git-cliff configuration
+dependencies_update = true          # update dependencies with `cargo update`
+git_release_type = "auto"           # SemVer pre-release in the version will mark the release as not ready for prod
+pr_labels = ["release"]             # add the `release` label to the release Pull Request
 publish_all_features = false
 # Verify releases with supported consumer-facing features. Nightly SIMD is
 # covered by CI; benchmark, fuzzing, simulation, and diagnostic features are omitted.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,5 +3,21 @@ changelog_config = "git-cliff.toml"             # use a custom git-cliff configu
 dependencies_update = true                      # update dependencies with `cargo update`
 git_release_type = "auto"                       # SemVer pre-release in the version will mark the release as not ready for prod
 pr_labels = ["release"]                         # add the `release` label to the release Pull Request
-publish_all_features = true
+publish_all_features = false
+# Verify releases with supported consumer-facing features. Nightly SIMD is
+# covered by CI; benchmark, fuzzing, simulation, and diagnostic features are omitted.
+publish_features = [
+  "buffered_result_collection",
+  "csv",
+  "f16",
+  "fixed",
+  "huge_pages",
+  "las",
+  "leaf_nta_prefetch",
+  "logging_off",
+  "multi-threaded",
+  "rkyv_08",
+  "serde",
+  "small_n_result_collectors",
+]
 release_commits = "^(feat|fix|perf|docs)!?[(:]"


### PR DESCRIPTION
## Summary

- replace release-plz `--all-features` verification with an explicit stable, consumer-facing feature set
- configure docs.rs with an explicit feature set that keeps `simd` documentation enabled
- exclude C++ benchmark, fuzzing, simulation, assembly-hook, and diagnostic instrumentation features from release verification and docs.rs

## Root cause

The v6.0.0 release workflow failed while verifying the package tarball because `publish_all_features = true` enabled `cpp_competitors`. Its build requires system Boost headers that are not installed in the release job, so release-plz stopped before publishing the crate or creating the v6.0.0 tag.

Kiddo remains at version 6.0.0 because that version has not been published.

## Validation

- `cargo +stable package --allow-dirty --features 'buffered_result_collection,csv,f16,fixed,huge_pages,las,leaf_nta_prefetch,logging_off,multi-threaded,rkyv_08,serde,small_n_result_collectors'`
- `cargo +nightly doc --no-deps --features 'buffered_result_collection,csv,f16,fixed,huge_pages,las,leaf_nta_prefetch,logging_off,multi-threaded,rkyv_08,serde,simd,small_n_result_collectors'`

The PR should carry the `release` label so merging it retries publication of the still-unpublished v6.0.0 through the existing Release and Publish workflow.
