### PR TITLE
fix: correct optional dependency feature gates

### DIFF
--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -75,10 +75,19 @@ jobs:
         run: cargo hack check --workspace --each-feature --all-targets --exclude-features simd
 
       # `--all-targets` unifies features via the dev-dependency on kiddo itself,
-      # which re-enables `multi-threaded`. Check the lib alone so the serial
-      # construction and batch-query fallbacks stay compiled.
-      - name: Check single-threaded fallback paths
-        run: cargo check --lib --no-default-features --features=fixed
+      # which re-enables `fixed` and `multi-threaded`. Check the lib alone so
+      # optional dependencies and serial fallback paths stay covered.
+      - name: Check minimal feature combinations
+        run: |
+          cargo check --lib --no-default-features
+          cargo check --lib --no-default-features --features=fixed
+          cargo check --lib --no-default-features --features=serde
+
+          normal_dependencies=$(cargo tree --edges=normal --no-default-features --features=serde --prefix=none)
+          if grep -Eq '^(fixed|test-log) v' <<< "$normal_dependencies"; then
+            echo "fixed and test-log must not be normal dependencies without the fixed feature" >&2
+            exit 1
+          fi
 
   test-stable:
     name: Test (Stable)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -752,6 +752,11 @@ name = "donnelly_simd_regressions"
 path = "tests/donnelly_simd_regressions.rs"
 
 [[test]]
+name = "fixed_float_distance_queries"
+path = "tests/fixed_float_distance_queries.rs"
+required-features = ["fixed"]
+
+[[test]]
 name = "kd_tree_fuzz_v6"
 path = "tests/kd_tree_fuzz_v6.rs"
 required-features = ["fuzz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ las = ["dep:las"]
 multi-threaded = ["dep:rayon"]
 result_collection_stats = []
 exact_query_stats = []
-serde = ["dep:serde", "serde/derive", "fixed/serde", "aligned-vec/serde"]
+serde = ["dep:serde", "serde/derive", "fixed?/serde", "aligned-vec/serde"]
 simd = []
 simulator = []
 rkyv_08 = ["dep:rkyv_08", "dep:ptr_meta", "dep:bytecheck"]
@@ -79,7 +79,6 @@ cmov = "0.5"
 nonmax = "0.5.5"
 num-traits = "0.2"
 sorted-vec = "0.8"
-test-log = { version = "0.2.19", features = ["trace"] }
 
 [dependencies.bytecheck]
 version = "0.8"
@@ -186,6 +185,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 rstest = "0.26"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
+test-log = { version = "0.2.19", features = ["trace"] }
 tracing-subscriber = "0.3"
 trybuild = "1"
 ubyte = "0.10"

--- a/src/dist/chebyshev/mod.rs
+++ b/src/dist/chebyshev/mod.rs
@@ -2,6 +2,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
+    WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -19,13 +20,13 @@ pub struct Chebyshev<R>(core::marker::PhantomData<R>);
 impl<A, R> DistanceMetricScalar<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A>,
+    R: Axis<Coord = R> + WideningCastFrom<A>,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        <R as From<A>>::from(a)
+        R::widening_cast_from(a)
     }
 
     #[inline(always)]
@@ -75,7 +76,7 @@ where
 impl<A, R> DistanceMetricAvx512<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A>,
+    R: Axis<Coord = R> + WideningCastFrom<A>,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::ChebyshevAvx512F64LeafOps;
@@ -87,7 +88,7 @@ where
 impl<A, R> DistanceMetricAvx2<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A>,
+    R: Axis<Coord = R> + WideningCastFrom<A>,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::ChebyshevAvx2F64LeafOps;
@@ -99,7 +100,7 @@ where
 impl<A, R> DistanceMetricNeon<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A>,
+    R: Axis<Coord = R> + WideningCastFrom<A>,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::ChebyshevNeonF64LeafOps;

--- a/src/dist/chebyshev/mod.rs
+++ b/src/dist/chebyshev/mod.rs
@@ -1,5 +1,3 @@
-use fixed::traits::LossyFrom;
-
 use crate::Axis;
 
 use crate::dist::{
@@ -21,13 +19,13 @@ pub struct Chebyshev<R>(core::marker::PhantomData<R>);
 impl<A, R> DistanceMetricScalar<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A>,
+    R: Axis<Coord = R> + From<A>,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        R::lossy_from(a)
+        <R as From<A>>::from(a)
     }
 
     #[inline(always)]
@@ -53,7 +51,7 @@ where
 
         for axis in 0..K {
             let off_val = if axis == dim { new_off } else { off[axis] };
-            Self::combine_component(&mut acc, off_val);
+            <Self as DistanceMetricScalar<A>>::combine_component(&mut acc, off_val);
         }
 
         acc
@@ -77,7 +75,7 @@ where
 impl<A, R> DistanceMetricAvx512<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A>,
+    R: Axis<Coord = R> + From<A>,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::ChebyshevAvx512F64LeafOps;
@@ -89,7 +87,7 @@ where
 impl<A, R> DistanceMetricAvx2<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A>,
+    R: Axis<Coord = R> + From<A>,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::ChebyshevAvx2F64LeafOps;
@@ -101,7 +99,7 @@ where
 impl<A, R> DistanceMetricNeon<A> for Chebyshev<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A>,
+    R: Axis<Coord = R> + From<A>,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::ChebyshevNeonF64LeafOps;

--- a/src/dist/distance_metric_core.rs
+++ b/src/dist/distance_metric_core.rs
@@ -2,6 +2,103 @@ use std::cmp::Ordering;
 
 use crate::Axis;
 
+/// Coordinate conversion used by Kiddo's built-in widened distance metrics.
+///
+/// Primitive and fixed-point combinations delegate to [`az::CastFrom`]. The
+/// `half::f16` combinations use `num_traits::AsPrimitive`, because `az` does
+/// not implement casts for `half` types.
+#[doc(hidden)]
+pub trait WideningCastFrom<Src>: Sized {
+    fn widening_cast_from(src: Src) -> Self;
+}
+
+impl<T> WideningCastFrom<T> for T {
+    #[inline(always)]
+    fn widening_cast_from(src: T) -> Self {
+        src
+    }
+}
+
+macro_rules! impl_az_widening_casts {
+    ($src:ty => $($dst:ty),+ $(,)?) => {
+        $(
+            impl $crate::dist::WideningCastFrom<$src> for $dst {
+                #[inline(always)]
+                fn widening_cast_from(src: $src) -> Self {
+                    <$dst as az::CastFrom<$src>>::cast_from(src)
+                }
+            }
+        )+
+    };
+}
+
+impl_az_widening_casts!(f32 => f64, u8, u16, u32);
+impl_az_widening_casts!(f64 => f32, u8, u16, u32);
+impl_az_widening_casts!(u8 => f32, f64, u16, u32);
+impl_az_widening_casts!(u16 => f32, f64, u8, u32);
+impl_az_widening_casts!(u32 => f32, f64, u8, u16);
+
+#[cfg(feature = "fixed")]
+mod fixed_widening_casts {
+    use fixed::{
+        types::extra::{U0, U16, U8},
+        FixedI32, FixedU16,
+    };
+
+    type FixedI32U16 = FixedI32<U16>;
+    type FixedI32U0 = FixedI32<U0>;
+    type FixedU16U8 = FixedU16<U8>;
+
+    impl_az_widening_casts!(f32 => FixedI32U16, FixedI32U0, FixedU16U8);
+    impl_az_widening_casts!(f64 => FixedI32U16, FixedI32U0, FixedU16U8);
+    impl_az_widening_casts!(u8 => FixedI32U16, FixedI32U0, FixedU16U8);
+    impl_az_widening_casts!(u16 => FixedI32U16, FixedI32U0, FixedU16U8);
+    impl_az_widening_casts!(u32 => FixedI32U16, FixedI32U0, FixedU16U8);
+
+    impl_az_widening_casts!(FixedI32U16 => f32, f64, u8, u16, u32, FixedI32U0, FixedU16U8);
+    impl_az_widening_casts!(FixedI32U0 => f32, f64, u8, u16, u32, FixedI32U16, FixedU16U8);
+    impl_az_widening_casts!(FixedU16U8 => f32, f64, u8, u16, u32, FixedI32U16, FixedI32U0);
+
+    #[cfg(feature = "f16")]
+    mod f16 {
+        use super::{FixedI32U0, FixedI32U16, FixedU16U8};
+        use half::f16;
+
+        impl_az_widening_casts!(f16 => FixedI32U16, FixedI32U0, FixedU16U8);
+        impl_az_widening_casts!(FixedI32U16 => f16);
+        impl_az_widening_casts!(FixedI32U0 => f16);
+        impl_az_widening_casts!(FixedU16U8 => f16);
+    }
+}
+
+#[cfg(feature = "f16")]
+mod f16_widening_casts {
+    use half::f16;
+    use num_traits::AsPrimitive;
+
+    use super::WideningCastFrom;
+
+    macro_rules! impl_f16_widening_casts {
+        ($src:ty => $($dst:ty),+ $(,)?) => {
+            $(
+                impl WideningCastFrom<$src> for $dst {
+                    #[inline(always)]
+                    fn widening_cast_from(src: $src) -> Self {
+                        <$src as AsPrimitive<$dst>>::as_(src)
+                    }
+                }
+            )+
+        };
+    }
+
+    impl_f16_widening_casts!(f16 => f32, f64, u8, u16, u32);
+    impl_f16_widening_casts!(f32 => f16);
+    impl_f16_widening_casts!(f64 => f16);
+    impl_f16_widening_casts!(u8 => f16);
+    impl_f16_widening_casts!(u16 => f16);
+    impl_f16_widening_casts!(u32 => f16);
+}
+
 /// Core distance metric behavior independent of architecture-specific SIMD.
 ///
 /// `A` is the coordinate type stored in the tree/query.

--- a/src/dist/manhattan/mod.rs
+++ b/src/dist/manhattan/mod.rs
@@ -4,6 +4,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
+    WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -21,13 +22,13 @@ pub struct Manhattan<R>(core::marker::PhantomData<R>);
 impl<A, R> DistanceMetricScalar<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Add<Output = R>,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        <R as From<A>>::from(a)
+        R::widening_cast_from(a)
     }
 
     #[inline(always)]
@@ -49,7 +50,7 @@ where
 impl<A, R> DistanceMetricAvx512<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::ManhattanAvx512F64LeafOps;
@@ -61,7 +62,7 @@ where
 impl<A, R> DistanceMetricAvx2<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::ManhattanAvx2F64LeafOps;
@@ -73,7 +74,7 @@ where
 impl<A, R> DistanceMetricNeon<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::ManhattanNeonF64LeafOps;

--- a/src/dist/manhattan/mod.rs
+++ b/src/dist/manhattan/mod.rs
@@ -1,7 +1,5 @@
 use std::ops::Add;
 
-use fixed::traits::LossyFrom;
-
 use crate::Axis;
 
 use crate::dist::{
@@ -23,13 +21,13 @@ pub struct Manhattan<R>(core::marker::PhantomData<R>);
 impl<A, R> DistanceMetricScalar<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Add<Output = R>,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        R::lossy_from(a)
+        <R as From<A>>::from(a)
     }
 
     #[inline(always)]
@@ -51,7 +49,7 @@ where
 impl<A, R> DistanceMetricAvx512<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::ManhattanAvx512F64LeafOps;
@@ -63,7 +61,7 @@ where
 impl<A, R> DistanceMetricAvx2<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::ManhattanAvx2F64LeafOps;
@@ -75,7 +73,7 @@ where
 impl<A, R> DistanceMetricNeon<A> for Manhattan<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::ManhattanNeonF64LeafOps;

--- a/src/dist/minkowski/mod.rs
+++ b/src/dist/minkowski/mod.rs
@@ -4,6 +4,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
+    WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -41,13 +42,13 @@ impl<const P: u32, R> Minkowski<P, R> {
 impl<A, R, const P: u32> DistanceMetricScalar<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Float,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Float,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        <R as From<A>>::from(a)
+        R::widening_cast_from(a)
     }
 
     #[inline(always)]
@@ -61,7 +62,7 @@ where
 impl<A, R, const P: u32> DistanceMetricAvx512<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Float,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Float,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::MinkowskiAvx512F64LeafOps<P>;
@@ -73,7 +74,7 @@ where
 impl<A, R, const P: u32> DistanceMetricAvx2<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Float,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Float,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::MinkowskiAvx2F64LeafOps<P>;
@@ -85,7 +86,7 @@ where
 impl<A, R, const P: u32> DistanceMetricNeon<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Float,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Float,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::MinkowskiNeonF64LeafOps<P>;

--- a/src/dist/minkowski/mod.rs
+++ b/src/dist/minkowski/mod.rs
@@ -1,4 +1,3 @@
-use fixed::traits::LossyFrom;
 use num_traits::Float;
 
 use crate::Axis;
@@ -42,13 +41,13 @@ impl<const P: u32, R> Minkowski<P, R> {
 impl<A, R, const P: u32> DistanceMetricScalar<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Float,
+    R: Axis<Coord = R> + From<A> + Float,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        R::lossy_from(a)
+        <R as From<A>>::from(a)
     }
 
     #[inline(always)]
@@ -62,7 +61,7 @@ where
 impl<A, R, const P: u32> DistanceMetricAvx512<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Float,
+    R: Axis<Coord = R> + From<A> + Float,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::MinkowskiAvx512F64LeafOps<P>;
@@ -74,7 +73,7 @@ where
 impl<A, R, const P: u32> DistanceMetricAvx2<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Float,
+    R: Axis<Coord = R> + From<A> + Float,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::MinkowskiAvx2F64LeafOps<P>;
@@ -86,7 +85,7 @@ where
 impl<A, R, const P: u32> DistanceMetricNeon<A> for Minkowski<P, R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Float,
+    R: Axis<Coord = R> + From<A> + Float,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::MinkowskiNeonF64LeafOps<P>;

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -41,9 +41,9 @@ use std::ptr::NonNull;
 /// Shared distance metric functions
 pub(crate) mod common;
 
-#[doc(hidden)]
-pub use distance_metric_core::DistanceMetricScalar;
 pub(crate) use distance_metric_core::DistanceMetricScalar as DistanceMetricCore;
+#[doc(hidden)]
+pub use distance_metric_core::{DistanceMetricScalar, WideningCastFrom};
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),

--- a/src/dist/squared_euclidean/mod.rs
+++ b/src/dist/squared_euclidean/mod.rs
@@ -1,7 +1,5 @@
 use std::ops::{Add, Mul};
 
-use fixed::traits::LossyFrom;
-
 use crate::Axis;
 
 use crate::dist::{
@@ -23,13 +21,13 @@ pub struct SquaredEuclidean<R>(core::marker::PhantomData<R>);
 impl<A, R> DistanceMetricScalar<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        R::lossy_from(a)
+        <R as From<A>>::from(a)
     }
 
     #[inline(always)]
@@ -42,7 +40,7 @@ where
 impl<A, R> DistanceMetricAvx512<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::SquaredEuclideanAvx512F64LeafOps;
@@ -54,7 +52,7 @@ where
 impl<A, R> DistanceMetricAvx2<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::SquaredEuclideanAvx2F64LeafOps;
@@ -66,7 +64,7 @@ where
 impl<A, R> DistanceMetricNeon<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + LossyFrom<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::SquaredEuclideanNeonF64LeafOps;

--- a/src/dist/squared_euclidean/mod.rs
+++ b/src/dist/squared_euclidean/mod.rs
@@ -4,6 +4,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
+    WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -21,13 +22,13 @@ pub struct SquaredEuclidean<R>(core::marker::PhantomData<R>);
 impl<A, R> DistanceMetricScalar<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Mul<Output = R> + Add<Output = R>,
 {
     type Output = R;
 
     #[inline(always)]
     fn widen_coord(a: A) -> R {
-        <R as From<A>>::from(a)
+        R::widening_cast_from(a)
     }
 
     #[inline(always)]
@@ -40,7 +41,7 @@ where
 impl<A, R> DistanceMetricAvx512<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Mul<Output = R> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_feature = "avx512f"))]
     type Avx512F64Ops = avx512::SquaredEuclideanAvx512F64LeafOps;
@@ -52,7 +53,7 @@ where
 impl<A, R> DistanceMetricAvx2<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Mul<Output = R> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
     type Avx2F64Ops = avx2::SquaredEuclideanAvx2F64LeafOps;
@@ -64,7 +65,7 @@ where
 impl<A, R> DistanceMetricNeon<A> for SquaredEuclidean<R>
 where
     A: Copy,
-    R: Axis<Coord = R> + From<A> + Mul<Output = R> + Add<Output = R>,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Mul<Output = R> + Add<Output = R>,
 {
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF64Ops = neon::SquaredEuclideanNeonF64LeafOps;
@@ -110,6 +111,21 @@ mod tests {
 
         assert_eq!(<Metric as DistanceMetricScalar<u16>>::dist1(5, 2), 9);
         assert_eq!(<Metric as DistanceMetricScalar<u16>>::dist1(2, 5), 9);
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn f16_coordinates_and_output_remain_supported() {
+        use half::f16;
+
+        type Metric = SquaredEuclidean<f16>;
+        let a = [f16::from_f32(1.0), f16::from_f32(2.0)];
+        let b = [f16::from_f32(1.5), f16::from_f32(2.5)];
+
+        assert_eq!(
+            <Metric as DistanceMetricScalar<f16>>::dist_raw(&a, &b),
+            f16::from_f32(0.5)
+        );
     }
 
     #[cfg(feature = "fixed")]

--- a/src/leaf_view/mod.rs
+++ b/src/leaf_view/mod.rs
@@ -8,6 +8,7 @@ use crate::results::result_collection::{
 };
 use crate::{Axis, BestQueryResultItem, Content};
 
+#[cfg(feature = "fixed")]
 use fixed::{
     types::extra::{U0, U16, U8},
     FixedI32, FixedU16,
@@ -103,8 +104,11 @@ macro_rules! impl_tls_leaf_scratch {
 
 impl_tls_leaf_scratch!(LEAF_SCRATCH_F32, f32);
 impl_tls_leaf_scratch!(LEAF_SCRATCH_F64, f64);
+#[cfg(feature = "fixed")]
 impl_tls_leaf_scratch!(LEAF_SCRATCH_FIXED_I32_U16, FixedI32<U16>);
+#[cfg(feature = "fixed")]
 impl_tls_leaf_scratch!(LEAF_SCRATCH_FIXED_I32_U0, FixedI32<U0>);
+#[cfg(feature = "fixed")]
 impl_tls_leaf_scratch!(LEAF_SCRATCH_FIXED_U16_U8, FixedU16<U8>);
 
 #[cfg(feature = "f16")]

--- a/src/traits/axis.rs
+++ b/src/traits/axis.rs
@@ -3,7 +3,9 @@ use std::fmt::{Debug, Display};
 use std::mem::MaybeUninit;
 use std::ops::{AddAssign, Sub};
 
+#[cfg(feature = "fixed")]
 use fixed::types::extra::{U0, U16, U8};
+#[cfg(feature = "fixed")]
 use fixed::{FixedI32, FixedU16};
 
 use num_traits::Float;

--- a/tests/fixed_float_distance_queries.rs
+++ b/tests/fixed_float_distance_queries.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "fixed")]
+
+use fixed::{types::extra::U16, FixedI32};
+use kiddo::{Chebyshev, ImmutableKdTree, Manhattan, Minkowski, SquaredEuclidean};
+
+type Fixed = FixedI32<U16>;
+
+fn fixed(value: f64) -> Fixed {
+    Fixed::from_num(value)
+}
+
+fn tree_and_query() -> (ImmutableKdTree<Fixed, 2>, [Fixed; 2]) {
+    let points = [
+        [fixed(-4.0), fixed(3.0)],
+        [fixed(1.5), fixed(2.25)],
+        [fixed(8.0), fixed(-2.0)],
+    ];
+
+    (
+        ImmutableKdTree::new_from_slice(&points).unwrap(),
+        [fixed(1.75), fixed(2.0)],
+    )
+}
+
+#[test]
+fn fixed_tree_supports_f32_distances() {
+    let (tree, query) = tree_and_query();
+    let squared_euclidean = tree
+        .query(&query)
+        .nearest_one::<SquaredEuclidean<f32>>()
+        .execute();
+    let manhattan = tree.query(&query).nearest_one::<Manhattan<f32>>().execute();
+    let chebyshev = tree.query(&query).nearest_one::<Chebyshev<f32>>().execute();
+    let minkowski = tree
+        .query(&query)
+        .nearest_one::<Minkowski<3, f32>>()
+        .execute();
+
+    assert_eq!(squared_euclidean.item, 1);
+    assert_eq!(squared_euclidean.distance, 0.125);
+    assert_eq!(manhattan.item, 1);
+    assert_eq!(chebyshev.item, 1);
+    assert_eq!(minkowski.item, 1);
+}
+
+#[test]
+fn fixed_tree_supports_f64_distances() {
+    let (tree, query) = tree_and_query();
+    let squared_euclidean = tree
+        .query(&query)
+        .nearest_one::<SquaredEuclidean<f64>>()
+        .execute();
+    let manhattan = tree.query(&query).nearest_one::<Manhattan<f64>>().execute();
+    let chebyshev = tree.query(&query).nearest_one::<Chebyshev<f64>>().execute();
+    let minkowski = tree
+        .query(&query)
+        .nearest_one::<Minkowski<3, f64>>()
+        .execute();
+
+    assert_eq!(squared_euclidean.item, 1);
+    assert_eq!(squared_euclidean.distance, 0.125);
+    assert_eq!(manhattan.item, 1);
+    assert_eq!(chebyshev.item, 1);
+    assert_eq!(minkowski.item, 1);
+}


### PR DESCRIPTION
Fixes #524.

## Summary

- move `test-log` to dev-dependencies so downstream users do not compile its logging stack
- make the `fixed` feature genuinely optional, including when `serde` is enabled
- use a feature-neutral widening adapter backed by `az::CastFrom` for primitive and fixed-point conversions
- add CI coverage for minimal feature builds and normal dependency leakage
- retain fixed-coordinate tree queries with `f32` and `f64` distance outputs, with direct regression coverage across all built-in metrics

## Root cause

`test-log` was declared as a normal dependency despite only being used by tests. Fixed-point imports and `LossyFrom` bounds were also compiled unconditionally, while the `serde` feature used a strong optional-dependency feature reference that enabled `fixed`.

The replacement widening abstraction delegates to `az::CastFrom` for primitive and fixed-point types. A small explicit adapter preserves `half::f16`, which `az` does not support directly. This keeps `fixed` optional without dropping fixed-to-`f32`/`f64` queries.

## Validation

- `cargo fmt --all --check`
- `taplo format --check Cargo.toml`
- `cargo sort -cwg`
- `cargo clippy --lib --no-default-features -- -D warnings`
- `cargo clippy --lib --no-default-features --features=fixed,serde -- -D warnings`
- `cargo clippy --lib --no-default-features --features=fixed,f16 -- -D warnings`
- `cargo check --lib --no-default-features`
- `cargo check --lib --no-default-features --features=fixed`
- `cargo check --lib --no-default-features --features=f16`
- `cargo check --lib --no-default-features --features=serde`
- `cargo check --lib`
- `cargo test --lib` (441 passed)
- `cargo test --test fixed_float_distance_queries --no-default-features --features=fixed` (2 passed; all four built-in metrics with both `f32` and `f64` outputs)
- `cargo test --lib --no-default-features --features=f16 f16_coordinates_and_output_remain_supported`

The crate version and changelog are intentionally unchanged so release-plz can manage them.
