### PR TITLE
chore: release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Kiddo Changelog
 
+## [6.2.0] - 2026-09-03
+
+### ✨ Features
+
+- Add a webassembly simd128 leaf-kernel backend ([@franciscouzo](https://github.com/franciscouzo))
+
+
+### 🐛 Bug Fixes
+
+- Support builds on other host architectures ([@sdd](https://github.com/sdd))
+
+- Repair pre-existing adversarial fuzz failures and fuzz-case-repro build ([@sdd](https://github.com/sdd), Note:examples/embedded-rkyv_08-deserialize requires a generated
+examples/data/geonames-embedded.rkyv data artifact and is unrelated
+to these fixes., Verified:cargo test --all-features --lib --tests (487 unit + 19
+integration tests, 0 failures), fuzz-case-repro builds clean.)
+
+
+### 🧪 Testing
+
+- Implement DistanceMetricWasmSimd for the custom-metric fixtures ([@franciscouzo](https://github.com/franciscouzo))
+
+
+### 🤖 CI
+
+- Exercise the wasm simd128 leaf kernels ([@franciscouzo](https://github.com/franciscouzo))
+
+
+### 🧹 Chore
+
+- Document CodeQL rust/access-invalid-pointer false positives in mirror_partition_in_blocks ([@sdd](https://github.com/sdd))
+
+- Create security.md ([@sdd](https://github.com/sdd))
+
+- Bump LoliGothick/clippy-check ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
+- Bump taiki-e/install-action from 2.85.5 to 2.87.1 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
 ## [6.1.0] - 2026-08-23
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,22 @@
 
 - Add a webassembly simd128 leaf-kernel backend ([@franciscouzo](https://github.com/franciscouzo))
 
-
 ### 🐛 Bug Fixes
 
 - Support builds on other host architectures ([@sdd](https://github.com/sdd))
 
 - Repair pre-existing adversarial fuzz failures and fuzz-case-repro build ([@sdd](https://github.com/sdd), Note:examples/embedded-rkyv_08-deserialize requires a generated
-examples/data/geonames-embedded.rkyv data artifact and is unrelated
-to these fixes., Verified:cargo test --all-features --lib --tests (487 unit + 19
-integration tests, 0 failures), fuzz-case-repro builds clean.)
-
+  examples/data/geonames-embedded.rkyv data artifact and is unrelated
+  to these fixes., Verified:cargo test --all-features --lib --tests (487 unit + 19
+  integration tests, 0 failures), fuzz-case-repro builds clean.)
 
 ### 🧪 Testing
 
 - Implement DistanceMetricWasmSimd for the custom-metric fixtures ([@franciscouzo](https://github.com/franciscouzo))
 
-
 ### 🤖 CI
 
 - Exercise the wasm simd128 leaf kernels ([@franciscouzo](https://github.com/franciscouzo))
-
 
 ### 🧹 Chore
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.89.0"
 authors = ["Scott Donnelly <scott@donnel.ly>"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add `kiddo` to `Cargo.toml`
 
 ```toml
 [dependencies]
-kiddo = "6.1.0"
+kiddo = "6.2.0"
 ```
 
 Add points to a k-d tree and query the nearest points with a distance metric:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/6.1.0")]
+#![doc(html_root_url = "https://docs.rs/kiddo/6.2.0")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 #![allow(clippy::pointers_in_nomem_asm_block)]
 #![allow(clippy::too_many_arguments)]
@@ -106,7 +106,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "6.1.0"
+//! kiddo = "6.2.0"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION



## 🤖 New release

* `kiddo`: 6.1.0 -> 6.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.2.0] - 2026-09-03

### ✨ Features

- Add a webassembly simd128 leaf-kernel backend ([@franciscouzo](https://github.com/franciscouzo))


### 🐛 Bug Fixes

- Support builds on other host architectures ([@sdd](https://github.com/sdd))

- Repair pre-existing adversarial fuzz failures and fuzz-case-repro build ([@sdd](https://github.com/sdd), Note:examples/embedded-rkyv_08-deserialize requires a generated
examples/data/geonames-embedded.rkyv data artifact and is unrelated
to these fixes., Verified:cargo test --all-features --lib --tests (487 unit + 19
integration tests, 0 failures), fuzz-case-repro builds clean.)


### 🧪 Testing

- Implement DistanceMetricWasmSimd for the custom-metric fixtures ([@franciscouzo](https://github.com/franciscouzo))


### 🤖 CI

- Exercise the wasm simd128 leaf kernels ([@franciscouzo](https://github.com/franciscouzo))


### 🧹 Chore

- Document CodeQL rust/access-invalid-pointer false positives in mirror_partition_in_blocks ([@sdd](https://github.com/sdd))

- Create security.md ([@sdd](https://github.com/sdd))

- Bump LoliGothick/clippy-check ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)

- Bump taiki-e/install-action from 2.85.5 to 2.87.1 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).