### PR TITLE
fix: restore stable and MSRV CI compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ autoexamples = false
 resolver = "2"
 
 [package.metadata.cargo-machete]
-ignored = ["log"]
+ignored = ["log", "ordered-float"]
 
 [package.metadata.docs.rs]
 features = [
@@ -172,6 +172,9 @@ las = { version = "0.11", features = ["laz-parallel"] }
 memmap = "0.7"
 nabo = { version = "0.6.0", default-features = false }
 neighbourhood = "0.2.0"
+# kd-tree accepts ordered-float 5.x, but 5.5.0 requires Rust 1.90.
+# Keep its transitive dependency compatible with this crate's Rust 1.89 MSRV.
+ordered-float = "5,<5.5.0"
 postcard = { version = "1", features = ["alloc"] }
 proc-macro2 = { version = "1", features = ["default", "proc-macro"] }
 radians = "0.3"

--- a/src/kd_tree/orchestrator/mod.rs
+++ b/src/kd_tree/orchestrator/mod.rs
@@ -1622,32 +1622,28 @@ where
 
                         let old_lower = unsafe { *lower.get_unchecked(dim_val) };
                         let old_upper = unsafe { *upper.get_unchecked(dim_val) };
-                        let near_lower;
-                        let near_upper;
-                        let far_lower;
-                        let far_upper;
-
-                        if is_right_child {
-                            near_lower = O::max(old_lower, pivot_wide);
-                            near_upper = old_upper;
-                            far_lower = old_lower;
-                            far_upper = if O::cmp(old_upper, pivot_wide) == std::cmp::Ordering::Less
-                            {
+                        let clipped_upper =
+                            if O::cmp(old_upper, pivot_wide) == std::cmp::Ordering::Less {
                                 old_upper
                             } else {
                                 pivot_wide
                             };
+
+                        let (near_lower, near_upper, far_lower, far_upper) = if is_right_child {
+                            (
+                                O::max(old_lower, pivot_wide),
+                                old_upper,
+                                old_lower,
+                                clipped_upper,
+                            )
                         } else {
-                            near_lower = old_lower;
-                            near_upper =
-                                if O::cmp(old_upper, pivot_wide) == std::cmp::Ordering::Less {
-                                    old_upper
-                                } else {
-                                    pivot_wide
-                                };
-                            far_lower = O::max(old_lower, pivot_wide);
-                            far_upper = old_upper;
-                        }
+                            (
+                                old_lower,
+                                clipped_upper,
+                                O::max(old_lower, pivot_wide),
+                                old_upper,
+                            )
+                        };
 
                         let near_off =
                             crate::stem_strategy::donnelly::simd_full::interval_distance_1d(

--- a/src/leaf_view_chunked/mod.rs
+++ b/src/leaf_view_chunked/mod.rs
@@ -45,28 +45,18 @@ where
 
     let widened_points = widened_points.map(|axis| axis.unwrap());
     let items = leaf.items();
-    let mut points_iterators = widened_points.map(|axis| axis.chunks_exact(CHUNK_SIZE));
-    let mut items_iterator = items.chunks_exact(CHUNK_SIZE);
+    let points_chunks = widened_points.map(|axis| axis.as_chunks::<CHUNK_SIZE>());
+    let (items_chunks, remainder_items) = items.as_chunks::<CHUNK_SIZE>();
 
-    for items_chunk_slice in items_iterator.by_ref() {
-        let points_chunk: [&[D::Output; CHUNK_SIZE]; K] = array_init(|dim| {
-            points_iterators[dim]
-                .next()
-                .expect("points/items chunk mismatch")
-                .try_into()
-                .expect("invalid points chunk length")
-        });
-
-        let items_chunk: &[T; CHUNK_SIZE] = items_chunk_slice
-            .try_into()
-            .expect("invalid items chunk length");
+    for (chunk_idx, items_chunk) in items_chunks.iter().enumerate() {
+        let points_chunk: [&[D::Output; CHUNK_SIZE]; K] =
+            array_init(|dim| &points_chunks[dim].0[chunk_idx]);
 
         let dists = dists_for_chunk::<AX, D, K, CHUNK_SIZE>(points_chunk, query_wide);
         update_nearest_dist_chunk(dists, items_chunk, best_dist, best_item);
     }
 
-    let remainder_points: [&[D::Output]; K] = array_init(|dim| points_iterators[dim].remainder());
-    let remainder_items = items_iterator.remainder();
+    let remainder_points: [&[D::Output]; K] = array_init(|dim| points_chunks[dim].1);
 
     // TODO: For FlatVec specifically, we can experiment with overreading the tail into the next
     // contiguous leaf (or padded end-of-vec region) to keep the distance kernel branchless, while


### PR DESCRIPTION
## Summary

- refactor the affected traversal bounds initialization for Rust 1.98 Clippy
- use `as_chunks` for the constant-sized leaf chunks now flagged by Rust 1.98 Clippy
- constrain the transitive `ordered-float` dev dependency below 5.5 so fresh Rust 1.89 resolution selects 5.4.0

## Context

PR #533 exposed two existing CI compatibility failures after stable moved to Rust 1.98 and `ordered-float` 5.5 raised its MSRV to Rust 1.90. This applies the fixes independently on `master` so #533 can rebase after this is merged.

## Verification

- stable Rust 1.98 Clippy with `serde,rkyv_08,test_utils` and warnings denied
- Rust 1.89 MSRV Clippy with the same features and warnings denied
- full workspace tests and doctests on Rust 1.98 and Rust 1.89
- repository pre-commit and commit-message hooks
