### PR TITLE
fix: repair pre-existing adversarial fuzz failures and fuzz-case-repro build

### DIFF
--- a/examples/fuzz-case-repro.rs
+++ b/examples/fuzz-case-repro.rs
@@ -339,14 +339,13 @@ impl V6StrategySelectorF32 for V6DonnellyStrategyF32 {
 impl V6StrategySelectorF32 for V6DonnellySimdStrategyF32 {
     fn run_mutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
         let _ = params;
-        #[cfg(feature = "simd")]
-        {
-            run_v6_mutable_case_f32::<K, B, DonnellySimdFull<4>>(params)
-        }
-        #[cfg(not(feature = "simd"))]
-        {
-            Err("donnelly_simd requires --features simd".to_string())
-        }
+        // Block-at-once stem strategies require an immutable leaf strategy
+        // (see StemLeafCompatibility), so this selector has no mutable case;
+        // instantiating one would fail the compile-time compatibility assert.
+        Err(
+            "donnelly_simd is immutable-only: mutable trees cannot use block-at-once stem strategies"
+                .to_string(),
+        )
     }
 
     fn run_immutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
@@ -365,14 +364,13 @@ impl V6StrategySelectorF32 for V6DonnellySimdStrategyF32 {
 impl V6StrategySelectorF32 for V6DonnellySimdBlock4StrategyF32 {
     fn run_mutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
         let _ = params;
-        #[cfg(feature = "simd")]
-        {
-            run_v6_mutable_case_f32::<K, B, DonnellySimdFull<4>>(params)
-        }
-        #[cfg(not(feature = "simd"))]
-        {
-            Err("donnelly_simd_block4 requires --features simd".to_string())
-        }
+        // Block-at-once stem strategies require an immutable leaf strategy
+        // (see StemLeafCompatibility), so this selector has no mutable case;
+        // instantiating one would fail the compile-time compatibility assert.
+        Err(
+            "donnelly_simd_block4 is immutable-only: mutable trees cannot use block-at-once stem strategies"
+                .to_string(),
+        )
     }
 
     fn run_immutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
@@ -409,14 +407,13 @@ impl V6StrategySelectorF64 for V6DonnellyStrategyF64 {
 impl V6StrategySelectorF64 for V6DonnellySimdStrategyF64 {
     fn run_mutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
         let _ = params;
-        #[cfg(feature = "simd")]
-        {
-            run_v6_mutable_case_f64::<K, B, DonnellySimdFull<3>>(params)
-        }
-        #[cfg(not(feature = "simd"))]
-        {
-            Err("donnelly_simd requires --features simd".to_string())
-        }
+        // Block-at-once stem strategies require an immutable leaf strategy
+        // (see StemLeafCompatibility), so this selector has no mutable case;
+        // instantiating one would fail the compile-time compatibility assert.
+        Err(
+            "donnelly_simd is immutable-only: mutable trees cannot use block-at-once stem strategies"
+                .to_string(),
+        )
     }
 
     fn run_immutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
@@ -435,14 +432,13 @@ impl V6StrategySelectorF64 for V6DonnellySimdStrategyF64 {
 impl V6StrategySelectorF64 for V6DonnellySimdBlock3StrategyF64 {
     fn run_mutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {
         let _ = params;
-        #[cfg(feature = "simd")]
-        {
-            run_v6_mutable_case_f64::<K, B, DonnellySimdFull<3>>(params)
-        }
-        #[cfg(not(feature = "simd"))]
-        {
-            Err("donnelly_simd_block3 requires --features simd".to_string())
-        }
+        // Block-at-once stem strategies require an immutable leaf strategy
+        // (see StemLeafCompatibility), so this selector has no mutable case;
+        // instantiating one would fail the compile-time compatibility assert.
+        Err(
+            "donnelly_simd_block3 is immutable-only: mutable trees cannot use block-at-once stem strategies"
+                .to_string(),
+        )
     }
 
     fn run_immutable<const K: usize, const B: usize>(params: &ReproParams) -> Result<(), String> {

--- a/tests/kd_tree_fuzz_v6.rs
+++ b/tests/kd_tree_fuzz_v6.rs
@@ -292,10 +292,6 @@ fn distances_match_for_fuzz<A: Copy + PartialEq + 'static>(expected: A, got: A) 
     false
 }
 
-fn distance_lt_for_fuzz<A: Copy + PartialOrd + PartialEq + 'static>(lhs: A, rhs: A) -> bool {
-    lhs < rhs && !distances_match_for_fuzz(lhs, rhs)
-}
-
 fn compare_nearest_n_sorted<
     A: Axis<Coord = A> + PartialOrd + PartialEq + std::fmt::Debug + 'static,
 >(
@@ -313,54 +309,52 @@ fn compare_nearest_n_sorted<
         return Ok(());
     }
 
-    let tail_dist = expected.last().unwrap().0;
-    let got_tail = got.last().unwrap().0;
-    if !distances_match_for_fuzz(got_tail, tail_dist) {
-        return Err(format!(
-            "tail distance mismatch expected={tail_dist:?} got={got_tail:?}"
-        ));
-    }
-
-    let mut i = 0usize;
-    let mut j = 0usize;
-    while i < expected.len() && distance_lt_for_fuzz(expected[i].0, tail_dist) {
-        let dist = expected[i].0;
-        let mut exp_items = Vec::new();
-        while i < expected.len() && distances_match_for_fuzz(expected[i].0, dist) {
-            exp_items.push(expected[i].1);
-            i += 1;
-        }
-
-        if j < got.len() && distance_lt_for_fuzz(got[j].0, dist) {
+    // The tree kernels may legitimately compute distances a few ULP
+    // differently from the brute-force reference (wider intermediates, SIMD
+    // reduction order), so every pair of corresponding entries must agree to
+    // within the fuzz tolerance. Anything further apart is a real difference,
+    // not float noise.
+    for (idx, ((exp_dist, _), (got_dist, _))) in expected.iter().zip(got).enumerate() {
+        if !distances_match_for_fuzz(*exp_dist, *got_dist) {
             return Err(format!(
-                "unexpected distance in results {got_dist:?} < expected {dist:?}",
-                got_dist = got[j].0
-            ));
-        }
-        if j >= got.len() || !distances_match_for_fuzz(got[j].0, dist) {
-            return Err(format!("missing distance in results {dist:?}"));
-        }
-
-        let mut got_items = Vec::new();
-        while j < got.len() && distances_match_for_fuzz(got[j].0, dist) {
-            got_items.push(got[j].1);
-            j += 1;
-        }
-
-        exp_items.sort();
-        got_items.sort();
-        if exp_items != got_items {
-            return Err(format!(
-                "tie mismatch at dist {dist:?} expected_items={exp_items:?} got_items={got_items:?}"
+                "distance mismatch at index {idx} expected={exp_dist:?} got={got_dist:?}"
             ));
         }
     }
 
-    if j < got.len() && distance_lt_for_fuzz(got[j].0, tail_dist) {
-        return Err(format!(
-            "unexpected distance in results {got_dist:?} < tail {tail_dist:?}",
-            got_dist = got[j].0
-        ));
+    // Within a run of mutually tolerable distances the tree may return the
+    // tied items in any order, and at the max-qty boundary it may pick any
+    // subset of the tie, so tie runs are compared as item sets. A run only
+    // ends where BOTH sides agree the neighbouring distances genuinely differ:
+    // if either side considers them within tolerance, they are a tie. The
+    // final run (containing the tail) is exempt from the item-set check
+    // because which members of the tail tie make the cut is
+    // implementation-defined.
+    let mut start = 0usize;
+    while start < expected.len() {
+        let mut end = start + 1;
+        while end < expected.len()
+            && (distances_match_for_fuzz(expected[end - 1].0, expected[end].0)
+                || distances_match_for_fuzz(got[end - 1].0, got[end].0))
+        {
+            end += 1;
+        }
+
+        if end < expected.len() {
+            let mut exp_items: Vec<usize> =
+                expected[start..end].iter().map(|(_, item)| *item).collect();
+            let mut got_items: Vec<usize> = got[start..end].iter().map(|(_, item)| *item).collect();
+            exp_items.sort_unstable();
+            got_items.sort_unstable();
+            if exp_items != got_items {
+                return Err(format!(
+                    "tie mismatch at dist {:?} expected_items={exp_items:?} got_items={got_items:?}",
+                    expected[start].0
+                ));
+            }
+        }
+
+        start = end;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Fixes two pre-existing failures on `master`, both fallout from the 4-ULP float-tolerance design of the fuzz comparator and the immutable-only block-at-once strategy constraint (39e60aa1), not kernel bugs.

### 1. Adversarial fuzz tests fail (`fuzz_v6_adversarial_fast_non_simd`, `fuzz_v6_adversarial_fast_simd`)

`compare_nearest_n_sorted` chained tie groups from a single anchor distance, so kernel-vs-brute drift of 1–2 ULP near a group boundary split/joined groups asymmetrically on the two sides:

- **f64 (simd)**: expected item 9 sat 4.7 ULP above the group anchor (excluded from the expected tie group) while its 1-ULP-shifted got counterpart sat ~4 ULP above (included) → spurious `tie mismatch`.
- **f32 (non-simd)**: expected[0] was within tolerance of the tail (exempt from checks), but got[0], 1 ULP lower, fell outside the tail tolerance → spurious `unexpected distance < tail`.

The comparator now ignores sub-tolerance (≤4 ULP) differences robustly:

- corresponding entries are compared **pairwise** against the tolerance;
- tie runs are compared as **item sets**, splitting only where **both** sides agree neighbouring distances genuinely differ;
- the tail tie run remains exempt from item-set checks, preserving the existing semantics that boundary-tie subset selection is implementation-defined.

The kernel-vs-brute ULP drift itself is expected behaviour (wider intermediates / SIMD reduction order) and is now tolerated exactly as intended.

### 2. `examples/fuzz-case-repro` does not compile (18 × E0080 const-eval errors)

Its `run_mutable` impls for the `DonnellySimdFull` selectors still instantiated the mutable + block-at-once pairing forbidden by `StemLeafCompatibility::ASSERT_COMPATIBLE` since 39e60aa1, breaking the whole binary at monomorphization. Those impls now return an explicit immutable-only error; immutable repro paths are unchanged.

## Out of scope (noted, not fixed)

`examples/embedded-rkyv_08-deserialize` requires a generated `examples/data/geonames-embedded.rkyv` data artifact; it is a data-availability issue, not a code failure.

## Testing

- `cargo test --all-features --lib --tests`: 487 unit + 19 integration tests, 0 failures
- `cargo test --all-features --test kd_tree_fuzz_v6`: 3 passed (previously 1 passed / 2 failed), 0 failures
- `cargo build --example fuzz-case-repro --all-features`: builds clean (previously 18 errors)
- fmt / clippy / pre-commit hooks: clean