### PR TITLE
fix(ci): dispatch the /fuzz command the way /benchmark does

### DIFF
--- a/.github/workflows/fuzz-command.yml
+++ b/.github/workflows/fuzz-command.yml
@@ -4,119 +4,76 @@ name: Fuzz Command
 # `/fuzz` on it. Feature PRs do not fuzz by default because the sweeps are far too
 # slow to sit on every push; this is the escape hatch for when a change warrants it.
 #
-# Any comment *starting* with `/fuzz` triggers a run, so `/fuzz please have a look`
-# works and, harmlessly, so does `/fuzzy`. Expressions have no regex, and matching the
-# body exactly would silently ignore a comment with a stray trailing space.
-#
 # Release PRs do not need this - `PR Mergeable` fuzzes those automatically and blocks
 # the merge on the result.
 #
-# TRUST MODEL: this checks out and executes the pull request's code, so it is limited
-# to commenters with write-ish access (owner, org member, or collaborator). A fork PR
-# can still propose code that runs here, which is why nothing beyond a read-only
-# `GITHUB_TOKEN` is exposed: no `secrets: inherit` on the fuzz call below.
+# Built the same way as the `/benchmark` command in benchmark-report-dispatch.yml:
+# validate the commenter, then `createWorkflowDispatch` the real workflow against the
+# PR's *base* ref, passing the head as inputs. Dispatching against the base ref means
+# the workflow definition always comes from the target branch, never from the proposed
+# code, while the checkout in the dispatched run still fuzzes the PR's head.
+#
+# TRUST MODEL: the dispatched run checks out and executes the pull request's code, so
+# this is limited to commenters with write-ish access. Note this is stricter than
+# `/benchmark`, which also allows CONTRIBUTOR.
 
 on:
   issue_comment:
     types: [created]
 
 permissions:
+  actions: write
   contents: read
-
-concurrency:
-  # Keyed on the PR, so a second `/fuzz` supersedes a run still in flight on the same
-  # pull request rather than queueing behind it.
-  group: fuzz-command-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  pull-requests: write
 
 jobs:
-  authorize:
-    name: Authorize
+  dispatch-fuzz:
     # `issue_comment` fires for issues as well as pull requests; `issue.pull_request`
-    # is only present on the latter. `author_association` is set by GitHub from the
-    # commenter's relationship to the repository and cannot be spoofed by the comment.
-    if: >-
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/fuzz') &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    # is only present on the latter.
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/fuzz')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: read
-    outputs:
-      ref: ${{ steps.resolve.outputs.ref }}
-      sha: ${{ steps.resolve.outputs.sha }}
     steps:
-      - name: Acknowledge the request
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh api \
-            --method POST \
-            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
-            -f content=eyes >/dev/null
+      - name: Validate trigger and dispatch the v6 fuzz suite
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.issue.number;
+            const comment = context.payload.comment;
+            const association = comment.author_association;
 
-      - name: Resolve the pull request head
-        id: resolve
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          set -euo pipefail
-          sha=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.head.sha')
+            // `author_association` is set by GitHub from the commenter's relationship to
+            // the repository, and cannot be spoofed by the contents of the comment.
+            const allowedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
-          # `refs/pull/N/head` rather than the bare SHA: it resolves in this repository
-          # for fork pull requests too, where the head SHA lives in the fork.
-          {
-            echo "ref=refs/pull/${PR_NUMBER}/head"
-            echo "sha=${sha}"
-          } >> "$GITHUB_OUTPUT"
+            if (!allowedAssociations.has(association)) {
+              core.setFailed(
+                `/fuzz requires OWNER, MEMBER, or COLLABORATOR status. ${comment.user.login} is ${association}.`
+              );
+              return;
+            }
 
-          echo "Fuzzing PR #${PR_NUMBER} at ${sha}"
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issueNumber,
+            });
 
-  fuzz:
-    name: Fuzz
-    needs: authorize
-    # Deliberately no `secrets: inherit` - see the trust model note above.
-    uses: ./.github/workflows/fuzz-v6.yml
-    with:
-      ref: ${{ needs.authorize.outputs.ref }}
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "fuzz-v6.yml",
+              ref: pr.base.ref,
+              inputs: {
+                pr_number: String(pr.number),
+                head_sha: pr.head.sha,
+              },
+            });
 
-  report:
-    name: Report
-    needs: [authorize, fuzz]
-    if: always() && needs.authorize.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Comment with the outcome
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RESULT: ${{ needs.fuzz.result }}
-          SHA: ${{ needs.authorize.outputs.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) summary="✅ v6 fuzz suite passed" ;;
-            cancelled) summary="⚠️ v6 fuzz suite was cancelled" ;;
-            *) summary="❌ v6 fuzz suite failed" ;;
-          esac
-
-          # Built with printf rather than a multi-line shell string: the indentation of
-          # a continued line would be carried into the comment, and four leading spaces
-          # turn a Markdown line into a code block.
-          #
-          # Double quotes with escaped backticks, not single quotes: the backticks are
-          # literal Markdown code spans, and in single quotes shellcheck reads them as a
-          # substitution that will not expand (SC2016).
-          body=$(printf "%s for \`%s\`.\n\n[View run](%s)\n\nOn failure the run uploads \`kd_tree_fuzz_v6_report.txt\` as an artifact, listing the failing seeds. Each is replayable locally with \`just fuzz-case-repro <repro-id>\`." \
-            "$summary" "$SHA" "$RUN_URL")
-
-          gh api \
-            --method POST \
-            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
-            -f body="$body" >/dev/null
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: `Queued v6 fuzz suite for \`${pr.head.label}\` at \`${pr.head.sha.slice(0, 12)}\`. The run comments back with the result.`,
+            });

--- a/.github/workflows/fuzz-v6.yml
+++ b/.github/workflows/fuzz-v6.yml
@@ -1,8 +1,18 @@
 name: Fuzz / v6
 
+run-name: Fuzz / v6 for ${{ inputs.head_sha || github.ref_name }}
+
 on:
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: "Pull request number for comment-dispatched fuzz runs"
+        required: false
+        type: string
+      head_sha:
+        description: "Head commit SHA to fuzz"
+        required: false
+        type: string
       cases:
         description: Number of generated tree cases for the exact-query fuzz tests
         required: false
@@ -47,13 +57,13 @@ on:
   # Called by `PR Mergeable` on release PRs, where the full sweep blocks the merge.
   workflow_call:
     inputs:
-      ref:
-        description: >-
-          Git ref to check out. Callers triggered by `issue_comment` run in the context
-          of the default branch, so they must pass the pull request's head ref to fuzz
-          the proposed code rather than master. Empty checks out the triggering ref.
+      pr_number:
+        description: "Pull request number for comment-dispatched fuzz runs"
         required: false
-        default: ""
+        type: string
+      head_sha:
+        description: "Head commit SHA to fuzz"
+        required: false
         type: string
       cases:
         description: Number of generated tree cases for the exact-query fuzz tests
@@ -98,11 +108,12 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   # Literal prefix, not `github.workflow`: under `workflow_call` that expands to the
   # calling workflow's name, which would put this in the same group as its caller.
-  group: fuzz-v6-${{ inputs.ref || github.ref }}
+  group: fuzz-v6-${{ inputs.head_sha || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -123,10 +134,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          # Falls back to the triggering ref, which is what `PR Mergeable` and a bare
+          # dispatch want. A `/fuzz` comment supplies the pull request's head commit,
+          # which is reachable here even when the pull request comes from a fork.
+          ref: ${{ inputs.head_sha || github.sha }}
           show-progress: false
-          # Empty falls back to the triggering ref, which is what push and
-          # workflow_dispatch runs want.
-          ref: ${{ inputs.ref }}
 
       - name: Cache Cargo
         uses: actions/cache@v6
@@ -156,6 +168,27 @@ jobs:
       - name: Run SIMD fuzz suite
         if: inputs.run_simd
         run: just fuzz-kd-tree-v6-simd
+
+      - name: Comment the outcome on the pull request
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const outcome = "${{ job.status }}";
+            const summary =
+              outcome === "success"
+                ? "✅ v6 fuzz suite passed"
+                : outcome === "cancelled"
+                  ? "⚠️ v6 fuzz suite was cancelled"
+                  : "❌ v6 fuzz suite failed";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number("${{ inputs.pr_number }}"),
+              body: `${summary} for \`${{ inputs.head_sha }}\`.\n\n[View run](${runUrl})\n\nOn failure the run uploads \`kd_tree_fuzz_v6_report.txt\` as an artifact, listing the failing seeds. Each is replayable locally with \`just fuzz-case-repro <repro-id>\`.`,
+            });
 
       - name: Upload fuzz failure report
         if: always()

--- a/.github/workflows/pr-mergeable.yml
+++ b/.github/workflows/pr-mergeable.yml
@@ -30,12 +30,14 @@ concurrency:
   cancel-in-progress: true
 
 # A called workflow's permissions can only narrow the caller's, never widen them, so
-# this must cover the union of what the called workflows ask for: `pull-requests: read`
-# for commit linting, `checks: write` for the clippy annotations. Each called job still
-# declares its own narrower set.
+# this must cover the union of what the called workflows ask for: `checks: write` for
+# the clippy annotations, and `pull-requests: write` because fuzz-v6.yml comments its
+# result back when a `/fuzz` comment dispatched it. Requesting less here does not
+# downgrade the called workflow, it stops the whole run from starting. Each called job
+# still declares its own narrower set.
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   checks: write
 
 jobs:


### PR DESCRIPTION
`/fuzz` failed on its first real use, on #521. The run is [here](https://github.com/sdd-org/kiddo/actions/runs/31277485531):

```
gh: Resource not accessible by integration (HTTP 403)
```

The `Acknowledge the request` step posts a 👀 reaction, and `set -e` ended the job before it reached the fuzz call. The job asked for `issues: write` and `pull-requests: read` — but the comment is on a pull request, so writing to it needs `pull-requests: write`. The repo's default token permission is already `write`, so it was purely the scope I requested.

## Rather than patch the permission, match `/benchmark`

`benchmark-report-dispatch.yml` has been doing this correctly all along, so `/fuzz` now works the same way:

- workflow-level `actions: write`, `contents: read`, `pull-requests: write`
- `actions/github-script@v9` instead of `gh api` in shell
- commenter validated inside the script via `author_association`, failing with `core.setFailed`
- `createWorkflowDispatch` on `fuzz-v6.yml` against the PR's **base** ref, with the head passed as inputs
- a confirmation comment naming the branch and SHA

Dispatching against the base ref means the workflow definition always comes from the target branch rather than from the code under test, while the checkout in the dispatched run still fuzzes the PR head. That also drops the reaction that failed, and the reusable-workflow call it replaces — the suite is now reached by one path whether it's `PR Mergeable` on a release PR or `/fuzz` on a feature PR.

## Two differences from `/benchmark`, both deliberate

- **Stricter authorization.** `/benchmark` allows `CONTRIBUTOR`; `/fuzz` does not, since it executes the PR's code.
- **Two head inputs, not four.** `workflow_dispatch` accepts at most 10 inputs and `fuzz-v6.yml` already has 8 tuning knobs, so it takes `pr_number` and `head_sha` only. A fork PR's head commit is reachable from this repository, so dropping `head_repo` costs nothing, and `head_ref` was only cosmetic. None of the existing tuning inputs were removed.

The dispatched run now comments its outcome back on the PR, which is where the result was going to be reported from before.

Validated with `actionlint` (with shellcheck available, which is how the original 403-shaped gap in my local checks got missed) and `prettier --check`. As with the last one, the dispatch wiring can only really be proven by running it here — and note that because `issue_comment` always runs the default branch's copy, `/fuzz` on #521 will not work until this is merged and #521 rebased on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)