### PR TITLE
feat: item-sorted leaves with embedded min-item summaries for best_n_within

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -57,6 +57,9 @@ pub use distance_metric_core::{DistanceMetricScalar, WideningCastFrom};
 ))]
 use std::any::TypeId;
 
+// Only used inside the AVX512 hooks below, which are gated on the same target
+// feature; ungated here the import is unused on non-AVX512 targets.
+#[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
 use crate::kd_tree::ITEM_LEAF_MODE_UNSORTED;
 use crate::leaf_view::TlsLeafScratch;
 use crate::stem_strategy::donnelly::simd_full::{BacktrackBlock3, BacktrackBlock4};

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -57,6 +57,7 @@ pub use distance_metric_core::{DistanceMetricScalar, WideningCastFrom};
 ))]
 use std::any::TypeId;
 
+use crate::kd_tree::ITEM_LEAF_MODE_UNSORTED;
 use crate::leaf_view::TlsLeafScratch;
 use crate::stem_strategy::donnelly::simd_full::{BacktrackBlock3, BacktrackBlock4};
 use crate::stem_strategy::{SimdPrune, SimdSelectBestChildBlock3};
@@ -226,6 +227,28 @@ macro_rules! with_best_result_emitter {
             };
 
             $results.add(candidate);
+        };
+
+        $body
+    }};
+}
+
+#[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+macro_rules! with_item_sorted_best_result_emitter {
+    ($results:expr, $distance_ty:ty, $item_ty:ty, $threshold_item:ident, $emit:ident, $body:block) => {{
+        #[allow(unused_mut)]
+        let mut $threshold_item = $results.threshold_item();
+        let mut $emit = |candidate_dist: $distance_ty, item: $item_ty| {
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_candidate_emitted();
+
+            let candidate = BestQueryResultItem {
+                point: (),
+                distance: std::mem::transmute_copy::<$distance_ty, Self::Output>(&candidate_dist),
+                item,
+            };
+            $results.add(candidate);
+            $results.threshold_item()
         };
 
         $body
@@ -552,6 +575,7 @@ pub trait DistanceMetricAvx512<A: Copy>: DistanceMetricScalar<A> {
         T,
         R,
         const EXCLUSIVE: bool,
+        const ITEM_LEAF_MODE: u8,
         const K: usize,
         const B: usize,
     >(
@@ -576,16 +600,29 @@ pub trait DistanceMetricAvx512<A: Copy>: DistanceMetricScalar<A> {
                 &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f64, T, K, B>);
             let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
             let max_dist = *(&max_dist as *const Self::Output as *const f64);
-            with_best_result_emitter!(results, threshold_item, f64, T, emit, {
-                crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_unchecked::<
-                    Self::Avx512F64Ops,
-                    T,
-                    _,
-                    EXCLUSIVE,
-                    K,
-                    B,
-                >(leaf, query_wide, max_dist, &mut emit);
-            });
+            if ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED {
+                with_item_sorted_best_result_emitter!(results, f64, T, threshold_item, emit, {
+                    let _ = crate::leaf_view_chunked::best_n_within::avx512::best_n_within_item_sorted_avx512_unchecked::<
+                            Self::Avx512F64Ops,
+                            T,
+                            _,
+                            EXCLUSIVE,
+                            K,
+                            B,
+                        >(leaf, query_wide, max_dist, threshold_item, &mut emit);
+                });
+            } else {
+                with_best_result_emitter!(results, threshold_item, f64, T, emit, {
+                    crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_unchecked::<
+                        Self::Avx512F64Ops,
+                        T,
+                        _,
+                        EXCLUSIVE,
+                        K,
+                        B,
+                    >(leaf, query_wide, max_dist, &mut emit);
+                });
+            }
 
             return true;
         }
@@ -599,16 +636,29 @@ pub trait DistanceMetricAvx512<A: Copy>: DistanceMetricScalar<A> {
                 &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f32, T, K, B>);
             let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
             let max_dist = *(&max_dist as *const Self::Output as *const f32);
-            with_best_result_emitter!(results, threshold_item, f32, T, emit, {
-                crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_unchecked_f32::<
-                    Self::Avx512F32Ops,
-                    T,
-                    _,
-                    EXCLUSIVE,
-                    K,
-                    B,
-                >(leaf, query_wide, max_dist, &mut emit);
-            });
+            if ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED {
+                with_item_sorted_best_result_emitter!(results, f32, T, threshold_item, emit, {
+                    let _ = crate::leaf_view_chunked::best_n_within::avx512::best_n_within_item_sorted_avx512_unchecked_f32::<
+                            Self::Avx512F32Ops,
+                            T,
+                            _,
+                            EXCLUSIVE,
+                            K,
+                            B,
+                        >(leaf, query_wide, max_dist, threshold_item, &mut emit);
+                });
+            } else {
+                with_best_result_emitter!(results, threshold_item, f32, T, emit, {
+                    crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_unchecked_f32::<
+                        Self::Avx512F32Ops,
+                        T,
+                        _,
+                        EXCLUSIVE,
+                        K,
+                        B,
+                    >(leaf, query_wide, max_dist, &mut emit);
+                });
+            }
 
             return true;
         }
@@ -619,7 +669,13 @@ pub trait DistanceMetricAvx512<A: Copy>: DistanceMetricScalar<A> {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
     #[inline(always)]
     /// Try an AVX512-specialized `best_n_within` arena kernel.
-    unsafe fn try_best_n_within_arena_avx512<T, R, const EXCLUSIVE: bool, const K: usize>(
+    unsafe fn try_best_n_within_arena_avx512<
+        T,
+        R,
+        const EXCLUSIVE: bool,
+        const ITEM_LEAF_MODE: u8,
+        const K: usize,
+    >(
         arena: &LeafArena<'_, A, T, K>,
         query_wide: &[Self::Output; K],
         max_dist: Self::Output,
@@ -639,25 +695,57 @@ pub trait DistanceMetricAvx512<A: Copy>: DistanceMetricScalar<A> {
         {
             let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
             let max_dist = *(&max_dist as *const Self::Output as *const f64);
-            with_best_result_emitter!(results, threshold_item, f64, T, emit, {
-                let mut tile_base = arena.as_ptr();
-                let mut remaining = arena.len();
+            if ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED {
+                with_item_sorted_best_result_emitter!(results, f64, T, threshold_item, emit, {
+                    let mut tile_base = arena.as_ptr();
+                    let mut remaining = arena.len();
+                    while remaining != 0 {
+                        let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                        let (next_threshold_item, stopped) = crate::leaf_view_chunked::best_n_within::avx512::best_n_within_item_sorted_avx512_arena_unchecked::<
+                                Self::Avx512F64Ops,
+                                T,
+                                _,
+                                EXCLUSIVE,
+                                K,
+                            >(
+                                tile_base,
+                                tile_len,
+                                query_wide,
+                                max_dist,
+                                threshold_item,
+                                &mut emit,
+                            );
+                        threshold_item = next_threshold_item;
+                        if stopped {
+                            break;
+                        }
+                        let tile_bytes = K * tile_len * std::mem::size_of::<f64>()
+                            + tile_len * std::mem::size_of::<T>();
+                        tile_base = tile_base.add(tile_bytes);
+                        remaining -= tile_len;
+                    }
+                });
+            } else {
+                with_best_result_emitter!(results, threshold_item, f64, T, emit, {
+                    let mut tile_base = arena.as_ptr();
+                    let mut remaining = arena.len();
 
-                while remaining != 0 {
-                    let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
-                    crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_arena_unchecked::<
-                        Self::Avx512F64Ops,
-                        T,
-                        _,
-                        EXCLUSIVE,
-                        K,
-                    >(tile_base, tile_len, query_wide, max_dist, &mut emit);
-                    let tile_bytes = K * tile_len * std::mem::size_of::<f64>()
-                        + tile_len * std::mem::size_of::<T>();
-                    tile_base = tile_base.add(tile_bytes);
-                    remaining -= tile_len;
-                }
-            });
+                    while remaining != 0 {
+                        let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                        crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_arena_unchecked::<
+                            Self::Avx512F64Ops,
+                            T,
+                            _,
+                            EXCLUSIVE,
+                            K,
+                        >(tile_base, tile_len, query_wide, max_dist, &mut emit);
+                        let tile_bytes = K * tile_len * std::mem::size_of::<f64>()
+                            + tile_len * std::mem::size_of::<T>();
+                        tile_base = tile_base.add(tile_bytes);
+                        remaining -= tile_len;
+                    }
+                });
+            }
 
             return true;
         }
@@ -669,25 +757,57 @@ pub trait DistanceMetricAvx512<A: Copy>: DistanceMetricScalar<A> {
         {
             let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
             let max_dist = *(&max_dist as *const Self::Output as *const f32);
-            with_best_result_emitter!(results, threshold_item, f32, T, emit, {
-                let mut tile_base = arena.as_ptr();
-                let mut remaining = arena.len();
+            if ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED {
+                with_item_sorted_best_result_emitter!(results, f32, T, threshold_item, emit, {
+                    let mut tile_base = arena.as_ptr();
+                    let mut remaining = arena.len();
+                    while remaining != 0 {
+                        let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                        let (next_threshold_item, stopped) = crate::leaf_view_chunked::best_n_within::avx512::best_n_within_item_sorted_avx512_arena_unchecked_f32::<
+                                Self::Avx512F32Ops,
+                                T,
+                                _,
+                                EXCLUSIVE,
+                                K,
+                            >(
+                                tile_base,
+                                tile_len,
+                                query_wide,
+                                max_dist,
+                                threshold_item,
+                                &mut emit,
+                            );
+                        threshold_item = next_threshold_item;
+                        if stopped {
+                            break;
+                        }
+                        let tile_bytes = K * tile_len * std::mem::size_of::<f32>()
+                            + tile_len * std::mem::size_of::<T>();
+                        tile_base = tile_base.add(tile_bytes);
+                        remaining -= tile_len;
+                    }
+                });
+            } else {
+                with_best_result_emitter!(results, threshold_item, f32, T, emit, {
+                    let mut tile_base = arena.as_ptr();
+                    let mut remaining = arena.len();
 
-                while remaining != 0 {
-                    let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
-                    crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_arena_unchecked_f32::<
-                        Self::Avx512F32Ops,
-                        T,
-                        _,
-                        EXCLUSIVE,
-                        K,
-                    >(tile_base, tile_len, query_wide, max_dist, &mut emit);
-                    let tile_bytes = K * tile_len * std::mem::size_of::<f32>()
-                        + tile_len * std::mem::size_of::<T>();
-                    tile_base = tile_base.add(tile_bytes);
-                    remaining -= tile_len;
-                }
-            });
+                    while remaining != 0 {
+                        let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                        crate::leaf_view_chunked::best_n_within::avx512::best_n_within_avx512_arena_unchecked_f32::<
+                            Self::Avx512F32Ops,
+                            T,
+                            _,
+                            EXCLUSIVE,
+                            K,
+                        >(tile_base, tile_len, query_wide, max_dist, &mut emit);
+                        let tile_bytes = K * tile_len * std::mem::size_of::<f32>()
+                            + tile_len * std::mem::size_of::<T>();
+                        tile_base = tile_base.add(tile_bytes);
+                        remaining -= tile_len;
+                    }
+                });
+            }
 
             return true;
         }

--- a/src/kd_tree/builder.rs
+++ b/src/kd_tree/builder.rs
@@ -1,8 +1,13 @@
-use crate::kd_tree::ConstructionError;
-use crate::traits::leaf_strategy::ConstructibleLeafStrategy;
+use crate::kd_tree::{ConstructionError, ITEM_LEAF_MODE_SORTED, ITEM_LEAF_MODE_UNSORTED};
+use crate::stem_strategy::donnelly::DonnellyBlock3SummaryLayout;
+use crate::traits::leaf_strategy::{ConstructibleLeafStrategy, Immutable, LeafStrategy};
 use crate::{Axis, Content, KdTree, StemStrategy};
 
-use super::construction::{validate_auto_generated_items, DefaultConstruction, SerialConstruction};
+use super::construction::{
+    populate_f64_donnelly3_min_item_summaries, sort_leaf_scratch_by_item,
+    validate_auto_generated_items, DefaultConstruction, LeafSorter, SerialConstruction,
+    StemSummaryPopulator,
+};
 #[cfg(feature = "multi-threaded")]
 use super::construction::{ParallelConstruction, DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD};
 
@@ -37,19 +42,72 @@ use super::construction::{ParallelConstruction, DEFAULT_PARALLEL_CONSTRUCTION_TH
 /// # }
 /// ```
 #[must_use = "a construction builder does nothing until a build method is called"]
-pub struct KdTreeBuilder<A, T, SS, LS, const K: usize, const B: usize, P = DefaultConstruction> {
+pub struct KdTreeBuilder<
+    A,
+    T,
+    SS,
+    LS,
+    const K: usize,
+    const B: usize,
+    P = DefaultConstruction,
+    const ITEM_LEAF_MODE: u8 = ITEM_LEAF_MODE_UNSORTED,
+> {
     // Only the parallel build path reads the policy; the serial one is a ZST
     // marker, so without `multi-threaded` this field is never loaded.
     #[cfg_attr(not(feature = "multi-threaded"), allow(dead_code))]
     pub(in crate::kd_tree) policy: P,
+    pub(in crate::kd_tree) leaf_sorter: Option<LeafSorter<A, T, K>>,
+    pub(in crate::kd_tree) stem_summary_populator: Option<StemSummaryPopulator<A, LS>>,
     pub(in crate::kd_tree) _phantom: std::marker::PhantomData<(A, T, SS, LS)>,
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize, P> KdTreeBuilder<A, T, SS, LS, K, B, P> {
+impl<A, T, SS, LS, const K: usize, const B: usize, P, const ITEM_LEAF_MODE: u8>
+    KdTreeBuilder<A, T, SS, LS, K, B, P, ITEM_LEAF_MODE>
+{
     /// Forces serial construction.
-    pub fn with_serial_construction(self) -> KdTreeBuilder<A, T, SS, LS, K, B, SerialConstruction> {
+    pub fn with_serial_construction(
+        self,
+    ) -> KdTreeBuilder<A, T, SS, LS, K, B, SerialConstruction, ITEM_LEAF_MODE> {
         KdTreeBuilder {
             policy: SerialConstruction,
+            leaf_sorter: self.leaf_sorter,
+            stem_summary_populator: self.stem_summary_populator,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Sorts every leaf by ascending item value after spatial construction.
+    ///
+    /// This enables an early-exit `best_n_within` leaf kernel. The item type
+    /// must implement [`Ord`] so the stored ordering is total and the early
+    /// exit remains valid for every item in a leaf.
+    ///
+    /// This mode is available only for immutable leaf strategies.
+    ///
+    /// ```compile_fail
+    /// use kiddo::leaf_strategy::VecOfArrays;
+    /// use kiddo::{Eytzinger, KdTree};
+    ///
+    /// type MutableTree =
+    ///     KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, 2, 32>, 2, 32>;
+    ///
+    /// let _ = MutableTree::builder().with_item_sorted_leaves();
+    /// ```
+    pub fn with_item_sorted_leaves(
+        mut self,
+    ) -> KdTreeBuilder<A, T, SS, LS, K, B, P, ITEM_LEAF_MODE_SORTED>
+    where
+        A: Axis<Coord = A>,
+        T: Content + Ord,
+        SS: StemStrategy,
+        LS: LeafStrategy<A, T, SS, K, B, Mutability = Immutable>,
+    {
+        self.leaf_sorter = Some(sort_leaf_scratch_by_item::<A, T, K>);
+        self.stem_summary_populator = None;
+        KdTreeBuilder {
+            policy: self.policy,
+            leaf_sorter: self.leaf_sorter,
+            stem_summary_populator: self.stem_summary_populator,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -63,9 +121,11 @@ impl<A, T, SS, LS, const K: usize, const B: usize, P> KdTreeBuilder<A, T, SS, LS
     #[cfg(feature = "multi-threaded")]
     pub fn with_parallel_construction(
         self,
-    ) -> KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction> {
+    ) -> KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction, ITEM_LEAF_MODE> {
         KdTreeBuilder {
             policy: ParallelConstruction::with_threshold(1),
+            leaf_sorter: self.leaf_sorter,
+            stem_summary_populator: self.stem_summary_populator,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -81,12 +141,158 @@ impl<A, T, SS, LS, const K: usize, const B: usize, P> KdTreeBuilder<A, T, SS, LS
     pub fn with_parallel_construction_threshold(
         self,
         item_count: usize,
-    ) -> KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction> {
+    ) -> KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction, ITEM_LEAF_MODE> {
         KdTreeBuilder {
             policy: ParallelConstruction::with_threshold(item_count),
+            leaf_sorter: self.leaf_sorter,
+            stem_summary_populator: self.stem_summary_populator,
             _phantom: std::marker::PhantomData,
         }
     }
+}
+
+fn enable_embedded_min_item_summary<
+    SS,
+    LS,
+    const K: usize,
+    const B: usize,
+    P,
+    const ITEM_LEAF_MODE: u8,
+    const SHIFT: u8,
+>(
+    mut builder: KdTreeBuilder<f64, u32, SS, LS, K, B, P, ITEM_LEAF_MODE>,
+) -> KdTreeBuilder<f64, u32, SS, LS, K, B, P, SHIFT>
+where
+    SS: DonnellyBlock3SummaryLayout,
+    LS: LeafStrategy<f64, u32, SS, K, B, Mutability = Immutable>,
+{
+    const {
+        assert!(
+            SHIFT > ITEM_LEAF_MODE_UNSORTED && SHIFT < u32::BITS as u8,
+            "an embedded minimum-item summary shift must be in 1..=31"
+        );
+    }
+
+    builder.leaf_sorter = Some(sort_leaf_scratch_by_item::<f64, u32, K>);
+    builder.stem_summary_populator =
+        Some(populate_f64_donnelly3_min_item_summaries::<SS, LS, K, B, SHIFT>);
+    KdTreeBuilder {
+        policy: builder.policy,
+        leaf_sorter: builder.leaf_sorter,
+        stem_summary_populator: builder.stem_summary_populator,
+        _phantom: std::marker::PhantomData,
+    }
+}
+
+impl<SS, LS, const K: usize, const B: usize, P, const ITEM_LEAF_MODE: u8>
+    KdTreeBuilder<f64, u32, SS, LS, K, B, P, ITEM_LEAF_MODE>
+where
+    SS: DonnellyBlock3SummaryLayout,
+    LS: LeafStrategy<f64, u32, SS, K, B, Mutability = Immutable>,
+{
+    /// Sorts every leaf by item and embeds subtree-minimum summaries.
+    ///
+    /// `SHIFT` is stored in the tree's item-leaf mode and must be in `1..=31`;
+    /// `0` denotes unsorted leaves and `255` denotes sorted leaves
+    /// without embedded summaries. The value is a const generic because the
+    /// item-leaf mode is part of the resulting [`KdTree`] type.
+    ///
+    /// Each Donnelly block's 64-bit padding slot stores eight child codes in
+    /// child-index order, from the least-significant byte upward. Each non-empty
+    /// code is the child subtree's minimum item shifted right by `SHIFT`,
+    /// saturated at `253`. Code `254` marks an empty subtree. This gives a
+    /// bucket width of `2^SHIFT` while collapsing all minima at or above
+    /// `253 * 2^SHIFT` into one conservative high bucket.
+    ///
+    /// This mode is currently available only for `u32` items with immutable
+    /// leaves and the padding-compatible public `f64` Donnelly block-height-3
+    /// stem strategies.
+    ///
+    /// ```rust
+    /// use kiddo::leaf_strategy::FlatVec;
+    /// use kiddo::{Donnelly, ItemLeafMode, KdTree};
+    ///
+    /// type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 2, 8>, 2, 8>;
+    ///
+    /// let tree = Tree::builder()
+    ///     .with_embedded_min_item_shifted_summary::<8>()
+    ///     .build_from_slice(&[[0.0, 1.0], [2.0, 3.0]])
+    ///     .unwrap();
+    ///
+    /// assert_eq!(
+    ///     tree.item_leaf_mode(),
+    ///     ItemLeafMode::SortedWithEncodedMin {
+    ///         shift: 8,
+    ///     }
+    /// );
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use kiddo::leaf_strategy::VecOfArrays;
+    /// use kiddo::{Donnelly, KdTree};
+    ///
+    /// type MutableTree =
+    ///     KdTree<f64, u32, Donnelly<3>, VecOfArrays<f64, u32, 2, 8>, 2, 8>;
+    ///
+    /// let _ = MutableTree::builder()
+    ///     .with_embedded_min_item_shifted_summary::<8>();
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use kiddo::leaf_strategy::FlatVec;
+    /// use kiddo::{Donnelly, KdTree};
+    ///
+    /// type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 2, 8>, 2, 8>;
+    ///
+    /// let _ = Tree::builder()
+    ///     .with_embedded_min_item_shifted_summary::<0>();
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use kiddo::leaf_strategy::FlatVec;
+    /// use kiddo::{Donnelly, KdTree};
+    ///
+    /// type UnsupportedTree =
+    ///     KdTree<f64, u32, Donnelly<4>, FlatVec<f64, u32, 2, 8>, 2, 8>;
+    ///
+    /// let _ = UnsupportedTree::builder()
+    ///     .with_embedded_min_item_shifted_summary::<8>();
+    /// ```
+    pub fn with_embedded_min_item_shifted_summary<const SHIFT: u8>(
+        self,
+    ) -> KdTreeBuilder<f64, u32, SS, LS, K, B, P, SHIFT> {
+        enable_embedded_min_item_summary(self)
+    }
+}
+
+fn populate_stem_summaries_if_configured<
+    A,
+    T,
+    SS,
+    LS,
+    const K: usize,
+    const B: usize,
+    const ITEM_LEAF_MODE: u8,
+>(
+    mut tree: KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>,
+    populator: Option<StemSummaryPopulator<A, LS>>,
+) -> KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
+where
+    A: Axis<Coord = A>,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B>,
+{
+    if let Some(populator) = populator {
+        populator(
+            &mut tree.stems,
+            &tree.leaves,
+            &tree.stem_leaf_resolution,
+            tree.max_stem_level,
+        );
+        tree.maybe_enable_huge_pages();
+    }
+    tree
 }
 
 impl<A, T, SS, LS, const K: usize, const B: usize> Default
@@ -95,13 +301,15 @@ impl<A, T, SS, LS, const K: usize, const B: usize> Default
     fn default() -> Self {
         Self {
             policy: SerialConstruction,
+            leaf_sorter: None,
+            stem_summary_populator: None,
             _phantom: std::marker::PhantomData,
         }
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize>
-    KdTreeBuilder<A, T, SS, LS, K, B, SerialConstruction>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTreeBuilder<A, T, SS, LS, K, B, SerialConstruction, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,
@@ -112,12 +320,12 @@ where
     pub fn build_from_slice(
         self,
         source: &[[A; K]],
-    ) -> Result<KdTree<A, T, SS, LS, K, B>, ConstructionError>
+    ) -> Result<KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError>
     where
         T: TryFrom<usize>,
     {
         validate_auto_generated_items::<T>(source.len())?;
-        KdTree::new_from_source_with(
+        let tree = KdTree::new_from_source_with(
             source,
             |point: &[A; K], dim| point[dim],
             |src_idx: usize, _point: &[A; K]| {
@@ -128,7 +336,12 @@ where
                     }
                 })
             },
-        )
+            self.leaf_sorter,
+        )?;
+        Ok(populate_stem_summaries_if_configured(
+            tree,
+            self.stem_summary_populator,
+        ))
     }
 
     /// Builds a tree from a generic source and coordinate/item accessors.
@@ -137,19 +350,28 @@ where
         source: &[X],
         axis_at: FA,
         item_at: FI,
-    ) -> Result<KdTree<A, T, SS, LS, K, B>, ConstructionError>
+    ) -> Result<KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError>
     where
         FA: Fn(&X, usize) -> A,
         FI: Fn(usize, &X) -> T,
     {
-        KdTree::new_from_source_with(source, axis_at, |src_idx, src| Ok(item_at(src_idx, src)))
+        let tree = KdTree::new_from_source_with(
+            source,
+            axis_at,
+            |src_idx, src| Ok(item_at(src_idx, src)),
+            self.leaf_sorter,
+        )?;
+        Ok(populate_stem_summaries_if_configured(
+            tree,
+            self.stem_summary_populator,
+        ))
     }
 
     /// Builds a tree from explicit item/point pairs.
     pub fn build_from_entries(
         self,
         source: &[(T, [A; K])],
-    ) -> Result<KdTree<A, T, SS, LS, K, B>, ConstructionError> {
+    ) -> Result<KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError> {
         self.build_from_source(
             source,
             |entry: &(T, [A; K]), dim| entry.1[dim],
@@ -158,8 +380,8 @@ where
     }
 }
 
-impl<A, SS, LS, const K: usize, const B: usize>
-    KdTreeBuilder<A, (), SS, LS, K, B, SerialConstruction>
+impl<A, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTreeBuilder<A, (), SS, LS, K, B, SerialConstruction, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     SS: StemStrategy,
@@ -169,7 +391,7 @@ where
     pub fn build_from_slice_no_items(
         self,
         source: &[[A; K]],
-    ) -> Result<KdTree<A, (), SS, LS, K, B>, ConstructionError> {
+    ) -> Result<KdTree<A, (), SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError> {
         self.build_from_source(
             source,
             |point: &[A; K], dim| point[dim],
@@ -185,14 +407,16 @@ impl<A, T, SS, LS, const K: usize, const B: usize> Default
     fn default() -> Self {
         Self {
             policy: ParallelConstruction::with_threshold(DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD),
+            leaf_sorter: None,
+            stem_summary_populator: None,
             _phantom: std::marker::PhantomData,
         }
     }
 }
 
 #[cfg(feature = "multi-threaded")]
-impl<A, T, SS, LS, const K: usize, const B: usize>
-    KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTreeBuilder<A, T, SS, LS, K, B, ParallelConstruction, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + Send + Sync,
     T: Content,
@@ -203,12 +427,12 @@ where
     pub fn build_from_slice(
         self,
         source: &[[A; K]],
-    ) -> Result<KdTree<A, T, SS, LS, K, B>, ConstructionError>
+    ) -> Result<KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError>
     where
         T: TryFrom<usize>,
     {
         validate_auto_generated_items::<T>(source.len())?;
-        KdTree::new_from_source_with_parallel_policy(
+        let tree = KdTree::new_from_source_with_parallel_policy(
             source,
             |point: &[A; K], dim| point[dim],
             |src_idx: usize, _point: &[A; K]| {
@@ -220,7 +444,12 @@ where
                 })
             },
             self.policy,
-        )
+            self.leaf_sorter,
+        )?;
+        Ok(populate_stem_summaries_if_configured(
+            tree,
+            self.stem_summary_populator,
+        ))
     }
 
     /// Builds a tree from a generic source and coordinate/item accessors.
@@ -229,25 +458,30 @@ where
         source: &[X],
         axis_at: FA,
         item_at: FI,
-    ) -> Result<KdTree<A, T, SS, LS, K, B>, ConstructionError>
+    ) -> Result<KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError>
     where
         X: Sync,
         FA: Fn(&X, usize) -> A + Sync,
         FI: Fn(usize, &X) -> T,
     {
-        KdTree::new_from_source_with_parallel_policy(
+        let tree = KdTree::new_from_source_with_parallel_policy(
             source,
             axis_at,
             |src_idx, src| Ok(item_at(src_idx, src)),
             self.policy,
-        )
+            self.leaf_sorter,
+        )?;
+        Ok(populate_stem_summaries_if_configured(
+            tree,
+            self.stem_summary_populator,
+        ))
     }
 
     /// Builds a tree from explicit item/point pairs.
     pub fn build_from_entries(
         self,
         source: &[(T, [A; K])],
-    ) -> Result<KdTree<A, T, SS, LS, K, B>, ConstructionError>
+    ) -> Result<KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError>
     where
         T: Sync,
     {
@@ -260,8 +494,8 @@ where
 }
 
 #[cfg(feature = "multi-threaded")]
-impl<A, SS, LS, const K: usize, const B: usize>
-    KdTreeBuilder<A, (), SS, LS, K, B, ParallelConstruction>
+impl<A, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTreeBuilder<A, (), SS, LS, K, B, ParallelConstruction, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + Send + Sync,
     SS: StemStrategy,
@@ -271,7 +505,7 @@ where
     pub fn build_from_slice_no_items(
         self,
         source: &[[A; K]],
-    ) -> Result<KdTree<A, (), SS, LS, K, B>, ConstructionError> {
+    ) -> Result<KdTree<A, (), SS, LS, K, B, ITEM_LEAF_MODE>, ConstructionError> {
         self.build_from_source(
             source,
             |point: &[A; K], dim| point[dim],

--- a/src/kd_tree/construction/item_summary.rs
+++ b/src/kd_tree/construction/item_summary.rs
@@ -1,0 +1,213 @@
+use aligned_vec::{AVec, ConstAlign, CACHELINE_ALIGN};
+
+use crate::kd_tree::item_summary::EMPTY_SUBTREE_CODE;
+use crate::kd_tree::OwnedStemLeafResolution;
+use crate::stem_strategy::donnelly::DonnellyBlock3SummaryLayout;
+use crate::traits::leaf_strategy::LeafStrategy;
+use crate::{Donnelly, StemStrategy};
+
+const BLOCK_HEIGHT: usize = 3;
+const CHILD_COUNT: usize = 1 << BLOCK_HEIGHT;
+const BLOCK_MASK: usize = CHILD_COUNT - 1;
+const MAX_NONEMPTY_CODE: u32 = crate::kd_tree::item_summary::MAX_NONEMPTY_CODE as u32;
+
+/// Encodes a conservative linear-bucket lower bound for a subtree minimum.
+///
+/// The code is `item >> SHIFT`, saturated at `253`. Code `254` is reserved for
+/// an empty subtree.
+#[inline]
+pub(super) const fn encode_min_item<const SHIFT: u8>(item: u32) -> u8 {
+    let bucket = item >> SHIFT;
+    if bucket > MAX_NONEMPTY_CODE {
+        MAX_NONEMPTY_CODE as u8
+    } else {
+        bucket as u8
+    }
+}
+
+#[inline]
+#[cfg(test)]
+pub(super) fn decode_min_item_lower_bound<const SHIFT: u8>(code: u8) -> Option<u32> {
+    match code {
+        EMPTY_SUBTREE_CODE => None,
+        _ => Some(((code as u64) << SHIFT).min(u64::from(u32::MAX)) as u32),
+    }
+}
+
+#[inline]
+fn encode_optional_min<const SHIFT: u8>(item: Option<u32>) -> u8 {
+    item.map_or(EMPTY_SUBTREE_CODE, encode_min_item::<SHIFT>)
+}
+
+#[inline]
+fn optional_min(left: Option<u32>, right: Option<u32>) -> Option<u32> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+struct SummaryBuilder<'a, SS, LS, const K: usize, const B: usize, const SHIFT: u8> {
+    stems: &'a mut AVec<f64, ConstAlign<{ CACHELINE_ALIGN }>>,
+    leaves: &'a LS,
+    resolution: &'a OwnedStemLeafResolution,
+    max_terminal_level: i32,
+    _stem_strategy: std::marker::PhantomData<SS>,
+}
+
+impl<'a, SS, LS, const K: usize, const B: usize, const SHIFT: u8>
+    SummaryBuilder<'a, SS, LS, K, B, SHIFT>
+where
+    SS: DonnellyBlock3SummaryLayout,
+    LS: LeafStrategy<f64, u32, SS, K, B>,
+{
+    fn terminal_leaf_idx(&self, stem: &Donnelly<3>) -> Option<usize> {
+        match self.resolution {
+            OwnedStemLeafResolution::Arithmetic {
+                stems_depth,
+                leaf_count,
+            }
+            | OwnedStemLeafResolution::Pristine {
+                stems_depth,
+                leaf_count,
+            } if stem.level() >= *stems_depth as i32 => {
+                let leaf_idx = self
+                    .resolution
+                    .resolve_terminal_stem_idx(stem.stem_idx(), stem.leaf_idx());
+                (leaf_idx < *leaf_count).then_some(leaf_idx)
+            }
+            OwnedStemLeafResolution::Mapped { .. }
+                if self.resolution.is_terminal_stem_idx(stem.stem_idx()) =>
+            {
+                Some(
+                    self.resolution
+                        .resolve_terminal_stem_idx(stem.stem_idx(), stem.leaf_idx()),
+                )
+            }
+            _ => None,
+        }
+    }
+
+    fn leaf_min(&self, leaf_idx: usize) -> Option<u32> {
+        (self.leaves.leaf_len(leaf_idx) != 0).then(|| self.leaves.leaf_point_item(leaf_idx, 0).1)
+    }
+
+    fn summarize_block(&mut self, root: Donnelly<3>) -> Option<u32> {
+        let block_base = root.stem_idx() & !BLOCK_MASK;
+        debug_assert_eq!(root.stem_idx(), block_base);
+
+        let mut child_codes = [EMPTY_SUBTREE_CODE; CHILD_COUNT];
+        let minimum = self.summarize_within_block(root, 0, 0, &mut child_codes);
+        let packed = child_codes
+            .into_iter()
+            .enumerate()
+            .fold(0u64, |word, (child_idx, code)| {
+                word | (u64::from(code) << (child_idx * u8::BITS as usize))
+            });
+
+        let padding_idx = block_base + BLOCK_MASK;
+        if padding_idx >= self.stems.len() {
+            self.stems.resize(padding_idx + 1, f64::INFINITY);
+        }
+        self.stems[padding_idx] = f64::from_bits(packed);
+
+        minimum
+    }
+
+    fn summarize_within_block(
+        &mut self,
+        stem: Donnelly<3>,
+        depth_in_block: usize,
+        child_prefix: usize,
+        child_codes: &mut [u8; CHILD_COUNT],
+    ) -> Option<u32> {
+        if let Some(leaf_idx) = self.terminal_leaf_idx(&stem) {
+            let minimum = self.leaf_min(leaf_idx);
+            let suffix_bits = BLOCK_HEIGHT - depth_in_block;
+            let first_child = child_prefix << suffix_bits;
+            let end_child = (child_prefix + 1) << suffix_bits;
+            child_codes[first_child..end_child].fill(encode_optional_min::<SHIFT>(minimum));
+            return minimum;
+        }
+
+        if stem.level() > self.max_terminal_level {
+            let suffix_bits = BLOCK_HEIGHT - depth_in_block;
+            let first_child = child_prefix << suffix_bits;
+            let end_child = (child_prefix + 1) << suffix_bits;
+            child_codes[first_child..end_child].fill(EMPTY_SUBTREE_CODE);
+            return None;
+        }
+
+        if depth_in_block == BLOCK_HEIGHT {
+            let minimum = self.summarize_block(stem);
+            child_codes[child_prefix] = encode_optional_min::<SHIFT>(minimum);
+            return minimum;
+        }
+
+        let (left, right) = stem.split::<f64, K>();
+        let left_minimum =
+            self.summarize_within_block(left, depth_in_block + 1, child_prefix << 1, child_codes);
+        let right_minimum = self.summarize_within_block(
+            right,
+            depth_in_block + 1,
+            (child_prefix << 1) | 1,
+            child_codes,
+        );
+        optional_min(left_minimum, right_minimum)
+    }
+}
+
+pub(in crate::kd_tree) fn populate_f64_donnelly3_min_item_summaries<
+    SS,
+    LS,
+    const K: usize,
+    const B: usize,
+    const SHIFT: u8,
+>(
+    stems: &mut AVec<f64, ConstAlign<{ CACHELINE_ALIGN }>>,
+    leaves: &LS,
+    resolution: &OwnedStemLeafResolution,
+    max_stem_level: i32,
+) where
+    SS: DonnellyBlock3SummaryLayout,
+    LS: LeafStrategy<f64, u32, SS, K, B>,
+{
+    if stems.is_empty() {
+        return;
+    }
+
+    SummaryBuilder::<SS, LS, K, B, SHIFT> {
+        stems,
+        leaves,
+        resolution,
+        max_terminal_level: max_stem_level + 1,
+        _stem_strategy: std::marker::PhantomData,
+    }
+    .summarize_block(Donnelly::<3>::new_no_ptr());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_encoding_is_a_conservative_saturating_lower_bound() {
+        assert_eq!(encode_min_item::<8>(0), 0);
+        assert_eq!(encode_min_item::<8>(255), 0);
+        assert_eq!(encode_min_item::<8>(256), 1);
+        assert_eq!(encode_min_item::<8>(511), 1);
+        assert_eq!(encode_min_item::<8>(512), 2);
+        assert_eq!(encode_min_item::<8>(64_767), 252);
+        assert_eq!(encode_min_item::<8>(64_768), 253);
+        assert_eq!(encode_min_item::<8>(116_000), 253);
+        assert_eq!(encode_min_item::<8>(u32::MAX), 253);
+
+        for item in [0, 1, 255, 256, 511, 512, 64_767, 64_768, 116_000] {
+            let code = encode_min_item::<8>(item);
+            let lower_bound = decode_min_item_lower_bound::<8>(code).unwrap();
+            assert!(lower_bound <= item);
+        }
+        assert_eq!(decode_min_item_lower_bound::<8>(EMPTY_SUBTREE_CODE), None);
+    }
+}

--- a/src/kd_tree/construction/mod.rs
+++ b/src/kd_tree/construction/mod.rs
@@ -10,17 +10,21 @@ use crate::{Axis, Content, KdTree, StemStrategy};
 
 use super::builder::KdTreeBuilder;
 
+mod item_summary;
 #[cfg(feature = "multi-threaded")]
 mod parallel;
 mod serial;
 mod shared;
 
+pub(in crate::kd_tree) use item_summary::populate_f64_donnelly3_min_item_summaries;
 #[cfg(feature = "multi-threaded")]
 pub use parallel::ParallelConstruction;
 pub use serial::SerialConstruction;
-pub(in crate::kd_tree) use shared::validate_auto_generated_items;
 use shared::{
     construction_index_fits_u32, ConstructionIndex, ConstructionLeafScratch, SoftConstructionMode,
+};
+pub(in crate::kd_tree) use shared::{
+    sort_leaf_scratch_by_item, validate_auto_generated_items, LeafSorter, StemSummaryPopulator,
 };
 
 /// The construction policy [`KdTree::builder`] starts from.
@@ -111,6 +115,7 @@ where
             &entries,
             |entry, dim| entry.1[dim],
             |_, entry| Ok(entry.0),
+            None,
         )?;
         *self = rebuilt;
 
@@ -533,13 +538,23 @@ where
             .with_parallel_construction_threshold(DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD)
             .build_from_entries(source)
     }
+}
 
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
+where
+    A: Axis<Coord = A>,
+    T: Content,
+    SS: StemStrategy,
+    LS: ConstructibleLeafStrategy<A, T, SS, K, B>,
+{
     /// Inner constructor shared by all variants. The accessors are invoked
     /// wherever we would normally pull coordinates or items from the source.
     pub(in crate::kd_tree) fn new_from_source_with<X, FA, FI>(
         source: &[X],
         axis_at: FA,
         item_at: FI,
+        leaf_sorter: Option<LeafSorter<A, T, K>>,
     ) -> Result<Self, ConstructionError>
     where
         FA: Fn(&X, usize) -> A,
@@ -549,7 +564,7 @@ where
         let leaf_node_count = item_count.div_ceil(B);
 
         if leaf_node_count < 2 {
-            return Self::new_from_source_no_stems_with(source, &axis_at, item_at);
+            return Self::new_from_source_no_stems_with(source, &axis_at, item_at, leaf_sorter);
         }
 
         if construction_index_fits_u32(item_count) {
@@ -558,6 +573,7 @@ where
                 axis_at,
                 item_at,
                 &SerialConstruction,
+                leaf_sorter,
             )
         } else {
             Self::new_from_source_with_index::<SerialConstruction, usize, _, _, _>(
@@ -565,6 +581,7 @@ where
                 axis_at,
                 item_at,
                 &SerialConstruction,
+                leaf_sorter,
             )
         }
     }
@@ -575,6 +592,7 @@ where
         axis_at: FA,
         item_at: FI,
         policy: ParallelConstruction,
+        leaf_sorter: Option<LeafSorter<A, T, K>>,
     ) -> Result<Self, ConstructionError>
     where
         A: Send + Sync,
@@ -586,16 +604,24 @@ where
         let leaf_node_count = item_count.div_ceil(B);
 
         if leaf_node_count < 2 {
-            return Self::new_from_source_no_stems_with(source, &axis_at, item_at);
+            return Self::new_from_source_no_stems_with(source, &axis_at, item_at, leaf_sorter);
         }
 
         if construction_index_fits_u32(item_count) {
             Self::new_from_source_with_index::<ParallelConstruction, u32, _, _, _>(
-                source, axis_at, item_at, &policy,
+                source,
+                axis_at,
+                item_at,
+                &policy,
+                leaf_sorter,
             )
         } else {
             Self::new_from_source_with_index::<ParallelConstruction, usize, _, _, _>(
-                source, axis_at, item_at, &policy,
+                source,
+                axis_at,
+                item_at,
+                &policy,
+                leaf_sorter,
             )
         }
     }
@@ -605,6 +631,7 @@ where
         axis_at: FA,
         mut item_at: FI,
         mode: &M,
+        leaf_sorter: Option<LeafSorter<A, T, K>>,
     ) -> Result<Self, ConstructionError>
     where
         I: ConstructionIndex,
@@ -668,7 +695,7 @@ where
         let mut terminal_stem_indices = Vec::with_capacity(leaf_node_count);
         let mut actual_max_stem_level: i32 = -1;
         let mut max_leaf_len = 0usize;
-        let mut leaf_scratch = ConstructionLeafScratch::<A, T, K>::with_capacity(B);
+        let mut leaf_scratch = ConstructionLeafScratch::<A, T, K>::with_capacity(B, leaf_sorter);
         let mut sort_index = Vec::from_iter((0..item_count).map(I::from_usize));
 
         match LS::BUCKET_LIMIT_TYPE {
@@ -738,6 +765,7 @@ where
         source: &[X],
         axis_at: &FA,
         mut item_at: FI,
+        leaf_sorter: Option<LeafSorter<A, T, K>>,
     ) -> Result<Self, ConstructionError>
     where
         FA: Fn(&X, usize) -> A,
@@ -746,24 +774,58 @@ where
         let item_count = source.len();
 
         if item_count == 0 {
-            return Ok(Self::default());
+            let (stems, max_stem_level, stem_leaf_resolution) = if LS::Mutability::is_mutable() {
+                let root_idx = SS::new_no_ptr().stem_idx();
+                let mut stems = AVec::new(CACHELINE_ALIGN);
+                stems.resize(root_idx + 1, A::max_value());
+                let mut leaf_idx_map = vec![None; root_idx + 1];
+                leaf_idx_map[root_idx] = NonMaxUsize::new(0);
+                (
+                    stems,
+                    0,
+                    OwnedStemLeafResolution::Mapped {
+                        min_stem_leaf_idx: 0,
+                        leaf_idx_map,
+                    },
+                )
+            } else {
+                (
+                    AVec::new(CACHELINE_ALIGN),
+                    -1,
+                    OwnedStemLeafResolution::Arithmetic {
+                        stems_depth: 0,
+                        leaf_count: 0,
+                    },
+                )
+            };
+            return Ok(Self {
+                stems,
+                leaves: LS::new_with_empty_leaf(),
+                stem_leaf_resolution,
+                size: 0,
+                max_stem_level,
+                max_leaf_len: Self::initial_max_leaf_len(),
+                _phantom: Default::default(),
+            });
         }
 
-        let mut leaf_points: [Vec<A>; K] =
-            array_init::array_init(|_| Vec::with_capacity(item_count));
-        let mut leaf_items: Vec<T> = Vec::with_capacity(item_count);
+        let mut leaf_scratch =
+            ConstructionLeafScratch::<A, T, K>::with_capacity(item_count, leaf_sorter);
 
         for idx in 0..item_count {
             for dim in 0..K {
-                leaf_points[dim].push(axis_at(&source[idx], dim));
+                leaf_scratch.points[dim].push(axis_at(&source[idx], dim));
             }
-            leaf_items.push(item_at(idx, &source[idx])?);
+            leaf_scratch.items.push(item_at(idx, &source[idx])?);
         }
 
-        let leaf_points_refs: [&[A]; K] = array_init::array_init(|dim| leaf_points[dim].as_slice());
+        leaf_scratch.sort_if_configured();
+
+        let leaf_points_refs: [&[A]; K] =
+            array_init::array_init(|dim| leaf_scratch.points[dim].as_slice());
 
         let mut leaves = LS::new_with_capacity(item_count);
-        leaves.append_leaf(&leaf_points_refs, leaf_items.as_slice());
+        leaves.append_leaf(&leaf_points_refs, leaf_scratch.items.as_slice());
 
         let stem_leaf_resolution =
             LS::Mutability::initial_stem_leaf_resolution::<A, SS, K>(0, leaves.leaf_count());
@@ -839,7 +901,8 @@ where
 }
 
 // Shared utility methods for construction (available to both Immutable and Mutable)
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,
@@ -872,6 +935,8 @@ where
             }
             leaf_scratch.items.push(item_at(src_idx, &source[src_idx])?);
         }
+
+        leaf_scratch.sort_if_configured();
 
         let leaf_points_refs: [&[A]; K] =
             array_init::array_init(|d| leaf_scratch.points[d].as_slice());

--- a/src/kd_tree/construction/parallel.rs
+++ b/src/kd_tree/construction/parallel.rs
@@ -109,7 +109,8 @@ where
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,

--- a/src/kd_tree/construction/serial.rs
+++ b/src/kd_tree/construction/serial.rs
@@ -55,7 +55,8 @@ where
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,

--- a/src/kd_tree/construction/shared.rs
+++ b/src/kd_tree/construction/shared.rs
@@ -1,6 +1,6 @@
 use aligned_vec::{AVec, ConstAlign, CACHELINE_ALIGN};
 
-use crate::kd_tree::ConstructionError;
+use crate::kd_tree::{ConstructionError, OwnedStemLeafResolution};
 use crate::traits::leaf_strategy::ConstructibleLeafStrategy;
 use crate::{Axis, Content, StemStrategy};
 
@@ -38,16 +38,77 @@ pub(super) const fn construction_index_fits_u32(item_count: usize) -> bool {
     item_count <= u32::MAX as usize
 }
 
-pub(super) struct ConstructionLeafScratch<A, T, const K: usize> {
+pub(in crate::kd_tree) struct ConstructionLeafScratch<A, T, const K: usize> {
     pub(super) points: [Vec<A>; K],
     pub(super) items: Vec<T>,
+    sort_order: Vec<usize>,
+    original_at_position: Vec<usize>,
+    position_of_original: Vec<usize>,
+    sorter: Option<LeafSorter<A, T, K>>,
+}
+
+pub(in crate::kd_tree) type LeafSorter<A, T, const K: usize> =
+    fn(&mut ConstructionLeafScratch<A, T, K>);
+
+/// The summary `SHIFT`, `SS`, `K` and `B` generics are erased by this `fn`
+/// pointer: the erased `SHIFT` is only recoverable through the builder's
+/// `ITEM_LEAF_MODE` const generic. The invariant that a stored populator's
+/// shift equals the builder's `ITEM_LEAF_MODE` is therefore enforced solely by
+/// `enable_embedded_min_item_summary` — the only constructor that sets both —
+/// not by the type system. Do not set `stem_summary_populator` anywhere else.
+pub(in crate::kd_tree) type StemSummaryPopulator<A, LS> =
+    fn(&mut AVec<A, ConstAlign<{ CACHELINE_ALIGN }>>, &LS, &OwnedStemLeafResolution, i32);
+
+pub(in crate::kd_tree) fn sort_leaf_scratch_by_item<A, T: Ord, const K: usize>(
+    scratch: &mut ConstructionLeafScratch<A, T, K>,
+) {
+    scratch.sort_order.clear();
+    scratch.sort_order.extend(0..scratch.items.len());
+    scratch
+        .sort_order
+        .sort_unstable_by(|&left, &right| scratch.items[left].cmp(&scratch.items[right]));
+
+    scratch.original_at_position.clear();
+    scratch.original_at_position.extend(0..scratch.items.len());
+    scratch.position_of_original.clear();
+    scratch.position_of_original.extend(0..scratch.items.len());
+
+    for sorted_position in 0..scratch.items.len() {
+        let desired_original = scratch.sort_order[sorted_position];
+        let current_position = scratch.position_of_original[desired_original];
+        if current_position == sorted_position {
+            continue;
+        }
+
+        let displaced_original = scratch.original_at_position[sorted_position];
+        scratch.items.swap(sorted_position, current_position);
+        for axis in &mut scratch.points {
+            axis.swap(sorted_position, current_position);
+        }
+        scratch
+            .original_at_position
+            .swap(sorted_position, current_position);
+        scratch.position_of_original[desired_original] = sorted_position;
+        scratch.position_of_original[displaced_original] = current_position;
+    }
 }
 
 impl<A, T, const K: usize> ConstructionLeafScratch<A, T, K> {
-    pub(super) fn with_capacity(capacity: usize) -> Self {
+    pub(super) fn with_capacity(capacity: usize, sorter: Option<LeafSorter<A, T, K>>) -> Self {
+        let sort_capacity = if sorter.is_some() { capacity } else { 0 };
         Self {
             points: array_init::array_init(|_| Vec::with_capacity(capacity)),
             items: Vec::with_capacity(capacity),
+            sort_order: Vec::with_capacity(sort_capacity),
+            original_at_position: Vec::with_capacity(sort_capacity),
+            position_of_original: Vec::with_capacity(sort_capacity),
+            sorter,
+        }
+    }
+
+    pub(super) fn sort_if_configured(&mut self) {
+        if let Some(sorter) = self.sorter {
+            sorter(self);
         }
     }
 

--- a/src/kd_tree/construction/tests.rs
+++ b/src/kd_tree/construction/tests.rs
@@ -1,10 +1,337 @@
 use super::*;
+use std::num::NonZeroUsize;
+
 use crate::dist::SquaredEuclidean;
 use crate::leaf_strategy::FlatVec;
 use crate::leaf_strategy::VecOfArenas;
 use crate::leaf_strategy::VecOfArrays;
 use crate::Donnelly;
 use crate::Eytzinger;
+use crate::ItemLeafMode;
+
+use super::item_summary::encode_min_item;
+use crate::kd_tree::item_summary::EMPTY_SUBTREE_CODE;
+
+fn assert_item_sorted_leaves<A, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>(
+    tree: &KdTree<A, u32, SS, LS, K, B, ITEM_LEAF_MODE>,
+) where
+    A: Axis<Coord = A>,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, u32, SS, K, B>,
+{
+    assert!(tree.item_sorted_leaves());
+    for leaf_idx in 0..tree.leaf_count() {
+        let items = (0..tree.leaves.leaf_len(leaf_idx))
+            .map(|position| tree.leaves.leaf_point_item(leaf_idx, position).1)
+            .collect::<Vec<_>>();
+        assert!(
+            items.windows(2).all(|pair| pair[0] <= pair[1]),
+            "leaf {leaf_idx} was not item-sorted: {items:?}"
+        );
+    }
+}
+
+#[test]
+fn embedded_min_item_summary_builder_supports_f64_donnelly_3() {
+    type F64Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 8>, 3, 8>;
+
+    let f64_entries = (0..97u32)
+        .map(|item| {
+            let scrambled_item = (item * 37) % 97;
+            (
+                scrambled_item,
+                [
+                    ((item * 19) % 101) as f64,
+                    ((item * 43) % 103) as f64,
+                    ((item * 61) % 107) as f64,
+                ],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let f64_tree = F64Tree::builder()
+        .with_embedded_min_item_shifted_summary::<1>()
+        .with_serial_construction()
+        .build_from_entries(&f64_entries)
+        .unwrap();
+    let sorted_without_summary = F64Tree::builder()
+        .with_embedded_min_item_shifted_summary::<1>()
+        .with_item_sorted_leaves()
+        .with_serial_construction()
+        .build_from_entries(&f64_entries)
+        .unwrap();
+
+    assert_item_sorted_leaves(&f64_tree);
+    assert_eq!(
+        f64_tree.item_leaf_mode(),
+        ItemLeafMode::SortedWithEncodedMin { shift: 1 }
+    );
+    assert_eq!(
+        sorted_without_summary.item_leaf_mode(),
+        ItemLeafMode::SortedWithoutEncodedMin
+    );
+    assert!(sorted_without_summary.stems[7].is_infinite());
+}
+
+fn embedded_summary_codes<LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>(
+    tree: &KdTree<f64, u32, Donnelly<3>, LS, K, B, ITEM_LEAF_MODE>,
+    block_base: usize,
+) -> [u8; 8]
+where
+    LS: LeafStrategy<f64, u32, Donnelly<3>, K, B>,
+{
+    let packed = tree.stems[block_base + 7].to_bits();
+    array_init::array_init(|child_idx| ((packed >> (child_idx * 8)) & 0xff) as u8)
+}
+
+fn leaf_min_item<LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>(
+    tree: &KdTree<f64, u32, Donnelly<3>, LS, K, B, ITEM_LEAF_MODE>,
+    leaf_idx: usize,
+) -> Option<u32>
+where
+    LS: LeafStrategy<f64, u32, Donnelly<3>, K, B>,
+{
+    (tree.leaves.leaf_len(leaf_idx) != 0).then(|| tree.leaves.leaf_point_item(leaf_idx, 0).1)
+}
+
+fn encoded_optional_min<const SHIFT: u8>(items: impl Iterator<Item = Option<u32>>) -> u8 {
+    items
+        .flatten()
+        .min()
+        .map_or(EMPTY_SUBTREE_CODE, encode_min_item::<SHIFT>)
+}
+
+#[test]
+fn embedded_min_item_summaries_propagate_across_complete_blocks() {
+    const SHIFT: u8 = 8;
+    type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 1>, 3, 1>;
+
+    let entries = (0..64u32)
+        .map(|idx| {
+            let exponent = 8 + ((idx * 7) % 20);
+            let item = (1u32 << exponent) | idx;
+            (
+                item,
+                [
+                    ((idx * 19) % 67) as f64,
+                    ((idx * 31) % 71) as f64,
+                    ((idx * 43) % 73) as f64,
+                ],
+            )
+        })
+        .collect::<Vec<_>>();
+    let tree = Tree::builder()
+        .with_embedded_min_item_shifted_summary::<SHIFT>()
+        .with_serial_construction()
+        .build_from_entries(&entries)
+        .unwrap();
+    let sorted_tree = Tree::builder()
+        .with_item_sorted_leaves()
+        .with_serial_construction()
+        .build_from_entries(&entries)
+        .unwrap();
+
+    assert!(tree.stems[7].is_finite());
+    let root_codes = embedded_summary_codes(&tree, 0);
+    for (child_idx, &actual) in root_codes.iter().enumerate() {
+        let first_leaf = child_idx * 8;
+        let expected = encoded_optional_min::<SHIFT>(
+            (first_leaf..first_leaf + 8).map(|leaf_idx| leaf_min_item(&tree, leaf_idx)),
+        );
+        assert_eq!(actual, expected, "root child {child_idx}");
+    }
+
+    for root_child_idx in 0..8 {
+        let block_base = (root_child_idx + 1) * 8;
+        assert!(tree.stems[block_base + 7].is_finite());
+        let child_codes = embedded_summary_codes(&tree, block_base);
+        for (child_idx, &actual) in child_codes.iter().enumerate() {
+            let leaf_idx = root_child_idx * 8 + child_idx;
+            let expected =
+                encoded_optional_min::<SHIFT>(std::iter::once(leaf_min_item(&tree, leaf_idx)));
+            assert_eq!(actual, expected, "block {root_child_idx} child {child_idx}");
+        }
+    }
+
+    for query in [[0.0, 0.0, 0.0], [31.0, 29.0, 23.0], [66.0, 70.0, 72.0]] {
+        let max_qty = NonZeroUsize::new(7).unwrap();
+        let expected = sorted_tree
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(20_000.0, max_qty)
+            .execute()
+            .into_sorted_vec();
+        let actual = tree
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(20_000.0, max_qty)
+            .execute()
+            .into_sorted_vec();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn embedded_min_item_summaries_fill_partial_block_child_ranges() {
+    const SHIFT: u8 = 8;
+    type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 1>, 3, 1>;
+
+    let entries = (0..9u32)
+        .map(|idx| {
+            (
+                (1u32 << (8 + idx)) | idx,
+                [
+                    idx as f64,
+                    ((idx * 7) % 17) as f64,
+                    ((idx * 11) % 19) as f64,
+                ],
+            )
+        })
+        .collect::<Vec<_>>();
+    let tree = Tree::builder()
+        .with_serial_construction()
+        .with_embedded_min_item_shifted_summary::<SHIFT>()
+        .build_from_entries(&entries)
+        .unwrap();
+
+    for root_child_idx in 0..8 {
+        let block_base = (root_child_idx + 1) * 8;
+        assert!(tree.stems[block_base + 7].is_finite());
+        let child_codes = embedded_summary_codes(&tree, block_base);
+        let left_code = encoded_optional_min::<SHIFT>(std::iter::once(leaf_min_item(
+            &tree,
+            root_child_idx * 2,
+        )));
+        let right_code = encoded_optional_min::<SHIFT>(std::iter::once(leaf_min_item(
+            &tree,
+            root_child_idx * 2 + 1,
+        )));
+        assert_eq!(
+            child_codes,
+            [
+                left_code, left_code, left_code, left_code, right_code, right_code, right_code,
+                right_code,
+            ]
+        );
+    }
+    assert!(
+        (0..tree.leaf_count()).any(|leaf_idx| leaf_min_item(&tree, leaf_idx).is_none()),
+        "fixture must exercise empty leaves"
+    );
+    assert!(
+        (0..8).any(|root_child_idx| {
+            embedded_summary_codes(&tree, (root_child_idx + 1) * 8).contains(&EMPTY_SUBTREE_CODE)
+        }),
+        "empty leaves must use the reserved empty-subtree code"
+    );
+}
+
+#[cfg(feature = "multi-threaded")]
+#[test]
+fn embedded_min_item_summaries_match_between_serial_and_parallel_construction() {
+    type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 8>, 3, 8>;
+
+    let entries = (0..4_096u32)
+        .map(|idx| {
+            (
+                (1u32 << (8 + (idx % 20))) | idx,
+                [
+                    ((idx * 19) % 4_099) as f64,
+                    ((idx * 31) % 4_111) as f64,
+                    ((idx * 43) % 4_129) as f64,
+                ],
+            )
+        })
+        .collect::<Vec<_>>();
+    let serial = Tree::builder()
+        .with_embedded_min_item_shifted_summary::<8>()
+        .with_serial_construction()
+        .build_from_entries(&entries)
+        .unwrap();
+    let parallel = Tree::builder()
+        .with_embedded_min_item_shifted_summary::<8>()
+        .with_parallel_construction()
+        .build_from_entries(&entries)
+        .unwrap();
+
+    assert_eq!(
+        serial
+            .stems
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>(),
+        parallel
+            .stems
+            .iter()
+            .map(|value| value.to_bits())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        serial.iter().collect::<Vec<_>>(),
+        parallel.iter().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn item_sorted_leaf_builder_sorts_immutable_leaf_layouts() {
+    type FlatTree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, 2, 8>, 2, 8>;
+    type ArenaTree = KdTree<f32, u32, Eytzinger, VecOfArenas<f32, u32, 2, 8>, 2, 8>;
+
+    let entries = (0..97u32)
+        .map(|item| {
+            let scrambled_item = (item * 37) % 97;
+            (
+                scrambled_item,
+                [((item * 19) % 101) as f32, ((item * 43) % 103) as f32],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let ordinary = FlatTree::builder()
+        .with_serial_construction()
+        .build_from_entries(&entries)
+        .unwrap();
+    assert!(!ordinary.item_sorted_leaves());
+    assert_eq!(ordinary.item_leaf_mode(), ItemLeafMode::Unsorted);
+
+    let flat = FlatTree::builder()
+        .with_item_sorted_leaves()
+        .with_serial_construction()
+        .build_from_entries(&entries)
+        .unwrap();
+    let arena = ArenaTree::builder()
+        .with_serial_construction()
+        .with_item_sorted_leaves()
+        .build_from_entries(&entries)
+        .unwrap();
+    assert_item_sorted_leaves(&flat);
+    assert_item_sorted_leaves(&arena);
+    assert_eq!(flat.item_leaf_mode(), ItemLeafMode::SortedWithoutEncodedMin);
+    assert_eq!(
+        arena.item_leaf_mode(),
+        ItemLeafMode::SortedWithoutEncodedMin
+    );
+
+    let mut expected = entries.clone();
+    expected.sort_unstable_by_key(|entry| entry.0);
+    for mut actual in [
+        flat.iter().collect::<Vec<_>>(),
+        arena.iter().collect::<Vec<_>>(),
+    ] {
+        actual.sort_unstable_by_key(|entry| entry.0);
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn empty_mutable_bulk_construction_remains_addable() {
+    type Tree = KdTree<f32, u32, Eytzinger, VecOfArrays<f32, u32, 2, 8>, 2, 8>;
+    let entries: [(u32, [f32; 2]); 0] = [];
+
+    let mut tree = Tree::builder().build_from_entries(&entries).unwrap();
+    tree.add(&[1.0, 2.0], 7).unwrap();
+
+    assert_eq!(tree.size(), 1);
+    assert_eq!(tree.iter().collect::<Vec<_>>(), vec![(7, [1.0, 2.0])]);
+}
 
 #[test]
 fn construction_index_selection_is_adaptive() {
@@ -281,6 +608,16 @@ fn parallel_soft_construction_matches_sequential_construction() {
                 .with_parallel_construction_threshold(points.len())
                 .build_from_slice(&points)
                 .unwrap();
+            let sequential_item_sorted = <$tree>::builder()
+                .with_item_sorted_leaves()
+                .with_serial_construction()
+                .build_from_slice(&points)
+                .unwrap();
+            let parallel_item_sorted = <$tree>::builder()
+                .with_parallel_construction()
+                .with_item_sorted_leaves()
+                .build_from_slice(&points)
+                .unwrap();
 
             assert_eq!(sequential.stems.as_slice(), parallel.stems.as_slice());
             assert_eq!(
@@ -293,6 +630,12 @@ fn parallel_soft_construction_matches_sequential_construction() {
             assert_eq!(
                 sequential.iter().collect::<Vec<_>>(),
                 parallel.iter().collect::<Vec<_>>()
+            );
+            assert!(sequential_item_sorted.item_sorted_leaves());
+            assert!(parallel_item_sorted.item_sorted_leaves());
+            assert_eq!(
+                sequential_item_sorted.iter().collect::<Vec<_>>(),
+                parallel_item_sorted.iter().collect::<Vec<_>>()
             );
 
             for query in [[0.0, 0.0], [500.0, 500.0], [996.0, 990.0]] {

--- a/src/kd_tree/item_summary.rs
+++ b/src/kd_tree/item_summary.rs
@@ -1,0 +1,278 @@
+use std::any::TypeId;
+
+use crate::Axis;
+
+use super::{ITEM_LEAF_MODE_SORTED, ITEM_LEAF_MODE_UNSORTED};
+
+const DONNELLY_BLOCK_HEIGHT: usize = 3;
+const DONNELLY_BLOCK_WIDTH: usize = 1 << DONNELLY_BLOCK_HEIGHT;
+const DONNELLY_BLOCK_MASK: usize = DONNELLY_BLOCK_WIDTH - 1;
+
+/// Reserved summary code marking an empty subtree. Shared with the
+/// construction-side encoder in `kd_tree::construction::item_summary`.
+pub(crate) const EMPTY_SUBTREE_CODE: u8 = u8::MAX - 1;
+/// Highest non-empty summary code; every higher code is `EMPTY_SUBTREE_CODE`.
+pub(crate) const MAX_NONEMPTY_CODE: u8 = EMPTY_SUBTREE_CODE - 1;
+
+/// Compact query-time state for filtering embedded subtree-minimum codes.
+/// It remains disabled until `best_n_within` has filled its result collection.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug)]
+pub struct ItemSummaryFilter {
+    max_live_code: u8,
+    enabled: bool,
+    any_live: bool,
+}
+
+impl ItemSummaryFilter {
+    #[inline(always)]
+    pub(crate) const fn disabled() -> Self {
+        Self {
+            max_live_code: MAX_NONEMPTY_CODE,
+            enabled: false,
+            any_live: true,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn from_threshold<T: Copy + 'static, const ITEM_LEAF_MODE: u8>(
+        threshold: Option<T>,
+    ) -> Self {
+        if ITEM_LEAF_MODE == ITEM_LEAF_MODE_UNSORTED
+            || ITEM_LEAF_MODE == ITEM_LEAF_MODE_SORTED
+            || ITEM_LEAF_MODE >= u32::BITS as u8
+            || TypeId::of::<T>() != TypeId::of::<u32>()
+        {
+            return Self::disabled();
+        }
+
+        let Some(threshold) = threshold else {
+            return Self::disabled();
+        };
+
+        // SAFETY: the TypeId equality above proves that T is u32.
+        let threshold = unsafe { *(&threshold as *const T).cast::<u32>() };
+        if threshold == 0 {
+            return Self {
+                max_live_code: 0,
+                enabled: true,
+                any_live: false,
+            };
+        }
+
+        let max_live_code =
+            ((threshold - 1) >> ITEM_LEAF_MODE).min(u32::from(MAX_NONEMPTY_CODE)) as u8;
+
+        Self {
+            max_live_code,
+            enabled: true,
+            any_live: true,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn live_mask(self, packed_codes: u64) -> u8 {
+        if !self.enabled {
+            return u8::MAX;
+        }
+        if !self.any_live {
+            return 0;
+        }
+        packed_code_live_mask(packed_codes, self.max_live_code)
+    }
+}
+
+#[inline(always)]
+fn packed_code_live_mask(packed_codes: u64, max_live_code: u8) -> u8 {
+    #[cfg(all(
+        feature = "simd",
+        target_arch = "x86_64",
+        target_feature = "avx512bw",
+        target_feature = "avx512vl"
+    ))]
+    unsafe {
+        use std::arch::x86_64::*;
+
+        let codes = _mm_cvtsi64_si128(packed_codes as i64);
+        let cutoff = _mm_set1_epi8(max_live_code as i8);
+        // The compare covers all 16 vector bytes; the upper eight are zero, so
+        // the `as u8` cast keeps exactly the eight summary lanes.
+        _mm_cmp_epu8_mask(codes, cutoff, _MM_CMPINT_LE) as u8
+    }
+
+    #[cfg(all(
+        feature = "simd",
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        not(all(target_feature = "avx512bw", target_feature = "avx512vl"))
+    ))]
+    unsafe {
+        use std::arch::x86_64::*;
+
+        let bytes = _mm_cvtsi64_si128(packed_codes as i64);
+        let codes = _mm256_cvtepu8_epi32(bytes);
+        let cutoff = _mm256_set1_epi32(i32::from(max_live_code));
+        let rejected = _mm256_cmpgt_epi32(codes, cutoff);
+        !(_mm256_movemask_ps(_mm256_castsi256_ps(rejected)) as u8)
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "aarch64"))]
+    unsafe {
+        use std::arch::aarch64::*;
+
+        let codes = vcreate_u8(packed_codes);
+        let cutoff = vdup_n_u8(max_live_code);
+        let live = vcle_u8(codes, cutoff);
+        let weights = vcreate_u8(0x8040_2010_0804_0201);
+        vaddv_u8(vand_u8(live, weights))
+    }
+
+    #[cfg(not(any(
+        all(
+            feature = "simd",
+            target_arch = "x86_64",
+            target_feature = "avx512bw",
+            target_feature = "avx512vl"
+        ),
+        all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
+        all(feature = "simd", target_arch = "aarch64")
+    )))]
+    {
+        let mut mask = 0u8;
+        let mut lane = 0usize;
+        while lane < DONNELLY_BLOCK_WIDTH {
+            let code = (packed_codes >> (lane * u8::BITS as usize)) as u8;
+            if code <= max_live_code {
+                mask |= 1u8 << lane;
+            }
+            lane += 1;
+        }
+        mask
+    }
+}
+
+#[allow(missing_docs)]
+#[cfg(feature = "cargo_asm")]
+pub mod cargo_asm {
+    use super::ItemSummaryFilter;
+
+    /// Assembly-inspection hook for the monomorphised u32/shift-8 mask kernel.
+    #[inline(never)]
+    #[unsafe(no_mangle)]
+    pub fn v6_embedded_min_item_summary_mask_cargo_asm_hook(
+        packed_codes: u64,
+        threshold: u32,
+    ) -> u8 {
+        ItemSummaryFilter::from_threshold::<u32, 8>(Some(threshold)).live_mask(packed_codes)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn donnelly3_block_live_mask<A>(
+    stems: &[A],
+    block_base: usize,
+    filter: ItemSummaryFilter,
+) -> u8
+where
+    A: Axis<Coord = A>,
+{
+    if !filter.enabled {
+        return u8::MAX;
+    }
+    let Some(&padding) = stems.get(block_base + DONNELLY_BLOCK_MASK) else {
+        return u8::MAX;
+    };
+    let Some(word) = A::embedded_item_summary_word(padding) else {
+        return u8::MAX;
+    };
+    let mask = filter.live_mask(word);
+    #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+    crate::results::exact_query_stats::record_item_summary_block(mask);
+    mask
+}
+
+#[inline(always)]
+pub(crate) fn donnelly3_subtree_is_live<A>(
+    stems: &[A],
+    stem_idx: usize,
+    level: i32,
+    filter: ItemSummaryFilter,
+) -> bool
+where
+    A: Axis<Coord = A>,
+{
+    if !filter.enabled || level < 0 {
+        return true;
+    }
+
+    let depth = level as usize % DONNELLY_BLOCK_HEIGHT;
+    let block_base = stem_idx & !DONNELLY_BLOCK_MASK;
+    let local_idx = stem_idx.wrapping_sub(block_base);
+    let first_at_depth = (1usize << depth) - 1;
+    if local_idx < first_at_depth || local_idx >= first_at_depth + (1usize << depth) {
+        return true;
+    }
+
+    let prefix = local_idx - first_at_depth;
+    let suffix_bits = DONNELLY_BLOCK_HEIGHT - depth;
+    let first_lane = prefix << suffix_bits;
+    let lane_count = 1usize << suffix_bits;
+    let subtree_mask = (((1u16 << lane_count) - 1) << first_lane) as u8;
+
+    let live = donnelly3_block_live_mask(stems, block_base, filter) & subtree_mask != 0;
+    #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+    if !live {
+        crate::results::exact_query_stats::record_item_summary_subtree_prune();
+    }
+    live
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pack(codes: [u8; 8]) -> u64 {
+        codes.into_iter().enumerate().fold(0, |word, (lane, code)| {
+            word | (u64::from(code) << (lane * 8))
+        })
+    }
+
+    #[test]
+    fn cutoff_tracks_strict_item_improvement_at_bucket_boundaries() {
+        let first_bucket_end = ItemSummaryFilter::from_threshold::<u32, 8>(Some(256));
+        assert_eq!(
+            first_bucket_end.live_mask(pack([0, 1, 2, 3, 253, 254, 0, 1])),
+            0b0100_0001
+        );
+
+        let second_bucket_start = ItemSummaryFilter::from_threshold::<u32, 8>(Some(257));
+        assert_eq!(
+            second_bucket_start.live_mask(pack([0, 1, 2, 3, 253, 254, 0, 1])),
+            0b1100_0011
+        );
+
+        let saturation_start = ItemSummaryFilter::from_threshold::<u32, 8>(Some(64_768));
+        assert_eq!(
+            saturation_start.live_mask(pack([252, 253, 254, 0, 251, 252, 253, 254])),
+            0b0011_1001
+        );
+
+        let inside_saturated_bucket = ItemSummaryFilter::from_threshold::<u32, 8>(Some(64_769));
+        assert_eq!(
+            inside_saturated_bucket.live_mask(pack([252, 253, 254, 0, 251, 252, 253, 254])),
+            0b0111_1011
+        );
+    }
+
+    #[test]
+    fn absent_threshold_disables_summary_checks() {
+        let filter = ItemSummaryFilter::from_threshold::<u32, 8>(None);
+        assert_eq!(filter.live_mask(pack([0, 1, 2, 31, 254, 0, 1, 2])), u8::MAX);
+    }
+
+    #[test]
+    fn zero_threshold_rejects_every_subtree() {
+        let filter = ItemSummaryFilter::from_threshold::<u32, 8>(Some(0));
+        assert_eq!(filter.live_mask(u64::MAX), 0);
+    }
+}

--- a/src/kd_tree/mod.rs
+++ b/src/kd_tree/mod.rs
@@ -17,6 +17,7 @@
 //!
 mod builder;
 mod construction;
+pub(crate) mod item_summary;
 mod iter;
 pub(crate) mod orchestrator;
 pub(crate) mod query;
@@ -53,6 +54,69 @@ pub use stem_leaf_resolution::OwnedStemLeafResolution;
 
 use crate::traits::leaf_strategy::{BucketLimitType, ConstructibleLeafStrategy, Mutability};
 use crate::{Axis, Content, LeafStrategy, StemStrategy};
+
+/// Encoded item-leaf mode for ordinary, unsorted leaves.
+pub const ITEM_LEAF_MODE_UNSORTED: u8 = 0;
+
+/// Encoded item-leaf mode for sorted leaves without stem-padding summaries.
+pub const ITEM_LEAF_MODE_SORTED: u8 = u8::MAX;
+
+/// The interpreted item-leaf mode carried by [`KdTree`]'s final const generic.
+///
+/// Rust does not currently support enums as const-generic parameter types, so
+/// the tree stores this choice in its type as a `u8` and exposes this enum for
+/// readable inspection. Codes `1..=254` represent sorted leaves whose stem
+/// padding carries encoded subtree-minimum summaries; the code is the number
+/// of bits by which minimum items are shifted right. Builders for a concrete
+/// encoding may accept a narrower range appropriate to its item type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ItemLeafMode {
+    /// Leaves retain their construction order.
+    Unsorted,
+    /// Leaves are sorted by ascending item without subtree-minimum summaries.
+    SortedWithoutEncodedMin,
+    /// Leaves are sorted and stem padding encodes subtree-minimum summaries.
+    SortedWithEncodedMin {
+        /// Power-of-two bucket shift used by the encoded summary.
+        shift: u8,
+    },
+}
+
+impl ItemLeafMode {
+    /// Interprets the `u8` item-leaf mode used as a const generic.
+    ///
+    /// Note that codes `32..=253` are not producible by any builder (a summary
+    /// shift must lie in `1..=31`) and query-side consumers treat them as
+    /// disabled; this function nevertheless reports them as
+    /// [`ItemLeafMode::SortedWithEncodedMin`] so that it remains total. Callers
+    /// must not treat the reported `shift` as a valid encoding.
+    #[inline]
+    pub const fn from_code(code: u8) -> Self {
+        match code {
+            ITEM_LEAF_MODE_UNSORTED => Self::Unsorted,
+            ITEM_LEAF_MODE_SORTED => Self::SortedWithoutEncodedMin,
+            shift => Self::SortedWithEncodedMin { shift },
+        }
+    }
+
+    /// Returns whether the mode guarantees ascending item order within leaves.
+    #[inline]
+    pub const fn has_sorted_leaves(self) -> bool {
+        matches!(
+            self,
+            Self::SortedWithoutEncodedMin | Self::SortedWithEncodedMin { .. }
+        )
+    }
+
+    /// Returns the encoded-minimum bucket shift, when enabled.
+    #[inline]
+    pub const fn encoded_min_shift(self) -> Option<u8> {
+        match self {
+            Self::SortedWithEncodedMin { shift } => Some(shift),
+            _ => None,
+        }
+    }
+}
 
 /// Errors returned by kd-tree construction and mutation when caller-controlled
 /// input or configuration cannot be accommodated.
@@ -252,6 +316,7 @@ fn resolve_mapped_terminal_stem_idx(
 /// * `LS`: [`LeafStrategy`] - determines how leaf nodes are stored.
 /// * `K`: [`usize`] - Dimensionality (number of dimensions)
 /// * `B`: [`usize`] - Bucket size (maximum items per leaf node - 32 is the recommended default)
+/// * `ITEM_LEAF_MODE`: encoded [`ItemLeafMode`]; defaults to [`ITEM_LEAF_MODE_UNSORTED`]
 #[cfg_attr(
     feature = "rkyv_08",
     derive(rkyv_08::Archive, rkyv_08::Serialize, rkyv_08::Deserialize)
@@ -267,6 +332,7 @@ pub struct KdTree<
     LS,             // LeafStrategy
     const K: usize, // dimensionality
     const B: usize, // bucket size
+    const ITEM_LEAF_MODE: u8 = ITEM_LEAF_MODE_UNSORTED,
 > {
     #[cfg_attr(
         feature = "rkyv_08",
@@ -282,7 +348,9 @@ pub struct KdTree<
     pub(crate) _phantom: std::marker::PhantomData<(SS, T)>,
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> std::fmt::Debug for KdTree<A, T, SS, LS, K, B> {
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8> std::fmt::Debug
+    for KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KdTree")
             .field("axis", &std::any::type_name::<A>())
@@ -291,6 +359,7 @@ impl<A, T, SS, LS, const K: usize, const B: usize> std::fmt::Debug for KdTree<A,
             .field("leaf_strategy", &std::any::type_name::<LS>())
             .field("dimensions", &K)
             .field("bucket_size", &B)
+            .field("item_leaf_mode", &ItemLeafMode::from_code(ITEM_LEAF_MODE))
             .field("size", &self.size)
             .field("stem_count", &self.stems.len())
             .field("max_stem_level", &self.max_stem_level)
@@ -299,8 +368,8 @@ impl<A, T, SS, LS, const K: usize, const B: usize> std::fmt::Debug for KdTree<A,
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTreeAccessor<A, T, SS, LS, K, B>
-    for KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTreeAccessor<A, T, SS, LS, K, B> for KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,
@@ -336,10 +405,16 @@ where
     fn max_leaf_len(&self) -> usize {
         self.max_leaf_len
     }
+
+    #[inline(always)]
+    fn item_leaf_mode_code(&self) -> u8 {
+        ITEM_LEAF_MODE
+    }
 }
 
 #[cfg(feature = "rkyv_08")]
-impl<A, T, SS, LS, const K: usize, const B: usize> ArchivedKdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A>,
     T: Content,
@@ -376,6 +451,19 @@ where
         self.max_leaf_len.to_native() as usize
     }
 
+    /// Returns whether each leaf is ordered by ascending item value and can use
+    /// the item-sorted `best_n_within` kernel.
+    #[inline]
+    pub fn item_sorted_leaves(&self) -> bool {
+        self.item_leaf_mode().has_sorted_leaves()
+    }
+
+    /// Returns the item ordering and subtree-summary mode encoded in this tree's type.
+    #[inline]
+    pub const fn item_leaf_mode(&self) -> ItemLeafMode {
+        ItemLeafMode::from_code(ITEM_LEAF_MODE)
+    }
+
     #[inline]
     /// Returns the number of leaf nodes in the archived tree.
     pub fn leaf_count(&self) -> usize {
@@ -390,8 +478,9 @@ where
 }
 
 #[cfg(feature = "rkyv_08")]
-impl<A, T, SS, LS, const K: usize, const B: usize>
-    KdTreeAccessor<A, T, SS, rkyv_08::Archived<LS>, K, B> for ArchivedKdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTreeAccessor<A, T, SS, rkyv_08::Archived<LS>, K, B>
+    for ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A>,
     T: Content,
@@ -427,6 +516,11 @@ where
     #[inline(always)]
     fn max_leaf_len(&self) -> usize {
         self.max_leaf_len.to_native() as usize
+    }
+
+    #[inline(always)]
+    fn item_leaf_mode_code(&self) -> u8 {
+        ITEM_LEAF_MODE
     }
 }
 
@@ -487,7 +581,8 @@ where
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,
@@ -538,6 +633,19 @@ where
     /// Returns the configured maximum leaf size heuristic used to size hot-path scratch buffers.
     pub fn max_leaf_len(&self) -> usize {
         self.max_leaf_len
+    }
+
+    /// Returns whether each leaf is ordered by ascending item value and can use
+    /// the item-sorted `best_n_within` kernel.
+    #[inline]
+    pub fn item_sorted_leaves(&self) -> bool {
+        self.item_leaf_mode().has_sorted_leaves()
+    }
+
+    /// Returns the item ordering and subtree-summary mode encoded in this tree's type.
+    #[inline]
+    pub const fn item_leaf_mode(&self) -> ItemLeafMode {
+        ItemLeafMode::from_code(ITEM_LEAF_MODE)
     }
 
     /// Returns an iterator over all item/point pairs in the tree.
@@ -597,8 +705,22 @@ where
     }
 }
 
-impl<'a, A1, T1, SS1, LS1, A2, T2, SS2, LS2, const K: usize, const B1: usize, const B2: usize>
-    TryFrom<&'a KdTree<A1, T1, SS1, LS1, K, B1>> for KdTree<A2, T2, SS2, LS2, K, B2>
+impl<
+        'a,
+        A1,
+        T1,
+        SS1,
+        LS1,
+        A2,
+        T2,
+        SS2,
+        LS2,
+        const K: usize,
+        const B1: usize,
+        const B2: usize,
+        const ITEM_LEAF_MODE: u8,
+    > TryFrom<&'a KdTree<A1, T1, SS1, LS1, K, B1, ITEM_LEAF_MODE>>
+    for KdTree<A2, T2, SS2, LS2, K, B2>
 where
     A1: Axis<Coord = A1>,
     T1: Content,
@@ -613,7 +735,9 @@ where
 {
     type Error = KdTreeConversionError;
 
-    fn try_from(source: &'a KdTree<A1, T1, SS1, LS1, K, B1>) -> Result<Self, Self::Error> {
+    fn try_from(
+        source: &'a KdTree<A1, T1, SS1, LS1, K, B1, ITEM_LEAF_MODE>,
+    ) -> Result<Self, Self::Error> {
         let mut entries = Vec::with_capacity(source.size());
 
         for (point_index, (item, point)) in source.iter().enumerate() {
@@ -642,7 +766,8 @@ where
 }
 
 // Display implementation for debugging
-impl<A, T, SS, LS, const K: usize, const B: usize> std::fmt::Display for KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8> std::fmt::Display
+    for KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + std::fmt::Display,
     T: Content + std::fmt::Display,
@@ -654,6 +779,7 @@ where
         writeln!(f, "  Summary:")?;
         writeln!(f, "    size: {}", self.size)?;
         writeln!(f, "    max_stem_level: {}", self.max_stem_level)?;
+        writeln!(f, "    item_leaf_mode: {:?}", self.item_leaf_mode())?;
         writeln!(f, "    stem len: {}", self.stems.len())?;
         writeln!(f, "    leaf count: {}", self.leaves.leaf_count())?;
         writeln!(f)?;
@@ -759,6 +885,20 @@ mod tests {
     #[cfg(feature = "rkyv_08")]
     use std::num::NonZeroUsize;
 
+    #[cfg(feature = "rkyv_08")]
+    #[derive(rkyv_08::Archive, rkyv_08::Serialize)]
+    #[rkyv(crate = rkyv_08)]
+    struct LegacyV6Tree {
+        #[rkyv(with = crate::rkyv::adapters::AsAlignedCachelineABox)]
+        stems: AVec<f64>,
+        leaves: VecOfArenas<f64, u32, 2, 8>,
+        stem_leaf_resolution: OwnedStemLeafResolution,
+        size: usize,
+        max_stem_level: i32,
+        max_leaf_len: usize,
+        _phantom: std::marker::PhantomData<(Eytzinger, u32)>,
+    }
+
     fn sort_entries_u32<A: Copy, const K: usize>(
         mut entries: Vec<(u32, [A; K])>,
     ) -> Vec<(u32, [A; K])> {
@@ -861,6 +1001,173 @@ mod tests {
             leaf_idx,
             tree.leaf_count()
         );
+    }
+
+    #[test]
+    fn item_leaf_mode_codes_have_stable_meanings() {
+        assert_eq!(ItemLeafMode::from_code(0), ItemLeafMode::Unsorted);
+        assert_eq!(
+            ItemLeafMode::from_code(2),
+            ItemLeafMode::SortedWithEncodedMin { shift: 2 }
+        );
+        assert_eq!(
+            ItemLeafMode::from_code(254),
+            ItemLeafMode::SortedWithEncodedMin { shift: 254 }
+        );
+        assert_eq!(
+            ItemLeafMode::from_code(255),
+            ItemLeafMode::SortedWithoutEncodedMin
+        );
+
+        assert!(!ItemLeafMode::Unsorted.has_sorted_leaves());
+        assert!(ItemLeafMode::SortedWithoutEncodedMin.has_sorted_leaves());
+        assert!(ItemLeafMode::from_code(2).has_sorted_leaves());
+        assert_eq!(ItemLeafMode::from_code(2).encoded_min_shift(), Some(2));
+    }
+
+    #[cfg(feature = "rkyv_08")]
+    #[test]
+    fn rkyv_preserves_item_sorted_leaves_and_best_n_within_dispatch() {
+        type Tree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 8>, 2, 8>;
+        type ArchivedTree = ArchivedKdTree<
+            f64,
+            u32,
+            Eytzinger,
+            VecOfArenas<f64, u32, 2, 8>,
+            2,
+            8,
+            ITEM_LEAF_MODE_SORTED,
+        >;
+
+        let entries = (0..97u32)
+            .map(|idx| {
+                (
+                    (idx * 37) % 97,
+                    [((idx * 19) % 101) as f64, ((idx * 43) % 103) as f64],
+                )
+            })
+            .collect::<Vec<_>>();
+        let tree = Tree::builder()
+            .with_item_sorted_leaves()
+            .build_from_entries(&entries)
+            .unwrap();
+        let query = [50.0, 50.0];
+        let max_qty = NonZeroUsize::new(7).unwrap();
+        let expected = tree
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(20_000.0, max_qty)
+            .execute()
+            .into_sorted_vec();
+
+        let bytes = rkyv_08::api::high::to_bytes_in::<_, rkyv_08::rancor::Error>(
+            &tree,
+            rkyv_08::util::AlignedVec::<128>::new(),
+        )
+        .unwrap();
+        let archived =
+            rkyv_08::access::<ArchivedTree, rkyv_08::rancor::Error>(bytes.as_slice()).unwrap();
+
+        assert!(archived.item_sorted_leaves());
+        assert_eq!(
+            archived.item_leaf_mode(),
+            ItemLeafMode::SortedWithoutEncodedMin
+        );
+        assert_eq!(
+            archived
+                .query(&query)
+                .best_n_within::<SquaredEuclidean<f64>>(20_000.0, max_qty)
+                .execute()
+                .into_sorted_vec(),
+            expected
+        );
+    }
+
+    #[cfg(feature = "rkyv_08")]
+    #[test]
+    fn rkyv_preserves_embedded_min_item_summary_mode_and_queries() {
+        type Tree = KdTree<f64, u32, Donnelly<3>, VecOfArenas<f64, u32, 3, 8>, 3, 8>;
+        type ArchivedTree =
+            ArchivedKdTree<f64, u32, Donnelly<3>, VecOfArenas<f64, u32, 3, 8>, 3, 8, 8>;
+
+        let entries = (0..97u32)
+            .map(|idx| {
+                (
+                    (1u32 << (16 + (idx % 8))) | idx,
+                    [
+                        ((idx * 19) % 101) as f64,
+                        ((idx * 43) % 103) as f64,
+                        ((idx * 61) % 107) as f64,
+                    ],
+                )
+            })
+            .collect::<Vec<_>>();
+        let tree = Tree::builder()
+            .with_embedded_min_item_shifted_summary::<8>()
+            .build_from_entries(&entries)
+            .unwrap();
+        let query = [50.0, 50.0, 50.0];
+        let max_qty = NonZeroUsize::new(7).unwrap();
+        let expected = tree
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(20_000.0, max_qty)
+            .execute()
+            .into_sorted_vec();
+
+        let bytes = rkyv_08::api::high::to_bytes_in::<_, rkyv_08::rancor::Error>(
+            &tree,
+            rkyv_08::util::AlignedVec::<128>::new(),
+        )
+        .unwrap();
+        let archived =
+            rkyv_08::access::<ArchivedTree, rkyv_08::rancor::Error>(bytes.as_slice()).unwrap();
+
+        assert_eq!(
+            archived.item_leaf_mode(),
+            ItemLeafMode::SortedWithEncodedMin { shift: 8 }
+        );
+        assert_eq!(
+            archived
+                .query(&query)
+                .best_n_within::<SquaredEuclidean<f64>>(20_000.0, max_qty)
+                .execute()
+                .into_sorted_vec(),
+            expected
+        );
+    }
+
+    #[cfg(feature = "rkyv_08")]
+    #[test]
+    fn rkyv_unsorted_tree_accepts_the_v6_archive_layout() {
+        type Tree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 8>, 2, 8>;
+        type ArchivedTree = ArchivedKdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 8>, 2, 8>;
+
+        let entries = (0..97u32)
+            .map(|idx| (idx, [((idx * 19) % 101) as f64, ((idx * 43) % 103) as f64]))
+            .collect::<Vec<_>>();
+        let tree = Tree::new_from_entries(&entries).unwrap();
+        let expected = tree.iter().collect::<Vec<_>>();
+        let legacy = LegacyV6Tree {
+            stems: tree.stems,
+            leaves: tree.leaves,
+            stem_leaf_resolution: tree.stem_leaf_resolution,
+            size: tree.size,
+            max_stem_level: tree.max_stem_level,
+            max_leaf_len: tree.max_leaf_len,
+            _phantom: std::marker::PhantomData,
+        };
+
+        let bytes = rkyv_08::api::high::to_bytes_in::<_, rkyv_08::rancor::Error>(
+            &legacy,
+            rkyv_08::util::AlignedVec::<128>::new(),
+        )
+        .unwrap();
+        let archived =
+            rkyv_08::access::<ArchivedTree, rkyv_08::rancor::Error>(bytes.as_slice()).unwrap();
+
+        assert!(!archived.item_sorted_leaves());
+        assert_eq!(archived.item_leaf_mode(), ItemLeafMode::Unsorted);
+        assert_eq!(archived.size(), entries.len());
+        assert_eq!(archived.iter().collect::<Vec<_>>(), expected);
     }
 
     #[cfg(feature = "rkyv_08")]

--- a/src/kd_tree/orchestrator/mod.rs
+++ b/src/kd_tree/orchestrator/mod.rs
@@ -304,6 +304,21 @@ where
             let (stem_state, restore_dim, old_off, rd) =
                 SS::StackContext::<O, K>::into_parts_with_restore_dim(stack_ctx);
             stem_strat.rehydrate_deferred_state(stem_state);
+
+            if QC::USES_EMBEDDED_ITEM_SUMMARY
+                && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                && !crate::kd_tree::item_summary::donnelly3_subtree_is_live(
+                    self.stems(),
+                    stem_strat.stem_idx(),
+                    stem_strat.level(),
+                    query_ctx.embedded_item_summary_filter(),
+                )
+            {
+                #[cfg(feature = "result_collection_stats")]
+                crate::results::result_collection_stats::record_query_prune();
+                continue;
+            }
+
             let mut dim = stem_strat.dim::<K>();
             let restore_dim = restore_dim.unwrap_or(dim);
             tracing::trace!(%dim, %old_off, %rd, ?off, "Popped stack context");
@@ -503,6 +518,21 @@ where
                     continue;
                 }
 
+                stem_strat.rehydrate_deferred_state(far.stem_state);
+                if QC::USES_EMBEDDED_ITEM_SUMMARY
+                    && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                    && !crate::kd_tree::item_summary::donnelly3_subtree_is_live(
+                        self.stems(),
+                        stem_strat.stem_idx(),
+                        stem_strat.level(),
+                        query_ctx.embedded_item_summary_filter(),
+                    )
+                {
+                    #[cfg(feature = "result_collection_stats")]
+                    crate::results::result_collection_stats::record_query_prune();
+                    continue;
+                }
+
                 restore_stack
                     .push_unchecked_inline(ScalarContinuationRestore::restore_only(old_off));
                 #[cfg(feature = "exact_query_stats")]
@@ -511,7 +541,6 @@ where
                 crate::results::result_collection_stats::record_query_scalar_continuation_frame_push();
 
                 unsafe { *off.get_unchecked_mut(restore_dim) = far.far_off };
-                stem_strat.rehydrate_deferred_state(far.stem_state);
                 rd = far.rd;
 
                 #[cfg(feature = "exact_query_stats")]
@@ -899,6 +928,20 @@ where
                         "Popped single context"
                     );
 
+                    if QC::USES_EMBEDDED_ITEM_SUMMARY
+                        && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                        && !crate::kd_tree::item_summary::donnelly3_subtree_is_live(
+                            self.stems(),
+                            ss.stem_idx(),
+                            ss.level(),
+                            query_ctx.embedded_item_summary_filter(),
+                        )
+                    {
+                        #[cfg(feature = "result_collection_stats")]
+                        crate::results::result_collection_stats::record_query_prune();
+                        continue;
+                    }
+
                     let max_dist = query_ctx.max_dist();
                     let rd_vs_max = O::cmp(rd, max_dist);
                     let should_prune = rd_vs_max == std::cmp::Ordering::Greater
@@ -918,8 +961,7 @@ where
                         *off.get_unchecked_mut(restore_dim) = old_off;
                     }
 
-                    let best_dist = query_ctx.max_dist();
-                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<O, D>(
+                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<QC, O, D>(
                         &query,
                         &query_wide,
                         &mut ss,
@@ -928,7 +970,7 @@ where
                         &mut off,
                         &mut dim,
                         rd,
-                        best_dist,
+                        query_ctx,
                         stack,
                     ) {
                         tracing::trace!(%leaf_idx, "processing leaf");
@@ -946,6 +988,23 @@ where
                     crate::results::exact_query_stats::record_block3_pending_pop(pending_mask);
 
                     let dim_val = base.dim::<K>();
+                    let pending_mask = if QC::USES_EMBEDDED_ITEM_SUMMARY
+                        && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                    {
+                        pending_mask
+                            & crate::kd_tree::item_summary::donnelly3_block_live_mask(
+                                self.stems(),
+                                base.stem_idx(),
+                                query_ctx.embedded_item_summary_filter(),
+                            )
+                    } else {
+                        pending_mask
+                    };
+                    if pending_mask == 0 {
+                        #[cfg(feature = "result_collection_stats")]
+                        crate::results::result_collection_stats::record_query_prune();
+                        continue;
+                    }
                     lower = restored_lower;
                     upper = restored_upper;
                     off = rebuild_interval_offs(&query_wide, &lower, &upper);
@@ -1180,7 +1239,7 @@ where
                         *upper.get_unchecked_mut(dim_val) = selected_upper_bound;
                     }
 
-                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<O, D>(
+                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<QC, O, D>(
                         &query,
                         &query_wide,
                         &mut ss,
@@ -1189,7 +1248,7 @@ where
                         &mut off,
                         &mut dim,
                         selected_child_rd,
-                        best_dist,
+                        query_ctx,
                         stack,
                     ) {
                         tracing::trace!(%leaf_idx, "processing leaf");
@@ -1270,6 +1329,20 @@ where
                         "Popped single context"
                     );
 
+                    if QC::USES_EMBEDDED_ITEM_SUMMARY
+                        && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                        && !crate::kd_tree::item_summary::donnelly3_subtree_is_live(
+                            self.stems(),
+                            ss.stem_idx(),
+                            ss.level(),
+                            query_ctx.embedded_item_summary_filter(),
+                        )
+                    {
+                        #[cfg(feature = "result_collection_stats")]
+                        crate::results::result_collection_stats::record_query_prune();
+                        continue;
+                    }
+
                     let max_dist = query_ctx.max_dist();
                     let rd_vs_max = O::cmp(rd, max_dist);
                     // TOOO: investigate into whether prune_on_equal_max_dist can be removed
@@ -1292,8 +1365,7 @@ where
                         *off.get_unchecked_mut(restore_dim) = old_off;
                     }
 
-                    let best_dist = query_ctx.max_dist();
-                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<O, D>(
+                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<QC, O, D>(
                         &query,
                         &query_wide,
                         &mut ss,
@@ -1302,7 +1374,7 @@ where
                         &mut off,
                         &mut dim,
                         rd,
-                        best_dist,
+                        query_ctx,
                         stack,
                     ) {
                         tracing::trace!(%leaf_idx, "processing leaf");
@@ -1334,6 +1406,19 @@ where
                     lower = lower_snapshot;
                     upper = upper_snapshot;
                     off = rebuild_interval_offs(&query_wide, &lower, &upper);
+
+                    let pending_mask = if QC::USES_EMBEDDED_ITEM_SUMMARY
+                        && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                    {
+                        pending_mask
+                            & crate::kd_tree::item_summary::donnelly3_block_live_mask(
+                                self.stems(),
+                                base.stem_idx(),
+                                query_ctx.embedded_item_summary_filter(),
+                            )
+                    } else {
+                        pending_mask
+                    };
 
                     let Some(selection) = select_block3_pending_child(
                         &rd_values,
@@ -1374,8 +1459,7 @@ where
                             upper_bounds[selection.child_idx as usize];
                     }
 
-                    let best_dist = query_ctx.max_dist();
-                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<O, D>(
+                    if let Some(leaf_idx) = self.traverse_to_leaf_simd::<QC, O, D>(
                         &query,
                         &query_wide,
                         &mut ss,
@@ -1384,7 +1468,7 @@ where
                         &mut off,
                         &mut dim,
                         selection.child_rd,
-                        best_dist,
+                        query_ctx,
                         stack,
                     ) {
                         tracing::trace!(%leaf_idx, "processing leaf");
@@ -1438,6 +1522,17 @@ where
                     for sibling_idx in 0..8 {
                         if surviving_mask & (1 << sibling_idx) != 0 {
                             let mut ss = siblings[sibling_idx];
+                            if QC::USES_EMBEDDED_ITEM_SUMMARY
+                                && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                                && !crate::kd_tree::item_summary::donnelly3_subtree_is_live(
+                                    self.stems(),
+                                    ss.stem_idx(),
+                                    ss.level(),
+                                    query_ctx.embedded_item_summary_filter(),
+                                )
+                            {
+                                continue;
+                            }
                             let rd = rd_values[sibling_idx];
                             let new_off = new_off_values[sibling_idx];
                             let mut dim = ss.dim::<K>();
@@ -1463,8 +1558,7 @@ where
                                 *upper.get_unchecked_mut(dim_val) = upper_bounds[sibling_idx];
                             }
 
-                            let best_dist = query_ctx.max_dist();
-                            if let Some(leaf_idx) = self.traverse_to_leaf_simd::<O, D>(
+                            if let Some(leaf_idx) = self.traverse_to_leaf_simd::<QC, O, D>(
                                 &query,
                                 &query_wide,
                                 &mut ss,
@@ -1473,7 +1567,7 @@ where
                                 &mut off,
                                 &mut dim,
                                 rd,
-                                best_dist,
+                                query_ctx,
                                 stack,
                             ) {
                                 tracing::trace!(%leaf_idx, "processing leaf");
@@ -1528,6 +1622,17 @@ where
                     for sibling_idx in 0..8 {
                         if surviving_mask & (1 << sibling_idx) != 0 {
                             let mut ss = base.block_child::<K>(child_base + sibling_idx as u8);
+                            if QC::USES_EMBEDDED_ITEM_SUMMARY
+                                && SS::SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY
+                                && !crate::kd_tree::item_summary::donnelly3_subtree_is_live(
+                                    self.stems(),
+                                    ss.stem_idx(),
+                                    ss.level(),
+                                    query_ctx.embedded_item_summary_filter(),
+                                )
+                            {
+                                continue;
+                            }
                             let rd = rd_values[sibling_idx];
                             let new_off = new_off_values[sibling_idx];
                             let mut dim = ss.dim::<K>();
@@ -1541,8 +1646,7 @@ where
                                 *upper.get_unchecked_mut(dim_val) = upper_bounds[sibling_idx];
                             }
 
-                            let best_dist = query_ctx.max_dist();
-                            if let Some(leaf_idx) = self.traverse_to_leaf_simd::<O, D>(
+                            if let Some(leaf_idx) = self.traverse_to_leaf_simd::<QC, O, D>(
                                 &query,
                                 &query_wide,
                                 &mut ss,
@@ -1551,7 +1655,7 @@ where
                                 &mut off,
                                 &mut dim,
                                 rd,
-                                best_dist,
+                                query_ctx,
                                 stack,
                             ) {
                                 tracing::trace!(%leaf_idx, "processing leaf");
@@ -1566,7 +1670,7 @@ where
 
     /// traverse to leaf with SIMD stack
     #[inline(always)]
-    fn traverse_to_leaf_simd<O, D>(
+    fn traverse_to_leaf_simd<QC, O, D>(
         &self,
         query: &[A; K],
         query_wide: &[O; K],
@@ -1576,16 +1680,18 @@ where
         off: &mut [O; K],
         dim: &mut usize,
         rd: O,
-        best_dist: O,
+        query_ctx: &QC,
         stack: &mut SS::Stack<O, K>,
     ) -> Option<usize>
     where
+        QC: QueryContext<A, O, K>,
         O: Axis<Coord = O> + SimdSelectBestChildBlock3 + BacktrackBlock3 + BacktrackBlock4,
         D: DistanceMetric<A, Output = O>,
         SS: StemStrategy + crate::stem_strategy::donnelly::simd_full::DeferredBlockTraversal,
         SS::StackContext<O, K>:
             crate::kd_tree::query_stack_simd::SimdIntervalStackContext<O, SS, K>,
     {
+        let best_dist = query_ctx.max_dist();
         let use_scalar_step = !self.stem_leaf_resolution().uses_arithmetic()
             && SS::BLOCK_SIZE != 3
             && !force_mapped_simd_block_step();

--- a/src/kd_tree/query/approx_nearest_one.rs
+++ b/src/kd_tree/query/approx_nearest_one.rs
@@ -5,7 +5,8 @@ use crate::leaf_view_chunked::nearest_one::nearest_one_with_query_wide;
 use crate::traits::leaf_strategy::LeafProjection;
 use crate::{Axis, Content, KdTree, LeafStrategy, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content + PartialOrd + PartialEq,

--- a/src/kd_tree/query/best_n_within.rs
+++ b/src/kd_tree/query/best_n_within.rs
@@ -4,7 +4,7 @@ use std::num::NonZero;
 use crate::dist::DistanceMetric;
 use crate::kd_tree::query_context::QueryContext;
 use crate::kd_tree::query_stack::StackTrait;
-use crate::kd_tree::KdTreeQueryOps;
+use crate::kd_tree::{KdTreeQueryOps, ITEM_LEAF_MODE_SORTED, ITEM_LEAF_MODE_UNSORTED};
 use crate::leaf_view::TlsLeafScratch;
 use crate::leaf_view_chunked::best_n_within::{
     best_n_within_with_query_wide, best_n_within_with_query_wide_arena,
@@ -22,7 +22,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 use crate::traits::leaf_strategy::LeafProjection;
 use crate::{Axis, BestQueryResultItem, Content, KdTree, LeafStrategy, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content + PartialOrd,
@@ -30,7 +31,7 @@ where
     SS: StemStrategy,
 {
     #[inline(always)]
-    fn process_leaf_best_n_within<D, R, const EXCLUSIVE: bool>(
+    fn process_leaf_best_n_within<D, R, const EXCLUSIVE: bool, const LEAF_MODE: u8>(
         &self,
         leaf_idx: usize,
         query_wide: &[D::Output; K],
@@ -41,6 +42,14 @@ where
         D::Output: Axis<Coord = D::Output> + TlsLeafScratch + 'static,
         R: BestNeighbourResultCollection<D::Output, T>,
     {
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        {
+            crate::results::exact_query_stats::record_leaf_visit();
+            crate::results::exact_query_stats::record_leaf_items_available(
+                self.leaves.leaf_len(leaf_idx),
+            );
+        }
+
         #[cfg(feature = "result_collection_stats")]
         let was_full = results.is_full();
 
@@ -55,7 +64,7 @@ where
             LeafProjection::LeafArena => {
                 let arena = self.leaves.leaf_arena(leaf_idx);
                 let threshold_item = results.threshold_item();
-                best_n_within_with_query_wide_arena::<A, T, D, R, EXCLUSIVE, K>(
+                best_n_within_with_query_wide_arena::<A, T, D, R, EXCLUSIVE, LEAF_MODE, K>(
                     &arena,
                     query_wide,
                     max_dist,
@@ -66,7 +75,7 @@ where
             LeafProjection::LeafView => {
                 let leaf = self.leaves.leaf_view(leaf_idx);
                 let threshold_item = results.threshold_item();
-                best_n_within_with_query_wide::<A, T, D, R, EXCLUSIVE, K, B>(
+                best_n_within_with_query_wide::<A, T, D, R, EXCLUSIVE, LEAF_MODE, K, B>(
                     &leaf,
                     query_wide,
                     max_dist,
@@ -177,19 +186,50 @@ where
         R: BestNeighbourResultCollection<D::Output, T>,
         SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K> + 'static,
     {
-        let mut req_ctx = BestNWithinReqCtx::<A, D::Output, R, EXCLUSIVE, K> {
+        self.best_n_within_inner_ordered::<D, R, EXCLUSIVE, ITEM_LEAF_MODE>(
+            query, max_dist, max_qty,
+        )
+    }
+
+    #[inline(always)]
+    fn best_n_within_inner_ordered<D, R, const EXCLUSIVE: bool, const LEAF_MODE: u8>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: usize,
+    ) -> R
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        R: BestNeighbourResultCollection<D::Output, T>,
+        SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K> + 'static,
+    {
+        let mut req_ctx = BestNWithinReqCtx::<A, D::Output, R, EXCLUSIVE, K, LEAF_MODE> {
             query,
             max_dist,
             results: R::with_max_qty(max_qty),
+            item_summary_filter: crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<
+                T,
+                LEAF_MODE,
+            >(None),
         };
 
         self.backtracking_query::<_, _, D>(&mut req_ctx, |leaf_idx, query_wide, req_ctx| {
-            self.process_leaf_best_n_within::<D, _, EXCLUSIVE>(
+            self.process_leaf_best_n_within::<D, _, EXCLUSIVE, LEAF_MODE>(
                 leaf_idx,
                 query_wide,
                 max_dist,
                 &mut req_ctx.results,
             );
+            req_ctx.item_summary_filter =
+                crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<T, LEAF_MODE>(
+                    req_ctx.results.threshold_item(),
+                );
         });
 
         req_ctx.results
@@ -213,22 +253,54 @@ where
         R: BestNeighbourResultCollection<D::Output, T>,
         SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K>,
     {
-        let mut req_ctx = BestNWithinReqCtx::<A, D::Output, R, EXCLUSIVE, K> {
+        self.best_n_within_inner_with_scratch_ordered::<D, R, EXCLUSIVE, ITEM_LEAF_MODE>(
+            query, max_dist, max_qty, stack,
+        )
+    }
+
+    #[inline(always)]
+    fn best_n_within_inner_with_scratch_ordered<D, R, const EXCLUSIVE: bool, const LEAF_MODE: u8>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: usize,
+        stack: &mut SS::Stack<D::Output, K>,
+    ) -> R
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        R: BestNeighbourResultCollection<D::Output, T>,
+        SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K>,
+    {
+        let mut req_ctx = BestNWithinReqCtx::<A, D::Output, R, EXCLUSIVE, K, LEAF_MODE> {
             query,
             max_dist,
             results: R::with_max_qty(max_qty),
+            item_summary_filter: crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<
+                T,
+                LEAF_MODE,
+            >(None),
         };
 
         self.backtracking_query_with_scratch::<_, _, D>(
             &mut req_ctx,
             stack,
             |leaf_idx, query_wide, req_ctx| {
-                self.process_leaf_best_n_within::<D, _, EXCLUSIVE>(
+                self.process_leaf_best_n_within::<D, _, EXCLUSIVE, LEAF_MODE>(
                     leaf_idx,
                     query_wide,
                     max_dist,
                     &mut req_ctx.results,
                 );
+                req_ctx.item_summary_filter =
+                    crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<T, LEAF_MODE>(
+                        req_ctx.results.threshold_item(),
+                    );
             },
         );
 
@@ -278,20 +350,31 @@ pub mod cargo_asm {
 
 #[allow(unused)]
 #[derive(Debug)]
-struct BestNWithinReqCtx<'a, A, O, R, const EXCLUSIVE: bool, const K: usize>
-where
+struct BestNWithinReqCtx<
+    'a,
+    A,
+    O,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const ITEM_LEAF_MODE: u8,
+> where
     O: Axis<Coord = O>,
 {
     query: &'a [A; K],
     max_dist: O,
     results: R,
+    item_summary_filter: crate::kd_tree::item_summary::ItemSummaryFilter,
 }
 
-impl<'a, A, O, R, const EXCLUSIVE: bool, const K: usize> QueryContext<A, O, K>
-    for BestNWithinReqCtx<'a, A, O, R, EXCLUSIVE, K>
+impl<'a, A, O, R, const EXCLUSIVE: bool, const K: usize, const ITEM_LEAF_MODE: u8>
+    QueryContext<A, O, K> for BestNWithinReqCtx<'a, A, O, R, EXCLUSIVE, K, ITEM_LEAF_MODE>
 where
     O: Axis<Coord = O>,
 {
+    const USES_EMBEDDED_ITEM_SUMMARY: bool =
+        ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED && ITEM_LEAF_MODE != ITEM_LEAF_MODE_SORTED;
+
     fn query(&self) -> &[A; K] {
         self.query
     }
@@ -302,6 +385,11 @@ where
     #[inline]
     fn prune_on_equal_max_dist(&self) -> bool {
         EXCLUSIVE
+    }
+
+    #[inline(always)]
+    fn embedded_item_summary_filter(&self) -> crate::kd_tree::item_summary::ItemSummaryFilter {
+        self.item_summary_filter
     }
 }
 
@@ -316,9 +404,300 @@ mod tests {
     use crate::dist::SquaredEuclidean;
     use crate::kd_tree::KdTree;
     use crate::leaf_strategy::{FlatVec, VecOfArenas, VecOfArrays};
-    use crate::{BestQueryResultItem, Eytzinger};
+    use crate::{
+        BestQueryResultItem, Donnelly, DonnellyCyclicSimdDescent, DonnellyCyclicSimdFull,
+        DonnellyNoPf, DonnellySimdDescent, DonnellySimdFull, DonnellyUnrolled,
+        DonnellyUnrolledBlockDim, Eytzinger,
+    };
 
     const RNG_SEED: u64 = 42;
+
+    #[test]
+    fn embedded_summary_builder_and_queries_cover_all_public_donnelly3_variants() {
+        let entries = (0..257u32)
+            .map(|idx| {
+                (
+                    (idx * 73) % 257,
+                    [
+                        ((idx * 19) % 263) as f64,
+                        ((idx * 43) % 269) as f64,
+                        ((idx * 61) % 271) as f64,
+                    ],
+                )
+            })
+            .collect::<Vec<_>>();
+        let query = [130.0, 130.0, 130.0];
+        let max_qty = NonZeroUsize::new(7).unwrap();
+
+        macro_rules! assert_strategy {
+            ($strategy:ty) => {{
+                type Tree<SS> = KdTree<f64, u32, SS, FlatVec<f64, u32, 3, 8>, 3, 8>;
+                let tree = Tree::<$strategy>::builder()
+                    .with_embedded_min_item_shifted_summary::<8>()
+                    .with_serial_construction()
+                    .build_from_entries(&entries)
+                    .unwrap();
+                let sorted = Tree::<$strategy>::builder()
+                    .with_item_sorted_leaves()
+                    .with_serial_construction()
+                    .build_from_entries(&entries)
+                    .unwrap();
+                let results = tree
+                    .query(&query)
+                    .best_n_within::<SquaredEuclidean<f64>>(f64::INFINITY, max_qty)
+                    .execute()
+                    .into_sorted_vec();
+                assert_eq!(
+                    results.iter().map(|result| result.item).collect::<Vec<_>>(),
+                    (0..7).collect::<Vec<_>>(),
+                    "strategy {}",
+                    std::any::type_name::<$strategy>()
+                );
+
+                for (query, radius, qty) in [
+                    ([0.0, 0.0, 0.0], 2_000.0, 1),
+                    ([130.0, 130.0, 130.0], 8_000.0, 7),
+                    ([262.0, 268.0, 270.0], 50_000.0, 31),
+                ] {
+                    let qty = NonZeroUsize::new(qty).unwrap();
+                    let expected = sorted
+                        .query(&query)
+                        .best_n_within::<SquaredEuclidean<f64>>(radius, qty)
+                        .execute()
+                        .into_sorted_vec();
+                    let actual = tree
+                        .query(&query)
+                        .best_n_within::<SquaredEuclidean<f64>>(radius, qty)
+                        .execute()
+                        .into_sorted_vec();
+                    assert_eq!(
+                        actual,
+                        expected,
+                        "strategy {} query={query:?} radius={radius}",
+                        std::any::type_name::<$strategy>(),
+                    );
+                }
+            }};
+        }
+
+        assert_strategy!(Donnelly<3>);
+        assert_strategy!(DonnellyNoPf<3>);
+        assert_strategy!(DonnellyUnrolled<3>);
+        assert_strategy!(DonnellyUnrolledBlockDim<3>);
+        assert_strategy!(DonnellySimdDescent<3>);
+        assert_strategy!(DonnellySimdFull<3>);
+        assert_strategy!(DonnellyCyclicSimdDescent<3>);
+        assert_strategy!(DonnellyCyclicSimdFull<3>);
+    }
+
+    #[cfg(feature = "test_utils")]
+    #[test]
+    fn embedded_summaries_prune_item_dead_subtrees_before_leaf_visits() {
+        type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 1>, 3, 1>;
+        let entries = (0..64u32)
+            .map(|item| (item, [item as f64, item as f64, item as f64]))
+            .collect::<Vec<_>>();
+        let query = [0.0, 0.0, 0.0];
+        let max_qty = NonZeroUsize::new(1).unwrap();
+
+        let sorted = Tree::builder()
+            .with_item_sorted_leaves()
+            .with_serial_construction()
+            .build_from_entries(&entries)
+            .unwrap();
+        crate::results::exact_query_stats::reset();
+        let expected = sorted
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(f64::INFINITY, max_qty)
+            .execute()
+            .into_sorted_vec();
+        let sorted_stats = crate::results::exact_query_stats::snapshot();
+
+        let summarized = Tree::builder()
+            .with_embedded_min_item_shifted_summary::<1>()
+            .with_serial_construction()
+            .build_from_entries(&entries)
+            .unwrap();
+        crate::results::exact_query_stats::reset();
+        let actual = summarized
+            .query(&query)
+            .best_n_within::<SquaredEuclidean<f64>>(f64::INFINITY, max_qty)
+            .execute()
+            .into_sorted_vec();
+        let summary_stats = crate::results::exact_query_stats::snapshot();
+
+        assert_eq!(actual, expected);
+        assert!(summary_stats.item_summary_subtrees_pruned > 0);
+        assert!(summary_stats.item_summary_lanes_rejected > 0);
+        assert!(summary_stats.leaf_visits < sorted_stats.leaf_visits);
+    }
+
+    #[cfg(feature = "test_utils")]
+    #[test]
+    fn embedded_summaries_are_not_checked_until_results_are_full() {
+        type Tree = KdTree<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 1>, 3, 1>;
+        let entries = (0..64u32)
+            .map(|item| (item, [item as f64, item as f64, item as f64]))
+            .collect::<Vec<_>>();
+        let tree = Tree::builder()
+            .with_embedded_min_item_shifted_summary::<1>()
+            .with_serial_construction()
+            .build_from_entries(&entries)
+            .unwrap();
+
+        crate::results::exact_query_stats::reset();
+        let results = tree
+            .query(&[0.0, 0.0, 0.0])
+            .best_n_within::<SquaredEuclidean<f64>>(0.0, NonZeroUsize::new(7).unwrap())
+            .execute();
+        let stats = crate::results::exact_query_stats::snapshot();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(stats.item_summary_blocks_checked, 0);
+        assert_eq!(stats.item_summary_lanes_rejected, 0);
+        assert_eq!(stats.item_summary_subtrees_pruned, 0);
+    }
+
+    #[test]
+    fn best_n_within_item_sorted_leaves_matches_ordinary_kernels() {
+        type FlatTree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 8>, 2, 8>;
+        type ArenaTree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 8>, 2, 8>;
+
+        let entries = (0..97u32)
+            .map(|idx| {
+                (
+                    (idx * 37) % 97,
+                    [((idx * 19) % 101) as f64, ((idx * 43) % 103) as f64],
+                )
+            })
+            .collect::<Vec<_>>();
+        let query = [50.0, 50.0];
+        let radius = 20_000.0;
+        let max_qty = NonZeroUsize::new(7).unwrap();
+
+        macro_rules! assert_sorted_matches {
+            ($tree:ty) => {{
+                let ordinary = <$tree>::builder()
+                    .with_serial_construction()
+                    .build_from_entries(&entries)
+                    .unwrap();
+                let item_sorted = <$tree>::builder()
+                    .with_serial_construction()
+                    .with_item_sorted_leaves()
+                    .build_from_entries(&entries)
+                    .unwrap();
+
+                let ordinary_results = ordinary
+                    .query(&query)
+                    .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+                    .execute()
+                    .into_sorted_vec();
+                let sorted_results = item_sorted
+                    .query(&query)
+                    .best_n_within::<SquaredEuclidean<f64>>(radius, max_qty)
+                    .execute()
+                    .into_sorted_vec();
+
+                assert_eq!(sorted_results, ordinary_results);
+                assert_eq!(
+                    sorted_results
+                        .iter()
+                        .map(|result| result.item)
+                        .collect::<Vec<_>>(),
+                    vec![0, 1, 2, 3, 4, 5, 6]
+                );
+            }};
+        }
+
+        assert_sorted_matches!(FlatTree);
+        assert_sorted_matches!(ArenaTree);
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+    #[test]
+    fn best_n_within_item_sorted_avx512_matches_ordinary_for_all_tail_widths() {
+        macro_rules! assert_avx512_sorted_matches {
+            ($axis:ty, $leaf:ident) => {{
+                type Tree = KdTree<$axis, u32, Eytzinger, $leaf<$axis, u32, 3, 32>, 3, 32>;
+
+                let assert_results = |actual: &[BestQueryResultItem<(), u32, $axis>],
+                                      expected: &[BestQueryResultItem<(), u32, $axis>],
+                                      context: &str| {
+                    assert_eq!(actual.len(), expected.len(), "{context}");
+                    for (actual, expected) in actual.iter().zip(expected) {
+                        assert_eq!(actual.item, expected.item, "{context}");
+                        let tolerance = (16.0 as $axis)
+                            * <$axis>::EPSILON
+                            * expected.distance.abs().max(1.0 as $axis);
+                        assert!(
+                            (actual.distance - expected.distance).abs() <= tolerance,
+                            "{context}: actual={actual:?} expected={expected:?}"
+                        );
+                    }
+                };
+
+                for len in [
+                    1usize, 2, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 40, 47, 64, 65,
+                ] {
+                    let entries = (0..len)
+                        .map(|idx| {
+                            (
+                                (len - idx - 1) as u32,
+                                [
+                                    ((idx * 19) % 101) as $axis / 101.0,
+                                    ((idx * 43) % 103) as $axis / 103.0,
+                                    ((idx * 61) % 107) as $axis / 107.0,
+                                ],
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    let ordinary = Tree::builder()
+                        .with_serial_construction()
+                        .build_from_entries(&entries)
+                        .unwrap();
+                    let item_sorted = Tree::builder()
+                        .with_serial_construction()
+                        .with_item_sorted_leaves()
+                        .build_from_entries(&entries)
+                        .unwrap();
+                    let query = [0.42 as $axis, 0.53 as $axis, 0.61 as $axis];
+                    let radius = 0.25 as $axis;
+                    let max_qty = NonZeroUsize::new(5).unwrap();
+
+                    let expected = ordinary
+                        .query(&query)
+                        .best_n_within::<SquaredEuclidean<$axis>>(radius, max_qty)
+                        .execute()
+                        .into_sorted_vec();
+                    let actual = item_sorted
+                        .query(&query)
+                        .best_n_within::<SquaredEuclidean<$axis>>(radius, max_qty)
+                        .execute()
+                        .into_sorted_vec();
+                    assert_results(&actual, &expected, &format!("inclusive len={len}"));
+
+                    let expected = ordinary
+                        .query(&query)
+                        .best_n_within::<SquaredEuclidean<$axis>>(radius, max_qty)
+                        .exclusive_boundaries()
+                        .execute()
+                        .into_sorted_vec();
+                    let actual = item_sorted
+                        .query(&query)
+                        .best_n_within::<SquaredEuclidean<$axis>>(radius, max_qty)
+                        .exclusive_boundaries()
+                        .execute()
+                        .into_sorted_vec();
+                    assert_results(&actual, &expected, &format!("exclusive len={len}"));
+                }
+            }};
+        }
+
+        assert_avx512_sorted_matches!(f64, FlatVec);
+        assert_avx512_sorted_matches!(f64, VecOfArenas);
+        assert_avx512_sorted_matches!(f32, FlatVec);
+        assert_avx512_sorted_matches!(f32, VecOfArenas);
+    }
 
     #[test]
     fn best_n_within_exclusive_boundaries_exclude_exact_threshold_matches() {

--- a/src/kd_tree/query/builder.rs
+++ b/src/kd_tree/query/builder.rs
@@ -585,8 +585,8 @@ where
         SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K>;
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> QueryBuilderTreeOps<A, T, SS, LS, K, B>
-    for KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    QueryBuilderTreeOps<A, T, SS, LS, K, B> for KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content,
@@ -746,8 +746,8 @@ where
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> QueryBuilderScratchTreeOps<A, T, SS, LS, K, B>
-    for KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    QueryBuilderScratchTreeOps<A, T, SS, LS, K, B> for KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content,
@@ -891,9 +891,9 @@ where
 }
 
 #[cfg(feature = "rkyv_08")]
-impl<A, T, SS, LS, const K: usize, const B: usize>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
     QueryBuilderTreeOps<A, T, SS, rkyv_08::Archived<LS>, K, B>
-    for ArchivedKdTree<A, T, SS, LS, K, B>
+    for ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A> + 'static,
     T: Content + PartialOrd + PartialEq,
@@ -1055,9 +1055,9 @@ where
 }
 
 #[cfg(feature = "rkyv_08")]
-impl<A, T, SS, LS, const K: usize, const B: usize>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
     QueryBuilderScratchTreeOps<A, T, SS, rkyv_08::Archived<LS>, K, B>
-    for ArchivedKdTree<A, T, SS, LS, K, B>
+    for ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A> + 'static,
     T: Content + PartialOrd + PartialEq,
@@ -2384,7 +2384,8 @@ where
         .collect()
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A>,
     T: Content,
@@ -2510,7 +2511,8 @@ where
 }
 
 #[cfg(feature = "rkyv_08")]
-impl<A, T, SS, LS, const K: usize, const B: usize> ArchivedKdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A>,
     T: Content,

--- a/src/kd_tree/query/nearest_n.rs
+++ b/src/kd_tree/query/nearest_n.rs
@@ -8,7 +8,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 };
 use crate::{Axis, Content, KdTree, LeafStrategy, QueryResultItem, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content + PartialOrd,

--- a/src/kd_tree/query/nearest_n_within.rs
+++ b/src/kd_tree/query/nearest_n_within.rs
@@ -28,7 +28,8 @@ const MAX_SORTED_VEC_RESULT_SIZE: usize = 192;
 #[cfg(not(feature = "small_n_result_collectors"))]
 const MAX_UNSORTED_VEC_RESULT_SIZE: usize = 24;
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content + PartialOrd,

--- a/src/kd_tree/query/nearest_one.rs
+++ b/src/kd_tree/query/nearest_one.rs
@@ -10,7 +10,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 use crate::traits::leaf_strategy::LeafProjection;
 use crate::{Axis, Content, KdTree, LeafStrategy, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content,

--- a/src/kd_tree/query/within.rs
+++ b/src/kd_tree/query/within.rs
@@ -8,7 +8,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 };
 use crate::{Axis, Content, KdTree, LeafStrategy, QueryResultItem, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content + PartialOrd,

--- a/src/kd_tree/query/within_unsorted.rs
+++ b/src/kd_tree/query/within_unsorted.rs
@@ -13,7 +13,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 use crate::traits::leaf_strategy::LeafProjection;
 use crate::{Axis, Content, KdTree, LeafStrategy, QueryResultItem, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: Axis<Coord = A> + 'static,
     T: Content + PartialOrd,

--- a/src/kd_tree/query_context.rs
+++ b/src/kd_tree/query_context.rs
@@ -4,6 +4,12 @@
 /// the query point and track the maximum distance for branch pruning during
 /// backtracking search.
 pub trait QueryContext<A, O, const K: usize> {
+    /// Whether this query instantiation consumes embedded item summaries.
+    /// This associated constant lets monomorphisation remove every summary
+    /// check from other query kinds and item-leaf modes.
+    #[doc(hidden)]
+    const USES_EMBEDDED_ITEM_SUMMARY: bool = false;
+
     /// Returns the query point coordinates.
     fn query(&self) -> &[A; K];
 
@@ -31,5 +37,13 @@ pub trait QueryContext<A, O, const K: usize> {
     #[inline]
     fn prune_on_equal_max_dist(&self) -> bool {
         false
+    }
+
+    /// Current encoded-summary filter for item-based subtree pruning. Summary
+    /// queries keep this disabled until their result collection is full.
+    #[doc(hidden)]
+    #[inline(always)]
+    fn embedded_item_summary_filter(&self) -> crate::kd_tree::item_summary::ItemSummaryFilter {
+        crate::kd_tree::item_summary::ItemSummaryFilter::disabled()
     }
 }

--- a/src/leaf_view_chunked/best_n_within/avx512.rs
+++ b/src/leaf_view_chunked/best_n_within/avx512.rs
@@ -32,6 +32,37 @@ pub(crate) unsafe fn best_n_within_avx512_unchecked<
 }
 
 #[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_unchecked<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f64, T, K, B>,
+    query: &[f64; K],
+    max_dist: f64,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f64, T) -> Option<T>,
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::avx512::best_n_within_item_sorted_avx512_unchecked::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+        B,
+    >(leaf, query, max_dist, threshold_item, &mut emit_positioned)
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
 pub(crate) unsafe fn best_n_within_avx512_arena_unchecked<
     L,
     T,
@@ -57,6 +88,43 @@ pub(crate) unsafe fn best_n_within_avx512_arena_unchecked<
         EXCLUSIVE,
         K,
     >(tile_base, len, query, max_dist, &mut emit_positioned);
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_arena_unchecked<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f64; K],
+    max_dist: f64,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f64, T) -> Option<T>,
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::avx512::best_n_within_item_sorted_avx512_arena_unchecked::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+    >(
+        tile_base,
+        len,
+        query,
+        max_dist,
+        threshold_item,
+        &mut emit_positioned,
+    )
 }
 
 #[target_feature(enable = "avx512f,avx512vl,fma")]
@@ -89,6 +157,37 @@ pub(crate) unsafe fn best_n_within_avx512_unchecked_f32<
 }
 
 #[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f32, T, K, B>,
+    query: &[f32; K],
+    max_dist: f32,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f32, T) -> Option<T>,
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::avx512::best_n_within_item_sorted_avx512_unchecked_f32::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+        B,
+    >(leaf, query, max_dist, threshold_item, &mut emit_positioned)
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
 pub(crate) unsafe fn best_n_within_avx512_arena_unchecked_f32<
     L,
     T,
@@ -114,4 +213,41 @@ pub(crate) unsafe fn best_n_within_avx512_arena_unchecked_f32<
         EXCLUSIVE,
         K,
     >(tile_base, len, query, max_dist, &mut emit_positioned);
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_arena_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f32; K],
+    max_dist: f32,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f32, T) -> Option<T>,
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::avx512::best_n_within_item_sorted_avx512_arena_unchecked_f32::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+    >(
+        tile_base,
+        len,
+        query,
+        max_dist,
+        threshold_item,
+        &mut emit_positioned,
+    )
 }

--- a/src/leaf_view_chunked/best_n_within/fallback.rs
+++ b/src/leaf_view_chunked/best_n_within/fallback.rs
@@ -102,3 +102,252 @@ pub(crate) fn best_n_within_with_query_wide_arena_fallback<
         }
     });
 }
+
+#[inline(always)]
+pub(crate) fn best_n_within_with_query_wide_item_sorted_fallback<
+    AX,
+    T,
+    D,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, AX, T, K, B>,
+    query_wide: &[D::Output; K],
+    dist: D::Output,
+    results: &mut R,
+) where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content + PartialOrd,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+    R: BestNeighbourResultCollection<D::Output, T>,
+{
+    let points = leaf.points();
+    let items = leaf.items();
+    let mut idx = 0usize;
+
+    while idx < items.len() {
+        let item = unsafe { *items.get_unchecked(idx) };
+        if results
+            .threshold_item()
+            .is_some_and(|worst_item| item >= worst_item)
+        {
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_best_item_threshold_reject();
+            break;
+        }
+
+        let mut candidate_dist = D::Output::zero();
+        for dim in 0..K {
+            let coord = unsafe { *points.get_unchecked(dim).get_unchecked(idx) };
+            D::combine_component(
+                &mut candidate_dist,
+                D::dist1(D::widen_coord(coord), unsafe {
+                    *query_wide.get_unchecked(dim)
+                }),
+            );
+        }
+
+        let is_within_dist = if EXCLUSIVE {
+            candidate_dist < dist
+        } else {
+            candidate_dist <= dist
+        };
+        if is_within_dist {
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_candidate_emitted();
+            results.add(BestQueryResultItem {
+                point: (),
+                distance: candidate_dist,
+                item,
+            });
+        }
+
+        idx += 1;
+    }
+}
+
+#[inline(always)]
+pub(crate) fn best_n_within_with_query_wide_arena_item_sorted_fallback<
+    AX,
+    T,
+    D,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    arena: &LeafArena<'_, AX, T, K>,
+    query_wide: &[D::Output; K],
+    dist: D::Output,
+    results: &mut R,
+) where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content + PartialOrd,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+    R: BestNeighbourResultCollection<D::Output, T>,
+{
+    let mut finished = false;
+
+    arena.for_each_tiled_chunk(|tile| {
+        if finished {
+            return;
+        }
+
+        let mut idx = 0usize;
+        while idx < tile.len() {
+            let item = unsafe { tile.item_unaligned(idx) };
+            if results
+                .threshold_item()
+                .is_some_and(|worst_item| item >= worst_item)
+            {
+                #[cfg(feature = "result_collection_stats")]
+                crate::results::result_collection_stats::record_best_item_threshold_reject();
+                finished = true;
+                break;
+            }
+
+            let mut candidate_dist = D::Output::zero();
+            for dim in 0..K {
+                let coord = unsafe { tile.point_unaligned(dim, idx) };
+                D::combine_component(
+                    &mut candidate_dist,
+                    D::dist1(D::widen_coord(coord), unsafe {
+                        *query_wide.get_unchecked(dim)
+                    }),
+                );
+            }
+
+            let is_within_dist = if EXCLUSIVE {
+                candidate_dist < dist
+            } else {
+                candidate_dist <= dist
+            };
+            if is_within_dist {
+                #[cfg(feature = "result_collection_stats")]
+                crate::results::result_collection_stats::record_candidate_emitted();
+                results.add(BestQueryResultItem {
+                    point: (),
+                    distance: candidate_dist,
+                    item,
+                });
+            }
+
+            idx += 1;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+    use crate::dist::SquaredEuclidean;
+    use crate::results::result_collection::ResultCollection;
+
+    struct FixedItemThresholdResults {
+        threshold_calls: Cell<usize>,
+        added: Vec<BestQueryResultItem<(), u32, f64>>,
+    }
+
+    impl ResultCollection<f64, BestQueryResultItem<(), u32, f64>> for FixedItemThresholdResults {
+        fn with_max_qty(_max_qty: usize) -> Self {
+            Self {
+                threshold_calls: Cell::new(0),
+                added: Vec::new(),
+            }
+        }
+
+        fn max_qty(&self) -> usize {
+            1
+        }
+
+        fn len(&self) -> usize {
+            self.added.len()
+        }
+
+        fn add(&mut self, entry: BestQueryResultItem<(), u32, f64>) {
+            self.added.push(entry);
+        }
+
+        fn threshold_distance(&self) -> Option<f64> {
+            None
+        }
+
+        fn into_vec(self) -> Vec<BestQueryResultItem<(), u32, f64>> {
+            self.added
+        }
+
+        fn into_sorted_vec(self) -> Vec<BestQueryResultItem<(), u32, f64>> {
+            self.added
+        }
+    }
+
+    impl BestNeighbourResultCollection<f64, u32> for FixedItemThresholdResults {
+        fn threshold_item(&self) -> Option<u32> {
+            self.threshold_calls.set(self.threshold_calls.get() + 1);
+            Some(2)
+        }
+    }
+
+    fn new_fixed_threshold_results() -> FixedItemThresholdResults {
+        FixedItemThresholdResults::with_max_qty(1)
+    }
+
+    #[test]
+    fn item_sorted_leaf_view_kernel_stops_at_current_worst_item() {
+        let points = [[0.0f64, 1.0, 2.0, 3.0]];
+        let items = [1u32, 2, 3, 4];
+        let leaf = LeafView::<f64, u32, 1, 8>::new([&points[0]], &items);
+        let mut results = new_fixed_threshold_results();
+
+        best_n_within_with_query_wide_item_sorted_fallback::<
+            f64,
+            u32,
+            SquaredEuclidean<f64>,
+            _,
+            false,
+            1,
+            8,
+        >(&leaf, &[0.0], f64::MAX, &mut results);
+
+        assert_eq!(results.threshold_calls.get(), 2);
+        assert_eq!(results.added.len(), 1);
+        assert_eq!(results.added[0].item, 1);
+    }
+
+    #[test]
+    fn item_sorted_leaf_arena_kernel_stops_at_current_worst_item() {
+        let points = [0.0f64, 1.0, 2.0, 3.0];
+        let items = [1u32, 2, 3, 4];
+        let mut bytes = Vec::new();
+        unsafe {
+            bytes.extend_from_slice(std::slice::from_raw_parts(
+                points.as_ptr().cast::<u8>(),
+                std::mem::size_of_val(&points),
+            ));
+            bytes.extend_from_slice(std::slice::from_raw_parts(
+                items.as_ptr().cast::<u8>(),
+                std::mem::size_of_val(&items),
+            ));
+        }
+        let arena = LeafArena::<f64, u32, 1>::new(bytes.as_ptr(), items.len());
+        let mut results = new_fixed_threshold_results();
+
+        best_n_within_with_query_wide_arena_item_sorted_fallback::<
+            f64,
+            u32,
+            SquaredEuclidean<f64>,
+            _,
+            false,
+            1,
+        >(&arena, &[0.0], f64::MAX, &mut results);
+
+        assert_eq!(results.threshold_calls.get(), 2);
+        assert_eq!(results.added.len(), 1);
+        assert_eq!(results.added[0].item, 1);
+    }
+}

--- a/src/leaf_view_chunked/best_n_within/mod.rs
+++ b/src/leaf_view_chunked/best_n_within/mod.rs
@@ -13,12 +13,15 @@ pub(crate) mod neon;
 pub(crate) mod wasm_simd;
 
 use crate::dist::DistanceMetric;
+use crate::kd_tree::ITEM_LEAF_MODE_UNSORTED;
 use crate::leaf_view::{LeafArena, LeafView, TlsLeafScratch};
 use crate::results::result_collection::BestNeighbourResultCollection;
 use crate::{Axis, Content};
 
 pub(crate) use fallback::{
-    best_n_within_with_query_wide_arena_fallback, best_n_within_with_query_wide_fallback,
+    best_n_within_with_query_wide_arena_fallback,
+    best_n_within_with_query_wide_arena_item_sorted_fallback,
+    best_n_within_with_query_wide_fallback, best_n_within_with_query_wide_item_sorted_fallback,
 };
 
 #[inline(always)]
@@ -28,6 +31,7 @@ pub(crate) fn best_n_within_with_query_wide_arena<
     D,
     R,
     const EXCLUSIVE: bool,
+    const ITEM_LEAF_MODE: u8,
     const K: usize,
 >(
     arena: &LeafArena<'_, AX, T, K>,
@@ -44,7 +48,7 @@ pub(crate) fn best_n_within_with_query_wide_arena<
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
     if unsafe {
-        try_best_n_within_arena_avx512::<AX, T, D, R, EXCLUSIVE, K>(
+        try_best_n_within_arena_avx512::<AX, T, D, R, EXCLUSIVE, ITEM_LEAF_MODE, K>(
             arena,
             query_wide,
             dist,
@@ -52,6 +56,13 @@ pub(crate) fn best_n_within_with_query_wide_arena<
             results,
         )
     } {
+        return;
+    }
+
+    if ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED {
+        best_n_within_with_query_wide_arena_item_sorted_fallback::<AX, T, D, R, EXCLUSIVE, K>(
+            arena, query_wide, dist, results,
+        );
         return;
     }
 
@@ -110,6 +121,7 @@ pub(crate) fn best_n_within_with_query_wide<
     D,
     R,
     const EXCLUSIVE: bool,
+    const ITEM_LEAF_MODE: u8,
     const K: usize,
     const B: usize,
 >(
@@ -127,7 +139,7 @@ pub(crate) fn best_n_within_with_query_wide<
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
     if unsafe {
-        try_best_n_within_avx512::<AX, T, D, R, EXCLUSIVE, K, B>(
+        try_best_n_within_avx512::<AX, T, D, R, EXCLUSIVE, ITEM_LEAF_MODE, K, B>(
             leaf,
             query_wide,
             dist,
@@ -135,6 +147,13 @@ pub(crate) fn best_n_within_with_query_wide<
             results,
         )
     } {
+        return;
+    }
+
+    if ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED {
+        best_n_within_with_query_wide_item_sorted_fallback::<AX, T, D, R, EXCLUSIVE, K, B>(
+            leaf, query_wide, dist, results,
+        );
         return;
     }
 
@@ -194,6 +213,7 @@ unsafe fn try_best_n_within_avx512<
     D,
     R,
     const EXCLUSIVE: bool,
+    const ITEM_LEAF_MODE: u8,
     const K: usize,
     const B: usize,
 >(
@@ -210,7 +230,7 @@ where
     D::Output: Axis<Coord = D::Output> + 'static,
     R: BestNeighbourResultCollection<D::Output, T>,
 {
-    D::try_best_n_within_leaf_avx512::<T, R, EXCLUSIVE, K, B>(
+    D::try_best_n_within_leaf_avx512::<T, R, EXCLUSIVE, ITEM_LEAF_MODE, K, B>(
         leaf,
         query_wide,
         dist,
@@ -221,7 +241,15 @@ where
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
 #[inline(always)]
-unsafe fn try_best_n_within_arena_avx512<AX, T, D, R, const EXCLUSIVE: bool, const K: usize>(
+unsafe fn try_best_n_within_arena_avx512<
+    AX,
+    T,
+    D,
+    R,
+    const EXCLUSIVE: bool,
+    const ITEM_LEAF_MODE: u8,
+    const K: usize,
+>(
     arena: &LeafArena<'_, AX, T, K>,
     query_wide: &[D::Output; K],
     dist: D::Output,
@@ -235,7 +263,7 @@ where
     D::Output: Axis<Coord = D::Output> + 'static,
     R: BestNeighbourResultCollection<D::Output, T>,
 {
-    D::try_best_n_within_arena_avx512::<T, R, EXCLUSIVE, K>(
+    D::try_best_n_within_arena_avx512::<T, R, EXCLUSIVE, ITEM_LEAF_MODE, K>(
         arena,
         query_wide,
         dist,

--- a/src/leaf_view_chunked/nearest_n_within/avx512.rs
+++ b/src/leaf_view_chunked/nearest_n_within/avx512.rs
@@ -203,6 +203,244 @@ where
     dist
 }
 
+#[inline(always)]
+unsafe fn item_sorted_line_can_start<T: Content + PartialOrd>(
+    items: *const T,
+    base: usize,
+    threshold_item: Option<T>,
+) -> bool {
+    let item = std::ptr::read_unaligned(items.add(base));
+    let can_start = !threshold_item.is_some_and(|worst_item| item >= worst_item);
+    if !can_start {
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        crate::results::exact_query_stats::record_item_sorted_threshold_stop();
+        #[cfg(feature = "result_collection_stats")]
+        crate::results::result_collection_stats::record_best_item_threshold_reject();
+    }
+    can_start
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_f64<T, F>(
+    mut remaining: u32,
+    dist_values: &[f64],
+    items: *const T,
+    base: usize,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    while remaining != 0 {
+        let lane = remaining.trailing_zeros() as usize;
+        let item = std::ptr::read_unaligned(items.add(base + lane));
+        if threshold_item.is_some_and(|worst_item| item >= worst_item) {
+            #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+            crate::results::exact_query_stats::record_item_sorted_threshold_stop();
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_best_item_threshold_reject();
+            return false;
+        }
+
+        *threshold_item = emit(base + lane, *dist_values.get_unchecked(lane), item);
+        remaining &= remaining - 1;
+    }
+    true
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_avx512<T, F, const EXCLUSIVE: bool>(
+    dists: __m512d,
+    items: *const T,
+    base: usize,
+    max_dist: f64,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    let mask = if EXCLUSIVE {
+        _mm512_cmp_pd_mask(dists, _mm512_set1_pd(max_dist), _CMP_LT_OQ)
+    } else {
+        _mm512_cmp_pd_mask(dists, _mm512_set1_pd(max_dist), _CMP_LE_OQ)
+    };
+    if mask == 0 {
+        return true;
+    }
+
+    let mut dist_values = [0.0f64; LINE_SIZE];
+    _mm512_storeu_pd(dist_values.as_mut_ptr(), dists);
+    emit_item_sorted_results_f64(mask as u32, &dist_values, items, base, threshold_item, emit)
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_avx2<T, F, const EXCLUSIVE: bool>(
+    dists: __m256d,
+    items: *const T,
+    base: usize,
+    max_dist: f64,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    let mask = if EXCLUSIVE {
+        _mm256_movemask_pd(_mm256_cmp_pd(dists, _mm256_set1_pd(max_dist), _CMP_LT_OQ)) as u8
+    } else {
+        _mm256_movemask_pd(_mm256_cmp_pd(dists, _mm256_set1_pd(max_dist), _CMP_LE_OQ)) as u8
+    };
+    if mask == 0 {
+        return true;
+    }
+
+    let mut dist_values = [0.0f64; AVX2_LINE_SIZE];
+    _mm256_storeu_pd(dist_values.as_mut_ptr(), dists);
+    emit_item_sorted_results_f64(mask as u32, &dist_values, items, base, threshold_item, emit)
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_avx128<T, F, const EXCLUSIVE: bool>(
+    dists: __m128d,
+    items: *const T,
+    base: usize,
+    max_dist: f64,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    let mask = _mm_movemask_pd(if EXCLUSIVE {
+        _mm_cmplt_pd(dists, _mm_set1_pd(max_dist))
+    } else {
+        _mm_cmple_pd(dists, _mm_set1_pd(max_dist))
+    }) as u8;
+    if mask == 0 {
+        return true;
+    }
+
+    let mut dist_values = [0.0f64; 2];
+    _mm_storeu_pd(dist_values.as_mut_ptr(), dists);
+    emit_item_sorted_results_f64(mask as u32, &dist_values, items, base, threshold_item, emit)
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+unsafe fn best_n_within_item_sorted_avx512_raw<L, T, F, const EXCLUSIVE: bool, const K: usize>(
+    points: [*const f64; K],
+    items: *const T,
+    len: usize,
+    query: &[f64; K],
+    max_dist: f64,
+    mut threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    if len == 0 {
+        return (threshold_item, false);
+    }
+
+    let query_512 = array_init(|dim| _mm512_set1_pd(query[dim]));
+    let query_256 = array_init(|dim| _mm256_set1_pd(query[dim]));
+    let query_128 = array_init(|dim| _mm_set1_pd(query[dim]));
+    let mut base = 0usize;
+
+    while base + LINE_SIZE <= len {
+        if !item_sorted_line_can_start(items, base, threshold_item) {
+            return (threshold_item, true);
+        }
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        crate::results::exact_query_stats::record_leaf_items_distance_evaluated(LINE_SIZE);
+        let dists = line_dists_avx512::<L, K>(&points, &query_512, base);
+        if !emit_item_sorted_results_avx512::<_, _, EXCLUSIVE>(
+            dists,
+            items,
+            base,
+            max_dist,
+            &mut threshold_item,
+            emit,
+        ) {
+            return (threshold_item, true);
+        }
+        base += LINE_SIZE;
+    }
+
+    if base + AVX2_LINE_SIZE <= len {
+        if !item_sorted_line_can_start(items, base, threshold_item) {
+            return (threshold_item, true);
+        }
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        crate::results::exact_query_stats::record_leaf_items_distance_evaluated(AVX2_LINE_SIZE);
+        let dists = line_dists_avx2::<L, K>(&points, &query_256, base);
+        if !emit_item_sorted_results_avx2::<_, _, EXCLUSIVE>(
+            dists,
+            items,
+            base,
+            max_dist,
+            &mut threshold_item,
+            emit,
+        ) {
+            return (threshold_item, true);
+        }
+        base += AVX2_LINE_SIZE;
+    }
+
+    if base + 2 <= len {
+        if !item_sorted_line_can_start(items, base, threshold_item) {
+            return (threshold_item, true);
+        }
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        crate::results::exact_query_stats::record_leaf_items_distance_evaluated(2);
+        let dists = line_dists_avx128::<L, K>(&points, &query_128, base);
+        if !emit_item_sorted_results_avx128::<_, _, EXCLUSIVE>(
+            dists,
+            items,
+            base,
+            max_dist,
+            &mut threshold_item,
+            emit,
+        ) {
+            return (threshold_item, true);
+        }
+        base += 2;
+    }
+
+    while base < len {
+        let item = std::ptr::read_unaligned(items.add(base));
+        if threshold_item.is_some_and(|worst_item| item >= worst_item) {
+            #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+            crate::results::exact_query_stats::record_item_sorted_threshold_stop();
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_best_item_threshold_reject();
+            return (threshold_item, true);
+        }
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        crate::results::exact_query_stats::record_leaf_items_distance_evaluated(1);
+        let dist = dist_scalar::<L, K>(&points, query, base);
+        let is_within_dist = if EXCLUSIVE {
+            dist < max_dist
+        } else {
+            dist <= max_dist
+        };
+        if is_within_dist {
+            threshold_item = emit(base, dist, item);
+        }
+        base += 1;
+    }
+
+    (threshold_item, false)
+}
+
 #[target_feature(enable = "avx512f,avx512vl,fma")]
 unsafe fn nearest_n_within_avx512_raw<L, T, F, const EXCLUSIVE: bool, const K: usize>(
     points: [*const f64; K],
@@ -329,6 +567,73 @@ pub(crate) unsafe fn nearest_n_within_avx512_arena_unchecked<
     nearest_n_within_avx512_raw::<L, T, F, EXCLUSIVE, K>(
         point_ptrs, items, len, query, max_dist, emit,
     );
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_unchecked<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f64, T, K, B>,
+    query: &[f64; K],
+    max_dist: f64,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    let points = leaf.points();
+    let point_ptrs = array_init(|dim| points[dim].as_ptr());
+    best_n_within_item_sorted_avx512_raw::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs,
+        leaf.items().as_ptr(),
+        leaf.items().len(),
+        query,
+        max_dist,
+        threshold_item,
+        emit,
+    )
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_arena_unchecked<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f64; K],
+    max_dist: f64,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(usize, f64, T) -> Option<T>,
+{
+    let point_base = tile_base as *const f64;
+    let point_ptrs = array_init(|dim| point_base.add(dim * len));
+    let items = tile_base.add(K * len * std::mem::size_of::<f64>()) as *const T;
+    best_n_within_item_sorted_avx512_raw::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs,
+        items,
+        len,
+        query,
+        max_dist,
+        threshold_item,
+        emit,
+    )
 }
 
 #[inline(always)]
@@ -518,6 +823,215 @@ where
     dist
 }
 
+#[inline(always)]
+unsafe fn emit_item_sorted_results_f32<T, F>(
+    mut remaining: u32,
+    dist_values: &[f32],
+    items: *const T,
+    base: usize,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    while remaining != 0 {
+        let lane = remaining.trailing_zeros() as usize;
+        let item = std::ptr::read_unaligned(items.add(base + lane));
+        if threshold_item.is_some_and(|worst_item| item >= worst_item) {
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_best_item_threshold_reject();
+            return false;
+        }
+
+        *threshold_item = emit(base + lane, *dist_values.get_unchecked(lane), item);
+        remaining &= remaining - 1;
+    }
+    true
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_avx512_f32<T, F, const EXCLUSIVE: bool>(
+    dists: __m512,
+    items: *const T,
+    base: usize,
+    max_dist: f32,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    let mask = if EXCLUSIVE {
+        _mm512_cmp_ps_mask(dists, _mm512_set1_ps(max_dist), _CMP_LT_OQ)
+    } else {
+        _mm512_cmp_ps_mask(dists, _mm512_set1_ps(max_dist), _CMP_LE_OQ)
+    };
+    if mask == 0 {
+        return true;
+    }
+
+    let mut dist_values = [0.0f32; LINE_SIZE_F32];
+    _mm512_storeu_ps(dist_values.as_mut_ptr(), dists);
+    emit_item_sorted_results_f32(mask as u32, &dist_values, items, base, threshold_item, emit)
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_avx2_f32<T, F, const EXCLUSIVE: bool>(
+    dists: __m256,
+    items: *const T,
+    base: usize,
+    max_dist: f32,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    let mask = if EXCLUSIVE {
+        _mm256_movemask_ps(_mm256_cmp_ps(dists, _mm256_set1_ps(max_dist), _CMP_LT_OQ)) as u8
+    } else {
+        _mm256_movemask_ps(_mm256_cmp_ps(dists, _mm256_set1_ps(max_dist), _CMP_LE_OQ)) as u8
+    };
+    if mask == 0 {
+        return true;
+    }
+
+    let mut dist_values = [0.0f32; AVX2_LINE_SIZE_F32];
+    _mm256_storeu_ps(dist_values.as_mut_ptr(), dists);
+    emit_item_sorted_results_f32(mask as u32, &dist_values, items, base, threshold_item, emit)
+}
+
+#[inline(always)]
+unsafe fn emit_item_sorted_results_avx128_f32<T, F, const EXCLUSIVE: bool>(
+    dists: __m128,
+    items: *const T,
+    base: usize,
+    max_dist: f32,
+    threshold_item: &mut Option<T>,
+    emit: &mut F,
+) -> bool
+where
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    let mask = if EXCLUSIVE {
+        _mm_movemask_ps(_mm_cmp_ps(dists, _mm_set1_ps(max_dist), _CMP_LT_OQ)) as u8
+    } else {
+        _mm_movemask_ps(_mm_cmp_ps(dists, _mm_set1_ps(max_dist), _CMP_LE_OQ)) as u8
+    };
+    if mask == 0 {
+        return true;
+    }
+
+    let mut dist_values = [0.0f32; SSE_LINE_SIZE_F32];
+    _mm_storeu_ps(dist_values.as_mut_ptr(), dists);
+    emit_item_sorted_results_f32(mask as u32, &dist_values, items, base, threshold_item, emit)
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+unsafe fn best_n_within_item_sorted_avx512_raw_f32<L, T, F, const EXCLUSIVE: bool, const K: usize>(
+    points: [*const f32; K],
+    items: *const T,
+    len: usize,
+    query: &[f32; K],
+    max_dist: f32,
+    mut threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    if len == 0 {
+        return (threshold_item, false);
+    }
+
+    let query_512 = array_init(|dim| _mm512_set1_ps(query[dim]));
+    let query_256 = array_init(|dim| _mm256_set1_ps(query[dim]));
+    let query_128 = array_init(|dim| _mm_set1_ps(query[dim]));
+    let mut base = 0usize;
+
+    while base + LINE_SIZE_F32 <= len {
+        if !item_sorted_line_can_start(items, base, threshold_item) {
+            return (threshold_item, true);
+        }
+        let dists = line_dists_avx512_f32::<L, K>(&points, &query_512, base);
+        if !emit_item_sorted_results_avx512_f32::<_, _, EXCLUSIVE>(
+            dists,
+            items,
+            base,
+            max_dist,
+            &mut threshold_item,
+            emit,
+        ) {
+            return (threshold_item, true);
+        }
+        base += LINE_SIZE_F32;
+    }
+
+    if base + AVX2_LINE_SIZE_F32 <= len {
+        if !item_sorted_line_can_start(items, base, threshold_item) {
+            return (threshold_item, true);
+        }
+        let dists = line_dists_avx2_f32::<L, K>(&points, &query_256, base);
+        if !emit_item_sorted_results_avx2_f32::<_, _, EXCLUSIVE>(
+            dists,
+            items,
+            base,
+            max_dist,
+            &mut threshold_item,
+            emit,
+        ) {
+            return (threshold_item, true);
+        }
+        base += AVX2_LINE_SIZE_F32;
+    }
+
+    if base + SSE_LINE_SIZE_F32 <= len {
+        if !item_sorted_line_can_start(items, base, threshold_item) {
+            return (threshold_item, true);
+        }
+        let dists = line_dists_avx128_f32::<L, K>(&points, &query_128, base);
+        if !emit_item_sorted_results_avx128_f32::<_, _, EXCLUSIVE>(
+            dists,
+            items,
+            base,
+            max_dist,
+            &mut threshold_item,
+            emit,
+        ) {
+            return (threshold_item, true);
+        }
+        base += SSE_LINE_SIZE_F32;
+    }
+
+    while base < len {
+        let item = std::ptr::read_unaligned(items.add(base));
+        if threshold_item.is_some_and(|worst_item| item >= worst_item) {
+            #[cfg(feature = "result_collection_stats")]
+            crate::results::result_collection_stats::record_best_item_threshold_reject();
+            return (threshold_item, true);
+        }
+        let dist = dist_scalar_f32::<L, K>(&points, query, base);
+        let is_within_dist = if EXCLUSIVE {
+            dist < max_dist
+        } else {
+            dist <= max_dist
+        };
+        if is_within_dist {
+            threshold_item = emit(base, dist, item);
+        }
+        base += 1;
+    }
+
+    (threshold_item, false)
+}
+
 #[target_feature(enable = "avx512f,avx512vl,fma")]
 unsafe fn nearest_n_within_avx512_raw_f32<L, T, F, const EXCLUSIVE: bool, const K: usize>(
     points: [*const f32; K],
@@ -655,4 +1169,129 @@ pub(crate) unsafe fn nearest_n_within_avx512_arena_unchecked_f32<
     nearest_n_within_avx512_raw_f32::<L, T, F, EXCLUSIVE, K>(
         point_ptrs, items, len, query, max_dist, emit,
     );
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f32, T, K, B>,
+    query: &[f32; K],
+    max_dist: f32,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    let points = leaf.points();
+    let point_ptrs = array_init(|dim| points[dim].as_ptr());
+    best_n_within_item_sorted_avx512_raw_f32::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs,
+        leaf.items().as_ptr(),
+        leaf.items().len(),
+        query,
+        max_dist,
+        threshold_item,
+        emit,
+    )
+}
+
+#[target_feature(enable = "avx512f,avx512vl,fma")]
+pub(crate) unsafe fn best_n_within_item_sorted_avx512_arena_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f32; K],
+    max_dist: f32,
+    threshold_item: Option<T>,
+    emit: &mut F,
+) -> (Option<T>, bool)
+where
+    L: Avx512F32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(usize, f32, T) -> Option<T>,
+{
+    let point_base = tile_base as *const f32;
+    let point_ptrs = array_init(|dim| point_base.add(dim * len));
+    let items = tile_base.add(K * len * std::mem::size_of::<f32>()) as *const T;
+    best_n_within_item_sorted_avx512_raw_f32::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs,
+        items,
+        len,
+        query,
+        max_dist,
+        threshold_item,
+        emit,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dist::{DistanceMetricAvx512, SquaredEuclidean};
+
+    #[test]
+    fn item_sorted_avx512_stops_inside_first_f64_line_at_item_threshold() {
+        type Ops = <SquaredEuclidean<f64> as DistanceMetricAvx512<f64>>::Avx512F64Ops;
+        let points = [(0..16).map(|idx| idx as f64).collect::<Vec<_>>()];
+        let items = (0..16u32).collect::<Vec<_>>();
+        let leaf = LeafView::<f64, u32, 1, 32>::new([&points[0]], &items);
+        let mut emitted = Vec::new();
+        let mut emit = |_, _distance, item| {
+            emitted.push(item);
+            Some(4)
+        };
+
+        let (_, stopped) = unsafe {
+            best_n_within_item_sorted_avx512_unchecked::<Ops, _, _, false, 1, 32>(
+                &leaf,
+                &[0.0],
+                f64::INFINITY,
+                Some(4),
+                &mut emit,
+            )
+        };
+
+        assert!(stopped);
+        assert_eq!(emitted, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn item_sorted_avx512_stops_inside_first_f32_line_at_item_threshold() {
+        type Ops = <SquaredEuclidean<f32> as DistanceMetricAvx512<f32>>::Avx512F32Ops;
+        let points = [(0..32).map(|idx| idx as f32).collect::<Vec<_>>()];
+        let items = (0..32u32).collect::<Vec<_>>();
+        let leaf = LeafView::<f32, u32, 1, 32>::new([&points[0]], &items);
+        let mut emitted = Vec::new();
+        let mut emit = |_, _distance, item| {
+            emitted.push(item);
+            Some(7)
+        };
+
+        let (_, stopped) = unsafe {
+            best_n_within_item_sorted_avx512_unchecked_f32::<Ops, _, _, false, 1, 32>(
+                &leaf,
+                &[0.0],
+                f32::INFINITY,
+                Some(7),
+                &mut emit,
+            )
+        };
+
+        assert!(stopped);
+        assert_eq!(emitted, vec![0, 1, 2, 3, 4, 5, 6]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,15 @@ mod custom_serde;
 
 pub mod kd_tree;
 #[doc(hidden)]
-pub type KdTree<A, T, SS, LS, const K: usize, const B: usize> = kd_tree::KdTree<A, T, SS, LS, K, B>;
+pub type KdTree<
+    A,
+    T,
+    SS,
+    LS,
+    const K: usize,
+    const B: usize,
+    const ITEM_LEAF_MODE: u8 = { kd_tree::ITEM_LEAF_MODE_UNSORTED },
+> = kd_tree::KdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>;
 #[cfg(feature = "exact_query_stats")]
 pub use kd_tree::query::tree::stats as tree_join_stats;
 pub use kd_tree::query::tree::{
@@ -265,7 +273,9 @@ pub use kd_tree::query::tree::{
 };
 #[cfg(feature = "multi-threaded")]
 pub use kd_tree::DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD;
-pub use kd_tree::{KdTreeBuilder, QueryScratch};
+pub use kd_tree::{
+    ItemLeafMode, KdTreeBuilder, QueryScratch, ITEM_LEAF_MODE_SORTED, ITEM_LEAF_MODE_UNSORTED,
+};
 
 /// Batch query execution: running many query points against one tree per call.
 pub mod batch {

--- a/src/results/exact_query_stats.rs
+++ b/src/results/exact_query_stats.rs
@@ -11,6 +11,9 @@ use std::cell::Cell;
 pub struct ExactQueryStats {
     pub queries: u64,
     pub leaf_visits: u64,
+    pub leaf_items_available: u64,
+    pub leaf_items_distance_evaluated: u64,
+    pub item_sorted_threshold_stops: u64,
     pub stem_steps: u64,
     pub real_pivot_steps: u64,
     pub padding_steps: u64,
@@ -31,6 +34,9 @@ pub struct ExactQueryStats {
     pub block3_step_entries: u64,
     pub block3_full_steps: u64,
     pub block3_scalar_fallback_steps: u64,
+    pub item_summary_blocks_checked: u64,
+    pub item_summary_lanes_rejected: u64,
+    pub item_summary_subtrees_pruned: u64,
 }
 
 thread_local! {
@@ -64,6 +70,21 @@ pub fn record_query() {
 #[inline]
 pub fn record_leaf_visit() {
     update(|stats| stats.leaf_visits += 1);
+}
+
+#[inline]
+pub fn record_leaf_items_available(len: usize) {
+    update(|stats| stats.leaf_items_available += len as u64);
+}
+
+#[inline]
+pub fn record_leaf_items_distance_evaluated(len: usize) {
+    update(|stats| stats.leaf_items_distance_evaluated += len as u64);
+}
+
+#[inline]
+pub fn record_item_sorted_threshold_stop() {
+    update(|stats| stats.item_sorted_threshold_stops += 1);
 }
 
 #[inline]
@@ -159,4 +180,17 @@ pub fn record_block3_scalar_fallback_step() {
 #[inline]
 pub fn record_block3_step_entry() {
     update(|stats| stats.block3_step_entries += 1);
+}
+
+#[inline]
+pub fn record_item_summary_block(mask: u8) {
+    update(|stats| {
+        stats.item_summary_blocks_checked += 1;
+        stats.item_summary_lanes_rejected += u64::from((!mask).count_ones());
+    });
+}
+
+#[inline]
+pub fn record_item_summary_subtree_prune() {
+    update(|stats| stats.item_summary_subtrees_pruned += 1);
 }

--- a/src/rkyv/query.rs
+++ b/src/rkyv/query.rs
@@ -5,7 +5,9 @@ use crate::dist::DistanceMetric;
 use crate::kd_tree::query_context::QueryContext;
 use crate::kd_tree::query_stack::StackTrait;
 use crate::kd_tree::KdTreeQueryOps;
-use crate::kd_tree::{ArchivedKdTree, KdTreeAccessor};
+use crate::kd_tree::{
+    ArchivedKdTree, KdTreeAccessor, ITEM_LEAF_MODE_SORTED, ITEM_LEAF_MODE_UNSORTED,
+};
 use crate::leaf_view::TlsLeafScratch;
 use crate::leaf_view_chunked::best_n_within::best_n_within_with_query_wide_arena;
 use crate::leaf_view_chunked::nearest_n_within::nearest_n_within_with_query_wide_arena;
@@ -22,7 +24,8 @@ use crate::stem_strategy::donnelly::simd_full::{
 use crate::traits::leaf_strategy::LeafProjection;
 use crate::{Axis, BestQueryResultItem, Content, LeafStrategy, QueryResultItem, StemStrategy};
 
-impl<A, T, SS, LS, const K: usize, const B: usize> ArchivedKdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A> + 'static,
     T: Content + PartialOrd + PartialEq,
@@ -150,7 +153,8 @@ where
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> ArchivedKdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A> + 'static,
     T: Content + PartialOrd,
@@ -647,7 +651,8 @@ where
     }
 }
 
-impl<A, T, SS, LS, const K: usize, const B: usize> ArchivedKdTree<A, T, SS, LS, K, B>
+impl<A, T, SS, LS, const K: usize, const B: usize, const ITEM_LEAF_MODE: u8>
+    ArchivedKdTree<A, T, SS, LS, K, B, ITEM_LEAF_MODE>
 where
     A: rkyv_08::Archive + Axis<Coord = A> + 'static,
     T: Content + PartialOrd,
@@ -656,7 +661,7 @@ where
     rkyv_08::Archived<LS>: LeafStrategy<A, T, SS, K, B>,
 {
     #[inline(always)]
-    fn process_leaf_best_n_within<D, R, const EXCLUSIVE: bool>(
+    fn process_leaf_best_n_within<D, R, const EXCLUSIVE: bool, const LEAF_MODE: u8>(
         &self,
         leaf_idx: usize,
         query_wide: &[D::Output; K],
@@ -667,11 +672,19 @@ where
         D::Output: Axis<Coord = D::Output> + TlsLeafScratch + 'static,
         R: BestNeighbourResultCollection<D::Output, T>,
     {
+        #[cfg(any(feature = "exact_query_stats", feature = "test_utils"))]
+        {
+            crate::results::exact_query_stats::record_leaf_visit();
+            crate::results::exact_query_stats::record_leaf_items_available(
+                self.leaves().leaf_len(leaf_idx),
+            );
+        }
+
         let threshold_item = results.threshold_item();
         match <rkyv_08::Archived<LS> as LeafStrategy<A, T, SS, K, B>>::LEAF_PROJECTION {
             LeafProjection::LeafArena => {
                 let arena = self.leaves().leaf_arena(leaf_idx);
-                best_n_within_with_query_wide_arena::<A, T, D, R, EXCLUSIVE, K>(
+                best_n_within_with_query_wide_arena::<A, T, D, R, EXCLUSIVE, LEAF_MODE, K>(
                     &arena,
                     query_wide,
                     max_dist,
@@ -687,6 +700,7 @@ where
                     D,
                     R,
                     EXCLUSIVE,
+                    LEAF_MODE,
                     K,
                     B,
                 >(&leaf, query_wide, max_dist, threshold_item, results);
@@ -710,22 +724,50 @@ where
             + 'static,
         SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K> + 'static,
     {
-        let mut req_ctx = ArchivedBestNWithinReqCtx::<A, D::Output, _, EXCLUSIVE, K> {
+        self.best_n_within_impl_ordered::<D, EXCLUSIVE, ITEM_LEAF_MODE>(query, max_dist, max_qty)
+    }
+
+    #[inline(always)]
+    fn best_n_within_impl_ordered<D, const EXCLUSIVE: bool, const LEAF_MODE: u8>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K> + 'static,
+    {
+        let mut req_ctx = ArchivedBestNWithinReqCtx::<A, D::Output, _, EXCLUSIVE, K, LEAF_MODE> {
             query,
             max_dist,
             results:
                 BinaryHeapResultCollection::<BestQueryResultItem<(), T, D::Output>>::with_max_qty(
                     max_qty.get(),
                 ),
+            item_summary_filter: crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<
+                T,
+                LEAF_MODE,
+            >(None),
         };
 
         self.backtracking_query::<_, _, D>(&mut req_ctx, |leaf_idx, query_wide, req_ctx| {
-            self.process_leaf_best_n_within::<D, _, EXCLUSIVE>(
+            self.process_leaf_best_n_within::<D, _, EXCLUSIVE, LEAF_MODE>(
                 leaf_idx,
                 query_wide,
                 max_dist,
                 &mut req_ctx.results,
             );
+            req_ctx.item_summary_filter =
+                crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<T, LEAF_MODE>(
+                    req_ctx.results.threshold_item(),
+                );
         });
 
         req_ctx.results.into_inner()
@@ -748,25 +790,56 @@ where
             + 'static,
         SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K>,
     {
-        let mut req_ctx = ArchivedBestNWithinReqCtx::<A, D::Output, _, EXCLUSIVE, K> {
+        self.best_n_within_impl_with_scratch_ordered::<D, EXCLUSIVE, ITEM_LEAF_MODE>(
+            query, max_dist, max_qty, stack,
+        )
+    }
+
+    #[inline(always)]
+    fn best_n_within_impl_with_scratch_ordered<D, const EXCLUSIVE: bool, const LEAF_MODE: u8>(
+        &self,
+        query: &[A; K],
+        max_dist: D::Output,
+        max_qty: NonZeroUsize,
+        stack: &mut SS::Stack<D::Output, K>,
+    ) -> BinaryHeap<BestQueryResultItem<(), T, D::Output>>
+    where
+        D: DistanceMetric<A>,
+        D::Output: crate::stem_strategy::SimdPrune
+            + SimdSelectBestChildBlock3
+            + BacktrackBlock3
+            + BacktrackBlock4
+            + TlsLeafScratch
+            + 'static,
+        SS::Stack<D::Output, K>: StackTrait<D::Output, SS, K>,
+    {
+        let mut req_ctx = ArchivedBestNWithinReqCtx::<A, D::Output, _, EXCLUSIVE, K, LEAF_MODE> {
             query,
             max_dist,
             results:
                 BinaryHeapResultCollection::<BestQueryResultItem<(), T, D::Output>>::with_max_qty(
                     max_qty.get(),
                 ),
+            item_summary_filter: crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<
+                T,
+                LEAF_MODE,
+            >(None),
         };
 
         self.backtracking_query_with_scratch::<_, _, D>(
             &mut req_ctx,
             stack,
             |leaf_idx, query_wide, req_ctx| {
-                self.process_leaf_best_n_within::<D, _, EXCLUSIVE>(
+                self.process_leaf_best_n_within::<D, _, EXCLUSIVE, LEAF_MODE>(
                     leaf_idx,
                     query_wide,
                     max_dist,
                     &mut req_ctx.results,
                 );
+                req_ctx.item_summary_filter =
+                    crate::kd_tree::item_summary::ItemSummaryFilter::from_threshold::<T, LEAF_MODE>(
+                        req_ctx.results.threshold_item(),
+                    );
             },
         );
 
@@ -879,20 +952,31 @@ where
     }
 }
 
-struct ArchivedBestNWithinReqCtx<'a, A, O, R, const EXCLUSIVE: bool, const K: usize>
-where
+struct ArchivedBestNWithinReqCtx<
+    'a,
+    A,
+    O,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const ITEM_LEAF_MODE: u8,
+> where
     O: Axis<Coord = O>,
 {
     query: &'a [A; K],
     max_dist: O,
     results: R,
+    item_summary_filter: crate::kd_tree::item_summary::ItemSummaryFilter,
 }
 
-impl<A, O, R, const EXCLUSIVE: bool, const K: usize> QueryContext<A, O, K>
-    for ArchivedBestNWithinReqCtx<'_, A, O, R, EXCLUSIVE, K>
+impl<A, O, R, const EXCLUSIVE: bool, const K: usize, const ITEM_LEAF_MODE: u8> QueryContext<A, O, K>
+    for ArchivedBestNWithinReqCtx<'_, A, O, R, EXCLUSIVE, K, ITEM_LEAF_MODE>
 where
     O: Axis<Coord = O>,
 {
+    const USES_EMBEDDED_ITEM_SUMMARY: bool =
+        ITEM_LEAF_MODE != ITEM_LEAF_MODE_UNSORTED && ITEM_LEAF_MODE != ITEM_LEAF_MODE_SORTED;
+
     fn query(&self) -> &[A; K] {
         self.query
     }
@@ -904,5 +988,10 @@ where
     #[inline]
     fn prune_on_equal_max_dist(&self) -> bool {
         EXCLUSIVE
+    }
+
+    #[inline(always)]
+    fn embedded_item_summary_filter(&self) -> crate::kd_tree::item_summary::ItemSummaryFilter {
+        self.item_summary_filter
     }
 }

--- a/src/stem_strategy/donnelly/cyclic_simd_descent.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_descent.rs
@@ -302,6 +302,7 @@ macro_rules! impl_cyclic_simd_descent {
         impl StemStrategy for $strategy<$bh> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $bh;
+            const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = $bh == 3;
             const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
             const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;
             const USES_SIMD_BLOCK_DESCENT: bool = true;

--- a/src/stem_strategy/donnelly/cyclic_simd_full.rs
+++ b/src/stem_strategy/donnelly/cyclic_simd_full.rs
@@ -517,9 +517,19 @@ fn cyclic_simd_full_arithmetic_query<
     process_leaf(first_leaf, &query_wide, query_ctx);
 
     while let Some(frame) = unsafe { stack.pop_inline_unchecked() } {
-        let (base_state, pending_mask, parent_off) = unsafe { frame.into_pending_unchecked() };
+        let (base_state, mut pending_mask, parent_off) = unsafe { frame.into_pending_unchecked() };
         let mut base = DonnellyCore::<BH>::new(stems_ptr);
         base.rehydrate_deferred_state(base_state);
+        if QC::USES_EMBEDDED_ITEM_SUMMARY && BH == 3 && A::VALUE_WIDTH_BYTES == 8 {
+            pending_mask &= u16::from(crate::kd_tree::item_summary::donnelly3_block_live_mask(
+                stems,
+                base.stem_idx(),
+                query_ctx.embedded_item_summary_filter(),
+            ));
+            if pending_mask == 0 {
+                continue;
+            }
+        }
         let max_dist = query_ctx.max_dist();
         let selection = select_cyclic_child::<A, O, D, K, BH>(
             stems,
@@ -569,6 +579,7 @@ macro_rules! impl_cyclic_simd_full {
         impl StemStrategy for $strategy<$bh> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $bh;
+            const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = $bh == 3;
             const TRAVERSES_BLOCK_AT_ONCE: bool = true;
             const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
             const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;

--- a/src/stem_strategy/donnelly/mod.rs
+++ b/src/stem_strategy/donnelly/mod.rs
@@ -62,3 +62,35 @@ pub use simd_full::DonnellySimdFull;
 pub use unrolled::DonnellyUnrolled;
 #[doc(inline)]
 pub use unrolled_block_dim::DonnellyUnrolledBlockDim;
+
+mod embedded_summary_layout {
+    pub trait Sealed {}
+}
+
+/// Marker for public stem strategies that share the f64 Donnelly<3> padding
+/// layout used by embedded minimum-item summaries.
+#[doc(hidden)]
+pub trait DonnellyBlock3SummaryLayout:
+    crate::StemStrategy + embedded_summary_layout::Sealed
+{
+}
+
+macro_rules! impl_block3_summary_layout {
+    ($($strategy:ty),+ $(,)?) => {
+        $(
+            impl embedded_summary_layout::Sealed for $strategy {}
+            impl DonnellyBlock3SummaryLayout for $strategy {}
+        )+
+    };
+}
+
+impl_block3_summary_layout!(
+    Donnelly<3>,
+    DonnellyNoPf<3>,
+    DonnellyUnrolled<3>,
+    DonnellyUnrolledBlockDim<3>,
+    DonnellySimdDescent<3>,
+    DonnellySimdFull<3>,
+    DonnellyCyclicSimdDescent<3>,
+    DonnellyCyclicSimdFull<3>,
+);

--- a/src/stem_strategy/donnelly/no_pf.rs
+++ b/src/stem_strategy/donnelly/no_pf.rs
@@ -16,6 +16,7 @@ pub struct DonnellyNoPf<const BH: usize> {
 impl<const BH: usize> StemStrategy for DonnellyNoPf<BH> {
     const ROOT_IDX: usize = 0;
     const BLOCK_SIZE: usize = BH;
+    const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = BH == 3;
     const REQUIRES_BLOCK_ALIGNED_STEM_HEIGHT: bool = false;
     const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
 

--- a/src/stem_strategy/donnelly/scalar.rs
+++ b/src/stem_strategy/donnelly/scalar.rs
@@ -20,6 +20,7 @@ pub struct Donnelly<const BH: usize> {
 impl<const BH: usize> StemStrategy for Donnelly<BH> {
     const ROOT_IDX: usize = 0;
     const BLOCK_SIZE: usize = BH;
+    const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = BH == 3;
     const REQUIRES_BLOCK_ALIGNED_STEM_HEIGHT: bool = false;
     const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
 

--- a/src/stem_strategy/donnelly/simd_descent.rs
+++ b/src/stem_strategy/donnelly/simd_descent.rs
@@ -36,6 +36,7 @@ macro_rules! impl_donnelly_simd_descent {
         impl StemStrategy for $strategy<$bh> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $bh;
+            const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = $bh == 3;
             const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
             const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;
             const USES_SIMD_BLOCK_DESCENT: bool = true;

--- a/src/stem_strategy/donnelly/simd_full/aarch64/mod.rs
+++ b/src/stem_strategy/donnelly/simd_full/aarch64/mod.rs
@@ -40,7 +40,8 @@ pub unsafe fn compare_block3_f64_neon(
     let count_0 = vaddvq_u64(ones_0);
     let count_1 = vaddvq_u64(ones_1);
     let count_2 = vaddvq_u64(ones_2);
-    let count_3 = vaddvq_u64(ones_3);
+    // Lane 7 is padding in Block3 and may contain an embedded item summary.
+    let count_3 = vgetq_lane_u64(ones_3, 0);
 
     (count_0 + count_1 + count_2 + count_3) as u8
 }
@@ -75,7 +76,8 @@ pub unsafe fn compare_block3_f32_neon(
     let ones_1 = vshrq_n_u32(cmp_1, 31);
 
     let count_0 = vaddvq_u32(ones_0);
-    let count_1 = vaddvq_u32(ones_1);
+    // Lane 7 is padding in Block3 and may contain an embedded item summary.
+    let count_1 = vaddvq_u32(ones_1) - vgetq_lane_u32(ones_1, 3);
 
     (count_0 + count_1) as u8
 }

--- a/src/stem_strategy/donnelly/simd_full/autovec.rs
+++ b/src/stem_strategy/donnelly/simd_full/autovec.rs
@@ -12,7 +12,7 @@ pub unsafe fn compare_block3_f64_autovec(
 ) -> u8 {
     let ptr = stems_ptr.as_ptr().add(cache_line_base * 8) as *const f64;
     let mut count = 0u8;
-    for i in 0..8 {
+    for i in 0..7 {
         if query_val >= *ptr.add(i) {
             count += 1;
         }
@@ -30,7 +30,7 @@ pub unsafe fn compare_block3_f32_autovec(
 ) -> u8 {
     let ptr = stems_ptr.as_ptr().add(cache_line_base * 4) as *const f32;
     let mut count = 0u8;
-    for i in 0..8 {
+    for i in 0..7 {
         if query_val >= *ptr.add(i) {
             count += 1;
         }
@@ -70,7 +70,7 @@ mod tests {
             -5.0,
             -4.0,
             -3.0,
-            f64::INFINITY,
+            f64::NEG_INFINITY,
             0.2,
             0.4,
             0.6,
@@ -100,7 +100,7 @@ mod tests {
             -5.0,
             -4.0,
             -3.0,
-            f32::INFINITY,
+            f32::NEG_INFINITY,
             0.2,
             0.4,
             0.6,

--- a/src/stem_strategy/donnelly/simd_full/compare_traits.rs
+++ b/src/stem_strategy/donnelly/simd_full/compare_traits.rs
@@ -68,7 +68,7 @@ pub trait CompareBlock4: Copy {
 
 /// Autovectorization-friendly comparison macro for block traversal.
 ///
-/// Compares query value against `$pivot_count + 1` pivots (includes padding).
+/// Compares query value against `$pivot_count` real pivots (ignores padding).
 /// Returns count of pivots <= query_val, which maps to child index.
 ///
 /// # Parameters
@@ -85,8 +85,7 @@ macro_rules! autovec_compare_block {
                 .add($block_base_idx * std::mem::size_of::<$ty>())
                 as *const $ty;
             let mut count = 0u8;
-            // Loop over pivot_count + 1 to include padding
-            for i in 0..($pivot_count + 1) {
+            for i in 0..$pivot_count {
                 if $query_val >= *ptr.add(i) {
                     count += 1;
                 }
@@ -113,7 +112,13 @@ impl CompareBlock3 for f64 {
                     let ptr = stems_ptr.as_ptr().add(block_base_idx * 8) as *const f64;
                     let pivots = _mm512_loadu_pd(ptr);
                     let query_vec = _mm512_set1_pd(query_val);
-                    let mask = _mm512_cmp_pd_mask(query_vec, pivots, _CMP_GE_OQ);
+                    // Lane 7 is the Block3 padding slot and may carry an embedded
+                    // item-summary bit pattern on summary-mode f64 trees. This kernel
+                    // is not parameterised by the tree's item-leaf mode, so excluding
+                    // lane 7 here is a negligible but unavoidable cost even for
+                    // unsorted trees, where the padding is ±INFINITY and could never
+                    // be selected anyway.
+                    let mask = _mm512_cmp_pd_mask(query_vec, pivots, _CMP_GE_OQ) & 0x7f;
                     _popcnt32(mask as i32) as u8
                 }
             }
@@ -133,7 +138,8 @@ impl CompareBlock3 for f64 {
 
                     let mask_low = _mm256_movemask_pd(cmp_low) as u32;
                     let mask_high = _mm256_movemask_pd(cmp_high) as u32;
-                    let mask = mask_low | (mask_high << 4);
+                    // Excludes lane 7 (Block3 padding); see the note above.
+                    let mask = (mask_low | (mask_high << 4)) & 0x7f;
 
                     _popcnt32(mask as i32) as u8
                 }
@@ -198,7 +204,12 @@ impl CompareBlock3 for f32 {
                     let ptr = stems_ptr.as_ptr().add(block_base_idx * 4) as *const f32;
                     let pivots = _mm256_loadu_ps(ptr);
                     let query_vec = _mm256_set1_ps(query_val);
-                    let mask = _mm256_cmp_ps_mask(query_vec, pivots, _CMP_GE_OQ);
+                    // Lane 7 is the Block3 padding slot. It never carries summaries
+                    // for f32 trees, but this kernel is not parameterised by the
+                    // tree's item-leaf mode, so excluding it is a negligible but
+                    // unavoidable cost; for unsorted trees the padding is ±INFINITY
+                    // and could never be selected anyway.
+                    let mask = _mm256_cmp_ps_mask(query_vec, pivots, _CMP_GE_OQ) & 0x7f;
                     _popcnt32(mask as i32) as u8
                 }
             }
@@ -213,7 +224,8 @@ impl CompareBlock3 for f32 {
                     let query_vec = _mm256_set1_ps(query_val);
 
                     let cmp = _mm256_cmp_ps(query_vec, pivots, _CMP_GE_OQ);
-                    let mask = _mm256_movemask_ps(cmp) as u32;
+                    // Excludes lane 7 (Block3 padding); see the note above.
+                    let mask = (_mm256_movemask_ps(cmp) as u32) & 0x7f;
 
                     _popcnt32(mask as i32) as u8
                 }

--- a/src/stem_strategy/donnelly/simd_full/mod.rs
+++ b/src/stem_strategy/donnelly/simd_full/mod.rs
@@ -623,6 +623,7 @@ pub mod cargo_asm {
 impl StemStrategy for DonnellySimdFull<3> {
     const ROOT_IDX: usize = 0;
     const BLOCK_SIZE: usize = 3;
+    const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = true;
     const TRAVERSES_BLOCK_AT_ONCE: bool = true;
 
     type DeferredState = Self;
@@ -665,6 +666,20 @@ impl StemStrategy for DonnellySimdFull<3> {
     #[inline(always)]
     fn dim<const K: usize>(&self) -> usize {
         self.core.level() as usize / Self::BLOCK_SIZE % K
+    }
+
+    #[inline(always)]
+    fn select_block_child<A: Axis<Coord = A>, const K: usize>(
+        &self,
+        stems: &[A],
+        query: &[A; K],
+        start_dim: usize,
+    ) -> u8 {
+        compare_block3(
+            stems,
+            unsafe { *query.get_unchecked(start_dim) },
+            self.stem_idx(),
+        )
     }
 
     #[inline(always)]
@@ -1471,7 +1486,8 @@ mod tests {
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
     fn build_test_block3_pivots_f64() -> [f64; 8] {
-        [0.2, 0.4, 0.6, 0.1, 0.3, 0.5, 0.7, f64::INFINITY]
+        // The final lane is padding. Embedded item summaries may give it any bit pattern.
+        [0.2, 0.4, 0.6, 0.1, 0.3, 0.5, 0.7, f64::NEG_INFINITY]
     }
 
     fn build_test_block3_pivots_f32() -> [f32; 8] {
@@ -1501,7 +1517,7 @@ mod tests {
 
     fn select_child_scalar_f64(query: f64, pivots: &[f64; 8]) -> u8 {
         let mut count = 0u8;
-        for i in 0..8 {
+        for i in 0..7 {
             if query >= pivots[i] {
                 count += 1;
             }
@@ -1511,7 +1527,7 @@ mod tests {
 
     fn select_child_scalar_f32(query: f32, pivots: &[f32; 8]) -> u8 {
         let mut count = 0u8;
-        for i in 0..8 {
+        for i in 0..7 {
             if query >= pivots[i] {
                 count += 1;
             }
@@ -2458,7 +2474,7 @@ mod tests {
         for (pivot_idx, &pivot_val) in pivots.iter().enumerate().take(7) {
             let child = select_child_scalar_f64(pivot_val, &pivots);
 
-            let expected = pivots.iter().take(8).filter(|&&p| pivot_val >= p).count() as u8;
+            let expected = pivots.iter().take(7).filter(|&&p| pivot_val >= p).count() as u8;
 
             assert_eq!(
                 child, expected,

--- a/src/stem_strategy/donnelly/unrolled.rs
+++ b/src/stem_strategy/donnelly/unrolled.rs
@@ -16,6 +16,7 @@ macro_rules! impl_donnelly_unrolled_strategy {
         impl StemStrategy for DonnellyUnrolled<$size> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $size;
+            const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = $size == 3;
             const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
             const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;
 

--- a/src/stem_strategy/donnelly/unrolled_block_dim.rs
+++ b/src/stem_strategy/donnelly/unrolled_block_dim.rs
@@ -16,6 +16,7 @@ macro_rules! impl_donnelly_unrolled_block_dim_strategy {
         impl StemStrategy for DonnellyUnrolledBlockDim<$size> {
             const ROOT_IDX: usize = 0;
             const BLOCK_SIZE: usize = $size;
+            const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = $size == 3;
             const SUPPORTS_ARITHMETIC_LEAF_RESOLUTION: bool = true;
             const USES_UNROLLED_SCALAR_TRAVERSAL: bool = true;
 

--- a/src/traits/axis.rs
+++ b/src/traits/axis.rs
@@ -72,6 +72,14 @@ pub trait Axis:
     /// Returns the maximum of two coordinate values.
     fn max(a: Self::Coord, b: Self::Coord) -> Self::Coord;
 
+    /// Returns the raw packed item-summary word stored in a Donnelly padding
+    /// slot, when this axis type supports that representation.
+    #[doc(hidden)]
+    #[inline(always)]
+    fn embedded_item_summary_word(_value: Self::Coord) -> Option<u64> {
+        None
+    }
+
     /// Select a path through a Donnelly block whose split dimension advances
     /// at every level. Implemented only by floating-point axes used by the
     /// experimental AVX-512 cyclic-SIMD strategy.
@@ -167,6 +175,17 @@ macro_rules! impl_axis_float {
             #[inline(always)]
             fn max(a: Self::Coord, b: Self::Coord) -> Self::Coord {
                 a.max(b)
+            }
+
+            #[inline(always)]
+            fn embedded_item_summary_word(value: Self::Coord) -> Option<u64> {
+                if size_of::<$t>() == size_of::<u64>() {
+                    // This branch is a compile-time constant for every macro
+                    // instantiation. Only f64 reaches the copy.
+                    Some(unsafe { std::mem::transmute_copy(&value) })
+                } else {
+                    None
+                }
             }
 
             #[inline(always)]

--- a/src/traits/kd_tree.rs
+++ b/src/traits/kd_tree.rs
@@ -38,6 +38,18 @@ where
     /// Maximum leaf length used for scratch sizing.
     fn max_leaf_len(&self) -> usize;
 
+    /// Encoded item ordering and subtree-summary mode.
+    #[inline]
+    fn item_leaf_mode_code(&self) -> u8 {
+        crate::kd_tree::ITEM_LEAF_MODE_UNSORTED
+    }
+
+    /// Whether leaf entries are ordered by ascending item value.
+    #[inline]
+    fn item_sorted_leaves(&self) -> bool {
+        crate::kd_tree::ItemLeafMode::from_code(self.item_leaf_mode_code()).has_sorted_leaves()
+    }
+
     /// Number of leaves.
     #[inline]
     fn leaf_count(&self) -> usize {

--- a/src/traits/stem_strategy.rs
+++ b/src/traits/stem_strategy.rs
@@ -86,6 +86,11 @@ pub trait StemStrategy: Clone + Debug + Sync + Send + 'static {
     #[doc(hidden)]
     const SIMD_BLOCK_DESCENT_ON_BACKTRACK: bool = true;
 
+    /// Whether this strategy uses the f64 Donnelly<3> block layout whose
+    /// eighth slot can carry embedded minimum-item summaries.
+    #[doc(hidden)]
+    const SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY: bool = false;
+
     /// Compact state persisted on scalar backtracking stacks.
     ///
     /// Scalar strategies can use this to store only the state needed to resume a deferred branch.


### PR DESCRIPTION
## Summary

Adds an optional **item-leaf mode** to `KdTree`, carried as a final const-generic `u8` (`ITEM_LEAF_MODE`) with an `ItemLeafMode` enum for readable interpretation:

| Code | Meaning |
|---|---|
| `ITEM_LEAF_MODE_UNSORTED` (0) | unchanged default behaviour, zero cost |
| `ITEM_LEAF_MODE_SORTED` (255) | leaves sorted by ascending item; enables an early-exit `best_n_within` leaf kernel |
| `1..=31` (SHIFT) | sorted leaves **plus** per-block subtree-minimum item summaries packed into the Donnelly Block3 padding slot, enabling subtree pruning during `best_n_within` descent |

### How it works

`best_n_within` ranks results by item value only, so strict threshold-based pruning and early exit are exact (an equal item can never displace the current worst). The stem summaries encode, per Donnelly Block3 subtree slot, the subtree's minimum item right-shifted by `SHIFT` and saturated at 253 (code 254 = empty subtree); at query time an `ItemSummaryFilter` derives a live-mask over the block's eight slots from the current threshold. All summary checks are const-gated (`USES_EMBEDDED_ITEM_SUMMARY` / `SUPPORTS_EMBEDDED_MIN_ITEM_SUMMARY`), so other query kinds and modes compile to exactly the previous code.

The Donnelly Block3 padding lane previously held `INFINITY` and now may carry arbitrary summary bit patterns, so every descent/compare kernel excludes lane 7 unconditionally (x86_64 `& 0x7f` masks, aarch64 lane-7 exclusion, autovec `0..7` loops) — a negligible but unavoidable cost.

### Builder API

- `.with_item_sorted_leaves()` — immutable leaf strategies, `T: Ord`
- `.with_embedded_min_item_shifted_summary::<SHIFT>()` — `f64`/`u32` items, `DonnellyBlock3SummaryLayout` stem strategies (all Donnelly<3> variants), `SHIFT` in `1..=31`

Includes rkyv support, `exact_query_stats` instrumentation (blocks checked, subtrees pruned, lanes rejected), and construction/query tests covering all eight Donnelly<3> stem strategies, encoding boundaries/saturation, threshold-timing semantics, and parallel construction.

## Review notes

- Two new modules must be included: `src/kd_tree/item_summary.rs` (query-side filter + shared encoding constants) and `src/kd_tree/construction/item_summary.rs` (build-time summary population).
- Mode correctness is builder-enforced rather than type-enforced (the `u8` const generic can't pin `T = u32`); documented on `ItemLeafMode::from_code` and `StemSummaryPopulator`.
- Summary constants (`EMPTY_SUBTREE_CODE`, `MAX_NONEMPTY_CODE`) are defined once in `kd_tree::item_summary` and shared with the constructor.

## Benchmarks

Local results (repo-root `bench_result-*.png` / `latest_v6_nearest_one_scratch.html`) show large `best_n_within` wins for sorted/summary modes; an `/benchmark extended` run on this PR will quantify the damage to the other query-family benchmarks.

## Testing

- `cargo test --all-features --lib --tests`: 495 unit + integration tests, 0 failures
- `cargo test --all-features --test kd_tree_fuzz_v6`: 3 passed / 0 failed (on top of #546's comparator fix, now merged)
- fmt / clippy (only pre-existing warnings) / pre-commit hooks clean