### PR TITLE
chore: release v6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Kiddo Changelog
 
+## [6.0.2] - 2026-08-13
+
+### 🐛 Bug Fixes
+
+- Correct optional dependency feature gates ([@sdd](https://github.com/sdd))
+
+- Preserve fixed-to-float distance queries ([@sdd](https://github.com/sdd))
+
 ## [6.0.1] - 2026-08-10
 
 ### 🐛 Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "6.0.1"
+version = "6.0.2"
 edition = "2021"
 rust-version = "1.89.0"
 authors = ["Scott Donnelly <scott@donnel.ly>"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add `kiddo` to `Cargo.toml`
 
 ```toml
 [dependencies]
-kiddo = "6.0.1"
+kiddo = "6.0.2"
 ```
 
 Add points to a k-d tree and query the nearest points with a distance metric:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/6.0.1")]
+#![doc(html_root_url = "https://docs.rs/kiddo/6.0.2")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 #![allow(clippy::pointers_in_nomem_asm_block)]
 #![allow(clippy::too_many_arguments)]
@@ -106,7 +106,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "6.0.1"
+//! kiddo = "6.0.2"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION



## 🤖 New release

* `kiddo`: 6.0.1 -> 6.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.0.2] - 2026-08-13

### 🐛 Bug Fixes

- Correct optional dependency feature gates ([@sdd](https://github.com/sdd))

- Preserve fixed-to-float distance queries ([@sdd](https://github.com/sdd))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).