### PR TITLE
ci: single PR Mergeable gate, and /fuzz on demand

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - master
       - v5.x.x
-  pull_request:
-    branches:
-      - "**"
+  # Pull requests reach these jobs through `PR Mergeable`, which aggregates every
+  # required check into a single status. Triggering here as well would double every
+  # run and leave two competing statuses on the PR.
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
+  # calling workflow's name, so every called workflow would share one group and
+  # deadlock against its caller.
+  group: ci-common-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build-msrv.yml
+++ b/.github/workflows/build-msrv.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - master
       - v5.x.x
-  pull_request:
-    branches:
-      - "**"
+  # Pull requests reach these jobs through `PR Mergeable`, which aggregates every
+  # required check into a single status. Triggering here as well would double every
+  # run and leave two competing statuses on the PR.
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
+  # calling workflow's name, so every called workflow would share one group and
+  # deadlock against its caller.
+  group: ci-msrv-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - master
       - v5.x.x
-  pull_request:
-    branches:
-      - "**"
+  # Pull requests reach these jobs through `PR Mergeable`, which aggregates every
+  # required check into a single status. Triggering here as well would double every
+  # run and leave two competing statuses on the PR.
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
+  # calling workflow's name, so every called workflow would share one group and
+  # deadlock against its caller.
+  group: ci-nightly-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - master
       - v5.x.x
-  pull_request:
-    branches:
-      - "**"
+  # Pull requests reach these jobs through `PR Mergeable`, which aggregates every
+  # required check into a single status. Triggering here as well would double every
+  # run and leave two competing statuses on the PR.
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
+  # calling workflow's name, so every called workflow would share one group and
+  # deadlock against its caller.
+  group: ci-stable-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/fuzz-command.yml
+++ b/.github/workflows/fuzz-command.yml
@@ -1,0 +1,122 @@
+name: Fuzz Command
+
+# Runs the v6 fuzz suite against a pull request on demand, when someone comments
+# `/fuzz` on it. Feature PRs do not fuzz by default because the sweeps are far too
+# slow to sit on every push; this is the escape hatch for when a change warrants it.
+#
+# Any comment *starting* with `/fuzz` triggers a run, so `/fuzz please have a look`
+# works and, harmlessly, so does `/fuzzy`. Expressions have no regex, and matching the
+# body exactly would silently ignore a comment with a stray trailing space.
+#
+# Release PRs do not need this - `PR Mergeable` fuzzes those automatically and blocks
+# the merge on the result.
+#
+# TRUST MODEL: this checks out and executes the pull request's code, so it is limited
+# to commenters with write-ish access (owner, org member, or collaborator). A fork PR
+# can still propose code that runs here, which is why nothing beyond a read-only
+# `GITHUB_TOKEN` is exposed: no `secrets: inherit` on the fuzz call below.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Keyed on the PR, so a second `/fuzz` supersedes a run still in flight on the same
+  # pull request rather than queueing behind it.
+  group: fuzz-command-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    name: Authorize
+    # `issue_comment` fires for issues as well as pull requests; `issue.pull_request`
+    # is only present on the latter. `author_association` is set by GitHub from the
+    # commenter's relationship to the repository and cannot be spoofed by the comment.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/fuzz') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Acknowledge the request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes >/dev/null
+
+      - name: Resolve the pull request head
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          sha=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          # `refs/pull/N/head` rather than the bare SHA: it resolves in this repository
+          # for fork pull requests too, where the head SHA lives in the fork.
+          {
+            echo "ref=refs/pull/${PR_NUMBER}/head"
+            echo "sha=${sha}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Fuzzing PR #${PR_NUMBER} at ${sha}"
+
+  fuzz:
+    name: Fuzz
+    needs: authorize
+    # Deliberately no `secrets: inherit` - see the trust model note above.
+    uses: ./.github/workflows/fuzz-v6.yml
+    with:
+      ref: ${{ needs.authorize.outputs.ref }}
+
+  report:
+    name: Report
+    needs: [authorize, fuzz]
+    if: always() && needs.authorize.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment with the outcome
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.fuzz.result }}
+          SHA: ${{ needs.authorize.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) summary="✅ v6 fuzz suite passed" ;;
+            cancelled) summary="⚠️ v6 fuzz suite was cancelled" ;;
+            *) summary="❌ v6 fuzz suite failed" ;;
+          esac
+
+          # Built with printf rather than a multi-line shell string: the indentation of
+          # a continued line would be carried into the comment, and four leading spaces
+          # turn a Markdown line into a code block.
+          #
+          # Double quotes with escaped backticks, not single quotes: the backticks are
+          # literal Markdown code spans, and in single quotes shellcheck reads them as a
+          # substitution that will not expand (SC2016).
+          body=$(printf "%s for \`%s\`.\n\n[View run](%s)\n\nOn failure the run uploads \`kd_tree_fuzz_v6_report.txt\` as an artifact, listing the failing seeds. Each is replayable locally with \`just fuzz-case-repro <repro-id>\`." \
+            "$summary" "$SHA" "$RUN_URL")
+
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body="$body" >/dev/null

--- a/.github/workflows/fuzz-v6.yml
+++ b/.github/workflows/fuzz-v6.yml
@@ -47,6 +47,14 @@ on:
   # Called by `PR Mergeable` on release PRs, where the full sweep blocks the merge.
   workflow_call:
     inputs:
+      ref:
+        description: >-
+          Git ref to check out. Callers triggered by `issue_comment` run in the context
+          of the default branch, so they must pass the pull request's head ref to fuzz
+          the proposed code rather than master. Empty checks out the triggering ref.
+        required: false
+        default: ""
+        type: string
       cases:
         description: Number of generated tree cases for the exact-query fuzz tests
         required: false
@@ -94,7 +102,7 @@ permissions:
 concurrency:
   # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
   # calling workflow's name, which would put this in the same group as its caller.
-  group: fuzz-v6-${{ github.ref }}
+  group: fuzz-v6-${{ inputs.ref || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -116,6 +124,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           show-progress: false
+          # Empty falls back to the triggering ref, which is what push and
+          # workflow_dispatch runs want.
+          ref: ${{ inputs.ref }}
 
       - name: Cache Cargo
         uses: actions/cache@v6

--- a/.github/workflows/fuzz-v6.yml
+++ b/.github/workflows/fuzz-v6.yml
@@ -44,11 +44,57 @@ on:
         default: true
         type: boolean
 
+  # Called by `PR Mergeable` on release PRs, where the full sweep blocks the merge.
+  workflow_call:
+    inputs:
+      cases:
+        description: Number of generated tree cases for the exact-query fuzz tests
+        required: false
+        default: "8"
+        type: string
+      query_count:
+        description: Queries per generated tree case
+        required: false
+        default: "100"
+        type: string
+      min_pow:
+        description: Minimum generated tree size as a power of two
+        required: false
+        default: "10"
+        type: string
+      max_pow:
+        description: Maximum generated tree size as a power of two
+        required: false
+        default: "20"
+        type: string
+      threads:
+        description: Query worker threads (large tree builds remain serial)
+        required: false
+        default: "4"
+        type: string
+      approx_cases:
+        description: Number of generated cases for the approximate-query quality sweep
+        required: false
+        default: "4"
+        type: string
+      approx_query_count:
+        description: Queries per approximate-query quality case
+        required: false
+        default: "128"
+        type: string
+      run_simd:
+        description: Run the SIMD matrix after the non-SIMD matrix
+        required: false
+        default: true
+        type: boolean
+
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
+  # calling workflow's name, which would put this in the same group as its caller.
+  group: fuzz-v6-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-mergeable.yml
+++ b/.github/workflows/pr-mergeable.yml
@@ -1,0 +1,106 @@
+name: CI
+
+# Single aggregated status for branch protection. `needs:` cannot reach across
+# workflows, so every check that must block a merge is invoked from here as a
+# reusable workflow and collected by the final `PR Mergeable` job. Configure the
+# repository to require only that check.
+#
+# Which checks block depends on the kind of PR: release PRs additionally run the
+# full v6 fuzz suite, including the long-running sweeps that ordinary CI marks
+# `#[ignore]`. release-plz labels its PRs via `pr_labels` in release-plz.toml.
+#
+# Checks deliberately left outside this gate, because they are advisory or carry
+# their own semantics: Test Coverage, CodeQL, Dependency Review.
+#
+# A nested check is reported as `<this workflow> / <job id> / <job in the called
+# workflow>`. Naming this workflow `CI` and the calling jobs after the workflows they
+# call keeps that reading identical to a push run - `CI / Common / Commit Lint` - since
+# the called workflows are themselves named `CI / Common` and friends.
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    # `labeled`/`unlabeled` matter because the release-PR decision below reads the
+    # labels: a PR that gains or loses the `release` label must re-evaluate.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: pr-mergeable-${{ github.ref }}
+  cancel-in-progress: true
+
+# A called workflow's permissions can only narrow the caller's, never widen them, so
+# this must cover the union of what the called workflows ask for: `pull-requests: read`
+# for commit linting, `checks: write` for the clippy annotations. Each called job still
+# declares its own narrower set.
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  Common:
+    uses: ./.github/workflows/build-common.yml
+    secrets: inherit
+
+  Stable:
+    uses: ./.github/workflows/build-stable.yml
+    secrets: inherit
+
+  Nightly:
+    uses: ./.github/workflows/build-nightly.yml
+    secrets: inherit
+
+  MSRV:
+    uses: ./.github/workflows/build-msrv.yml
+    secrets: inherit
+
+  WASM:
+    uses: ./.github/workflows/wasm.yml
+    secrets: inherit
+
+  Fuzz:
+    # Release PRs only. The sweeps take far too long for every feature PR, and the
+    # non-ignored fuzz tests already run as part of the normal test job.
+    #
+    # Two signals, either of which marks a release PR: the `release` label from
+    # `pr_labels` in release-plz.toml, and the branch release-plz pushes to. The label
+    # alone would stop gating if someone removed it by hand.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'release')
+      || startsWith(github.head_ref, 'release-plz-')
+    uses: ./.github/workflows/fuzz-v6.yml
+    secrets: inherit
+
+  pr-mergeable:
+    name: PR Mergeable
+    needs: [Common, Stable, Nightly, MSRV, WASM, Fuzz]
+    # Runs even when a dependency fails, so the status is always reported and
+    # branch protection never waits forever on a check that will not arrive.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every required check passed
+        env:
+          # `needs` carries each dependency's result: success, failure, cancelled
+          # or skipped. Passed as JSON rather than interpolated into the script so
+          # a job name can never be read as shell.
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+
+          # `skipped` is a pass: `fuzz` is skipped on every non-release PR, by design.
+          # Anything that ran and did not succeed blocks the merge.
+          blocking=$(echo "$NEEDS" | jq -r '
+            to_entries[]
+            | select(.value.result == "failure" or .value.result == "cancelled")
+            | .key
+          ')
+
+          if [ -n "$blocking" ]; then
+            echo "::error::Required checks did not pass: $(echo "$blocking" | tr '\n' ' ')"
+            exit 1
+          fi
+
+          echo "All required checks passed."

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - master
       - v5.x.x
-  pull_request:
-    branches:
-      - "**"
+  # Pull requests reach these jobs through `PR Mergeable`, which aggregates every
+  # required check into a single status. Triggering here as well would double every
+  # run and leave two competing statuses on the PR.
+  workflow_call:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Two CI changes, split into a commit each.

## `PR Mergeable`

Branch protection can only require checks by name, and `needs:` cannot reach across workflows. Every check that should block a merge is now invoked from one `PR Mergeable` workflow as a reusable workflow, collected by a final gate job that fails if any dependency failed or was cancelled.

Release PRs additionally run the **full v6 fuzz suite**, including the long-running sweeps ordinary CI marks `#[ignore]`, and it blocks the merge. Detected by either the `release` label (`pr_labels` in `release-plz.toml`) or a `release-plz-*` head branch, so removing the label by hand does not silently disable it. Feature PRs skip the sweep — `skipped` counts as a pass.

Test Coverage, CodeQL and Dependency Review stay outside the gate, being advisory or carrying their own semantics.

The five called workflows lose their own `pull_request` trigger (keeping `push` and `workflow_dispatch`) so nothing runs twice.

## `/fuzz`

Commenting `/fuzz` on a PR runs the suite against that PR and reports back with a link to the run. Limited to owner/member/collaborator, since it executes the PR's code; the call does not inherit secrets and gets a read-only token.

## Two things that would have broken this silently

- Concurrency groups keyed on `${{ github.workflow }}` expand to the *calling* workflow's name under `workflow_call`, which would have put every called workflow and its caller in one group and deadlocked. Now literal prefixes.
- A called workflow's permissions can only narrow the caller's. `build-nightly`/`build-msrv` want `checks: write` and `build-common` wants `pull-requests: read`; the caller now grants that union.

## Before merging

**Branch protection must be updated as this lands.** master currently requires 11 named checks; those names are no longer reported directly on PRs, so any left in the list will be waited on forever. Replace them with `PR Mergeable` alone. This PR is itself affected and will need an admin override or the rule relaxed first.

**Release PRs will be blocked** once this is in: the deep sweep currently fails on `fuzz_v6_immutable_f32` and `fuzz_v6_mutable_f64`, both pre-existing on master and confirmed by replaying their seeds against master. Worth an issue before release-plz next opens a PR.

Validated locally with `actionlint` and `prettier --check`; the reusable-workflow wiring can only really be proven by running here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)