### PR TITLE
chore: release v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Kiddo Changelog
 
+## [6.0.1] - 2026-08-10
+
+### 🐛 Bug Fixes
+
+- Ensure kibrary compiles for wasm32-unknown-unknown target ([@sdd](https://github.com/sdd), Fixes:#515)
+
+- Dispatch the /fuzz command the way /benchmark does ([@sdd](https://github.com/sdd))
+
+- Grant the aggregate gate the permissions its called workflows need ([@sdd](https://github.com/sdd))
+
+- Chebyshev over-pruning found by fuzz testing ([@sdd](https://github.com/sdd))
+
+- Simd block-4 construction panic found by fuzzer ([@sdd](https://github.com/sdd))
+
+- Fuzzer-found SIMD backtracking optimisatition correctness issue ([@sdd](https://github.com/sdd))
+
+- Fuzz-uncovered construction bug ([@sdd](https://github.com/sdd))
+
+- Prevent f32 over-prune found in fuzz test ([@sdd](https://github.com/sdd))
+
+- Block-at-once strats now immutable-only ([@sdd](https://github.com/sdd))
+
+
+### 🤖 CI
+
+- Aggregate required checks into a single PR Mergeable status ([@sdd](https://github.com/sdd))
+
+- Run the v6 fuzz suite on demand via a /fuzz comment ([@sdd](https://github.com/sdd))
+
+
+### 🧹 Chore
+
+- Bump taiki-e/install-action from 2 to 2.85.5 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
 ## [6.0.0] - 2026-07-27
 
 Almost a year in the making and counting, Kiddo v6 is effectively a full rewrite, addressing some

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,11 @@
 
 - Block-at-once strats now immutable-only ([@sdd](https://github.com/sdd))
 
-
 ### 🤖 CI
 
 - Aggregate required checks into a single PR Mergeable status ([@sdd](https://github.com/sdd))
 
 - Run the v6 fuzz suite on demand via a /fuzz comment ([@sdd](https://github.com/sdd))
-
 
 ### 🧹 Chore
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "6.0.0"
+version = "6.0.1"
 edition = "2021"
 rust-version = "1.89.0"
 authors = ["Scott Donnelly <scott@donnel.ly>"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add `kiddo` to `Cargo.toml`
 
 ```toml
 [dependencies]
-kiddo = "6.0.0"
+kiddo = "6.0.1"
 ```
 
 Add points to a k-d tree and query the nearest points with a distance metric:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/6.0.0")]
+#![doc(html_root_url = "https://docs.rs/kiddo/6.0.1")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 #![allow(clippy::pointers_in_nomem_asm_block)]
 #![allow(clippy::too_many_arguments)]
@@ -106,7 +106,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "6.0.0"
+//! kiddo = "6.0.1"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION



## 🤖 New release

* `kiddo`: 6.0.0 -> 6.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.1] - 2026-08-10

### 🐛 Bug Fixes

- Ensure kibrary compiles for wasm32-unknown-unknown target ([@sdd](https://github.com/sdd), Fixes:#515)

- Dispatch the /fuzz command the way /benchmark does ([@sdd](https://github.com/sdd))

- Grant the aggregate gate the permissions its called workflows need ([@sdd](https://github.com/sdd))

- Chebyshev over-pruning found by fuzz testing ([@sdd](https://github.com/sdd))

- Simd block-4 construction panic found by fuzzer ([@sdd](https://github.com/sdd))

- Fuzzer-found SIMD backtracking optimisatition correctness issue ([@sdd](https://github.com/sdd))

- Fuzz-uncovered construction bug ([@sdd](https://github.com/sdd))

- Prevent f32 over-prune found in fuzz test ([@sdd](https://github.com/sdd))

- Block-at-once strats now immutable-only ([@sdd](https://github.com/sdd))


### 🤖 CI

- Aggregate required checks into a single PR Mergeable status ([@sdd](https://github.com/sdd))

- Run the v6 fuzz suite on demand via a /fuzz comment ([@sdd](https://github.com/sdd))


### 🧹 Chore

- Bump taiki-e/install-action from 2 to 2.85.5 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).