### PR TITLE
Wasm simd128

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -30,3 +30,32 @@ jobs:
 
       - name: Build ImmutableKdTree WASM smoke test
         run: cargo build --manifest-path tests/wasm-smoke/Cargo.toml --target wasm32-unknown-unknown
+
+  wasm-simd128:
+    name: WASM SIMD128 leaf kernels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - name: Install stable Rust with the WASM target
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Build the SIMD128 leaf kernels
+        run: cargo build --target wasm32-unknown-unknown --no-default-features --features simd
+        env:
+          RUSTFLAGS: -C target-feature=+simd128
+
+      - name: Clippy the SIMD128 leaf kernels
+        run: cargo clippy --target wasm32-unknown-unknown --no-default-features --features simd -- -D warnings
+        env:
+          RUSTFLAGS: -C target-feature=+simd128
+
+      - name: Build ImmutableKdTree WASM smoke test with SIMD128
+        run: cargo build --manifest-path tests/wasm-smoke/Cargo.toml --target wasm32-unknown-unknown --features simd
+        env:
+          RUSTFLAGS: -C target-feature=+simd128

--- a/src/dist/chebyshev/mod.rs
+++ b/src/dist/chebyshev/mod.rs
@@ -2,7 +2,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
-    WideningCastFrom,
+    DistanceMetricWasmSimd, WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -13,6 +13,9 @@ mod avx512;
 
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 mod neon;
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+mod wasm_simd;
 
 /// Chebyshev / L-infinity distance metric, parameterized by output type `R`.
 pub struct Chebyshev<R>(core::marker::PhantomData<R>);
@@ -107,4 +110,16 @@ where
 
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF32Ops = neon::ChebyshevNeonF32LeafOps;
+}
+
+impl<A, R> DistanceMetricWasmSimd<A> for Chebyshev<R>
+where
+    A: Copy,
+    R: Axis<Coord = R> + WideningCastFrom<A>,
+{
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops = wasm_simd::ChebyshevWasmSimdF64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops = wasm_simd::ChebyshevWasmSimdF32LeafOps;
 }

--- a/src/dist/chebyshev/wasm_simd.rs
+++ b/src/dist/chebyshev/wasm_simd.rs
@@ -1,0 +1,51 @@
+use core::arch::wasm32::*;
+
+use crate::dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps};
+
+pub struct ChebyshevWasmSimdF64LeafOps;
+
+impl WasmSimdF64LeafOps for ChebyshevWasmSimdF64LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f64x2(delta: v128) -> v128 {
+        f64x2_abs(delta)
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f64x2(acc: v128, delta: v128) -> v128 {
+        f64x2_max(acc, f64x2_abs(delta))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f64x1(delta: f64) -> f64 {
+        delta.abs()
+    }
+
+    #[inline(always)]
+    fn dist_kn_f64x1(acc: f64, delta: f64) -> f64 {
+        acc.max(delta.abs())
+    }
+}
+
+pub struct ChebyshevWasmSimdF32LeafOps;
+
+impl WasmSimdF32LeafOps for ChebyshevWasmSimdF32LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f32x4(delta: v128) -> v128 {
+        f32x4_abs(delta)
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f32x4(acc: v128, delta: v128) -> v128 {
+        f32x4_max(acc, f32x4_abs(delta))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f32x1(delta: f32) -> f32 {
+        delta.abs()
+    }
+
+    #[inline(always)]
+    fn dist_kn_f32x1(acc: f32, delta: f32) -> f32 {
+        acc.max(delta.abs())
+    }
+}

--- a/src/dist/distance_metric_wasm_simd.rs
+++ b/src/dist/distance_metric_wasm_simd.rs
@@ -1,0 +1,81 @@
+use core::arch::wasm32::v128;
+
+/// WebAssembly SIMD128 f64 leaf-kernel operations contract.
+pub trait WasmSimdF64LeafOps {
+    /// Calculate distance on 2 f64 lanes for the first dimension.
+    unsafe fn dist_k0_f64x2(delta: v128) -> v128;
+
+    /// Accumulate distance on 2 f64 lanes for subsequent dimensions.
+    unsafe fn dist_kn_f64x2(acc: v128, delta: v128) -> v128;
+
+    /// Calculate scalar f64 distance for the first dimension.
+    fn dist_k0_f64x1(delta: f64) -> f64;
+
+    /// Accumulate scalar f64 distance for subsequent dimensions.
+    fn dist_kn_f64x1(acc: f64, delta: f64) -> f64;
+}
+
+/// Placeholder implementation for metrics without SIMD128 f64 specializations.
+pub struct UnsupportedWasmSimdF64LeafOps;
+
+impl WasmSimdF64LeafOps for UnsupportedWasmSimdF64LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f64x2(_delta: v128) -> v128 {
+        panic!("SIMD128 f64 leaf ops are not implemented for this metric")
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f64x2(_acc: v128, _delta: v128) -> v128 {
+        panic!("SIMD128 f64 leaf ops are not implemented for this metric")
+    }
+
+    #[inline(always)]
+    fn dist_k0_f64x1(_delta: f64) -> f64 {
+        panic!("SIMD128 f64 leaf ops are not implemented for this metric")
+    }
+
+    #[inline(always)]
+    fn dist_kn_f64x1(_acc: f64, _delta: f64) -> f64 {
+        panic!("SIMD128 f64 leaf ops are not implemented for this metric")
+    }
+}
+
+/// WebAssembly SIMD128 f32 leaf-kernel operations contract.
+pub trait WasmSimdF32LeafOps {
+    /// Calculate distance on 4 f32 lanes for the first dimension.
+    unsafe fn dist_k0_f32x4(delta: v128) -> v128;
+
+    /// Accumulate distance on 4 f32 lanes for subsequent dimensions.
+    unsafe fn dist_kn_f32x4(acc: v128, delta: v128) -> v128;
+
+    /// Calculate scalar f32 distance for the first dimension.
+    fn dist_k0_f32x1(delta: f32) -> f32;
+
+    /// Accumulate scalar f32 distance for subsequent dimensions.
+    fn dist_kn_f32x1(acc: f32, delta: f32) -> f32;
+}
+
+/// Placeholder implementation for metrics without SIMD128 f32 specializations.
+pub struct UnsupportedWasmSimdF32LeafOps;
+
+impl WasmSimdF32LeafOps for UnsupportedWasmSimdF32LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f32x4(_delta: v128) -> v128 {
+        panic!("SIMD128 f32 leaf ops are not implemented for this metric")
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f32x4(_acc: v128, _delta: v128) -> v128 {
+        panic!("SIMD128 f32 leaf ops are not implemented for this metric")
+    }
+
+    #[inline(always)]
+    fn dist_k0_f32x1(_delta: f32) -> f32 {
+        panic!("SIMD128 f32 leaf ops are not implemented for this metric")
+    }
+
+    #[inline(always)]
+    fn dist_kn_f32x1(_acc: f32, _delta: f32) -> f32 {
+        panic!("SIMD128 f32 leaf ops are not implemented for this metric")
+    }
+}

--- a/src/dist/manhattan/mod.rs
+++ b/src/dist/manhattan/mod.rs
@@ -4,7 +4,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
-    WideningCastFrom,
+    DistanceMetricWasmSimd, WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -15,6 +15,9 @@ mod avx512;
 
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 mod neon;
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+mod wasm_simd;
 
 /// Manhattan / L1 distance metric, parameterized by output type `R`.
 pub struct Manhattan<R>(core::marker::PhantomData<R>);
@@ -81,4 +84,16 @@ where
 
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF32Ops = neon::ManhattanNeonF32LeafOps;
+}
+
+impl<A, R> DistanceMetricWasmSimd<A> for Manhattan<R>
+where
+    A: Copy,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Add<Output = R>,
+{
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops = wasm_simd::ManhattanWasmSimdF64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops = wasm_simd::ManhattanWasmSimdF32LeafOps;
 }

--- a/src/dist/manhattan/wasm_simd.rs
+++ b/src/dist/manhattan/wasm_simd.rs
@@ -1,0 +1,51 @@
+use core::arch::wasm32::*;
+
+use crate::dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps};
+
+pub struct ManhattanWasmSimdF64LeafOps;
+
+impl WasmSimdF64LeafOps for ManhattanWasmSimdF64LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f64x2(delta: v128) -> v128 {
+        f64x2_abs(delta)
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f64x2(acc: v128, delta: v128) -> v128 {
+        f64x2_add(acc, f64x2_abs(delta))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f64x1(delta: f64) -> f64 {
+        delta.abs()
+    }
+
+    #[inline(always)]
+    fn dist_kn_f64x1(acc: f64, delta: f64) -> f64 {
+        acc + delta.abs()
+    }
+}
+
+pub struct ManhattanWasmSimdF32LeafOps;
+
+impl WasmSimdF32LeafOps for ManhattanWasmSimdF32LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f32x4(delta: v128) -> v128 {
+        f32x4_abs(delta)
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f32x4(acc: v128, delta: v128) -> v128 {
+        f32x4_add(acc, f32x4_abs(delta))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f32x1(delta: f32) -> f32 {
+        delta.abs()
+    }
+
+    #[inline(always)]
+    fn dist_kn_f32x1(acc: f32, delta: f32) -> f32 {
+        acc + delta.abs()
+    }
+}

--- a/src/dist/minkowski/mod.rs
+++ b/src/dist/minkowski/mod.rs
@@ -4,7 +4,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
-    WideningCastFrom,
+    DistanceMetricWasmSimd, WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -15,6 +15,9 @@ mod avx512;
 
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 mod neon;
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+mod wasm_simd;
 
 /// Generalized integer-power Minkowski distance metric.
 ///
@@ -93,4 +96,16 @@ where
 
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF32Ops = neon::MinkowskiNeonF32LeafOps<P>;
+}
+
+impl<A, R, const P: u32> DistanceMetricWasmSimd<A> for Minkowski<P, R>
+where
+    A: Copy,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Float,
+{
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops = wasm_simd::MinkowskiWasmSimdF64LeafOps<P>;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops = wasm_simd::MinkowskiWasmSimdF32LeafOps<P>;
 }

--- a/src/dist/minkowski/wasm_simd.rs
+++ b/src/dist/minkowski/wasm_simd.rs
@@ -1,0 +1,163 @@
+use core::arch::wasm32::*;
+
+use crate::dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps};
+
+#[inline(always)]
+unsafe fn pow_f64x2<const P: u32>(x: v128) -> v128 {
+    if P == 0 {
+        return f64x2_splat(1.0);
+    }
+    if P == 1 {
+        return x;
+    }
+    if P == 2 {
+        return f64x2_mul(x, x);
+    }
+    if P == 3 {
+        let x2 = f64x2_mul(x, x);
+        return f64x2_mul(x2, x);
+    }
+    if P == 4 {
+        let x2 = f64x2_mul(x, x);
+        return f64x2_mul(x2, x2);
+    }
+
+    let mut acc = f64x2_splat(1.0);
+    let mut base = x;
+    let mut exp = P;
+    while exp != 0 {
+        if exp & 1 == 1 {
+            acc = f64x2_mul(acc, base);
+        }
+        exp >>= 1;
+        if exp != 0 {
+            base = f64x2_mul(base, base);
+        }
+    }
+    acc
+}
+
+#[inline(always)]
+unsafe fn pow_f32x4<const P: u32>(x: v128) -> v128 {
+    if P == 0 {
+        return f32x4_splat(1.0);
+    }
+    if P == 1 {
+        return x;
+    }
+    if P == 2 {
+        return f32x4_mul(x, x);
+    }
+    if P == 3 {
+        let x2 = f32x4_mul(x, x);
+        return f32x4_mul(x2, x);
+    }
+    if P == 4 {
+        let x2 = f32x4_mul(x, x);
+        return f32x4_mul(x2, x2);
+    }
+
+    let mut acc = f32x4_splat(1.0);
+    let mut base = x;
+    let mut exp = P;
+    while exp != 0 {
+        if exp & 1 == 1 {
+            acc = f32x4_mul(acc, base);
+        }
+        exp >>= 1;
+        if exp != 0 {
+            base = f32x4_mul(base, base);
+        }
+    }
+    acc
+}
+
+#[inline(always)]
+fn pow_f64<const P: u32>(x: f64) -> f64 {
+    if P == 0 {
+        return 1.0;
+    }
+    if P == 1 {
+        return x;
+    }
+    if P == 2 {
+        return x * x;
+    }
+    if P == 3 {
+        return x * x * x;
+    }
+    if P == 4 {
+        let x2 = x * x;
+        return x2 * x2;
+    }
+    x.powi(P as i32)
+}
+
+#[inline(always)]
+fn pow_f32<const P: u32>(x: f32) -> f32 {
+    if P == 0 {
+        return 1.0;
+    }
+    if P == 1 {
+        return x;
+    }
+    if P == 2 {
+        return x * x;
+    }
+    if P == 3 {
+        return x * x * x;
+    }
+    if P == 4 {
+        let x2 = x * x;
+        return x2 * x2;
+    }
+    x.powi(P as i32)
+}
+
+pub struct MinkowskiWasmSimdF64LeafOps<const P: u32>;
+
+impl<const P: u32> WasmSimdF64LeafOps for MinkowskiWasmSimdF64LeafOps<P> {
+    #[inline(always)]
+    unsafe fn dist_k0_f64x2(delta: v128) -> v128 {
+        pow_f64x2::<P>(f64x2_abs(delta))
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f64x2(acc: v128, delta: v128) -> v128 {
+        f64x2_add(acc, pow_f64x2::<P>(f64x2_abs(delta)))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f64x1(delta: f64) -> f64 {
+        pow_f64::<P>(delta.abs())
+    }
+
+    #[inline(always)]
+    fn dist_kn_f64x1(acc: f64, delta: f64) -> f64 {
+        acc + pow_f64::<P>(delta.abs())
+    }
+}
+
+pub struct MinkowskiWasmSimdF32LeafOps<const P: u32>;
+
+impl<const P: u32> WasmSimdF32LeafOps for MinkowskiWasmSimdF32LeafOps<P> {
+    #[inline(always)]
+    unsafe fn dist_k0_f32x4(delta: v128) -> v128 {
+        pow_f32x4::<P>(f32x4_abs(delta))
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f32x4(acc: v128, delta: v128) -> v128 {
+        f32x4_add(acc, pow_f32x4::<P>(f32x4_abs(delta)))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f32x1(delta: f32) -> f32 {
+        pow_f32::<P>(delta.abs())
+    }
+
+    #[inline(always)]
+    fn dist_kn_f32x1(acc: f32, delta: f32) -> f32 {
+        acc + pow_f32::<P>(delta.abs())
+    }
+}

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -20,6 +20,11 @@ pub mod distance_metric_core;
 #[doc(hidden)]
 pub mod distance_metric_neon;
 
+/// WebAssembly SIMD128 distance metric trait
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[doc(hidden)]
+pub mod distance_metric_wasm_simd;
+
 /// Chebyshev distance metric
 #[doc(hidden)]
 pub mod chebyshev;
@@ -47,7 +52,8 @@ pub use distance_metric_core::{DistanceMetricScalar, WideningCastFrom};
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-    all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+    all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+    all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
 ))]
 use std::any::TypeId;
 
@@ -58,7 +64,8 @@ use crate::Axis;
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-    all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+    all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+    all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
 ))]
 use crate::{
     leaf_view::{LeafArena, LeafView},
@@ -152,7 +159,8 @@ impl<T, A: Copy> QueryMetric<A> for T where T: DistanceMetric<A, Output: QueryDi
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-    all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+    all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+    all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
 ))]
 macro_rules! with_nearest_result_emitter {
     ($results:expr, $entry_ty:ty, $distance_ty:ty, $item_ty:ty, $emit:ident, $body:block) => {{
@@ -179,7 +187,8 @@ macro_rules! with_nearest_result_emitter {
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-    all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+    all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+    all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
 ))]
 #[inline(always)]
 unsafe fn point_from_leaf_arena_tile<A: Copy, const K: usize>(
@@ -194,7 +203,8 @@ unsafe fn point_from_leaf_arena_tile<A: Copy, const K: usize>(
 #[cfg(any(
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
     all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-    all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+    all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+    all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
 ))]
 macro_rules! with_best_result_emitter {
     ($results:expr, $threshold_item:expr, $distance_ty:ty, $item_ty:ty, $emit:ident, $body:block) => {{
@@ -1354,10 +1364,474 @@ pub trait DistanceMetricNeon<A: Copy>: DistanceMetricScalar<A> {
     }
 }
 
+/// WebAssembly SIMD128 extension hooks.
+#[doc(hidden)]
+pub trait DistanceMetricWasmSimd<A: Copy>: DistanceMetricScalar<A> {
+    /// Whether a specialized SIMD128 path is provided by this metric impl.
+    const HAS_WASM_SIMD_SPECIALIZATION: bool = false;
+
+    /// Type that provides implementations of the SIMD128 f64 leaf ops.
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops: distance_metric_wasm_simd::WasmSimdF64LeafOps + 'static;
+
+    /// Type that provides implementations of the SIMD128 f32 leaf ops.
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops: distance_metric_wasm_simd::WasmSimdF32LeafOps + 'static;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    #[inline(always)]
+    /// Try a SIMD128-specialized `nearest_one` leaf kernel.
+    unsafe fn try_nearest_one_leaf_wasm_simd<T, const K: usize, const B: usize>(
+        leaf: &LeafView<'_, A, T, K, B>,
+        query_wide: &[Self::Output; K],
+        best_dist: &mut Self::Output,
+        best_item: &mut T,
+    ) -> bool
+    where
+        A: Axis<Coord = A> + 'static,
+        T: crate::Content,
+        Self::Output: Axis<Coord = Self::Output> + 'static,
+    {
+        if TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::WasmSimdF64Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF64LeafOps>()
+        {
+            let leaf =
+                &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f64, T, K, B>);
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
+            let best_dist = &mut *(best_dist as *mut Self::Output as *mut f64);
+
+            crate::leaf_view_chunked::nearest_one::wasm_simd::nearest_one_wasm_unchecked_f64::<
+                Self::WasmSimdF64Ops,
+                T,
+                K,
+                B,
+            >(leaf, query_wide, best_dist, best_item);
+
+            return true;
+        }
+
+        if TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::WasmSimdF32Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF32LeafOps>()
+        {
+            let leaf =
+                &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f32, T, K, B>);
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
+            let best_dist = &mut *(best_dist as *mut Self::Output as *mut f32);
+
+            crate::leaf_view_chunked::nearest_one::wasm_simd::nearest_one_wasm_unchecked_f32::<
+                Self::WasmSimdF32Ops,
+                T,
+                K,
+                B,
+            >(leaf, query_wide, best_dist, best_item);
+
+            return true;
+        }
+
+        false
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    #[inline(always)]
+    /// Try a SIMD128-specialized `nearest_one` arena kernel.
+    unsafe fn try_nearest_one_arena_wasm_simd<T, const K: usize>(
+        arena: &LeafArena<'_, A, T, K>,
+        query_wide: &[Self::Output; K],
+        best_dist: &mut Self::Output,
+        best_item: &mut T,
+    ) -> bool
+    where
+        A: Axis<Coord = A> + 'static,
+        T: crate::Content,
+        Self::Output: Axis<Coord = Self::Output> + 'static,
+    {
+        if TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::WasmSimdF64Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF64LeafOps>()
+        {
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
+            let best_dist = &mut *(best_dist as *mut Self::Output as *mut f64);
+            let mut tile_base = arena.as_ptr();
+            let mut remaining = arena.len();
+
+            while remaining != 0 {
+                let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                crate::leaf_view_chunked::nearest_one::wasm_simd::nearest_one_wasm_arena_unchecked_f64::<
+                    Self::WasmSimdF64Ops,
+                    T,
+                    K,
+                >(tile_base, tile_len, query_wide, best_dist, best_item);
+                let tile_bytes =
+                    K * tile_len * std::mem::size_of::<f64>() + tile_len * std::mem::size_of::<T>();
+                tile_base = tile_base.add(tile_bytes);
+                remaining -= tile_len;
+            }
+
+            return true;
+        }
+
+        if TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::WasmSimdF32Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF32LeafOps>()
+        {
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
+            let best_dist = &mut *(best_dist as *mut Self::Output as *mut f32);
+            let mut tile_base = arena.as_ptr();
+            let mut remaining = arena.len();
+
+            while remaining != 0 {
+                let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                crate::leaf_view_chunked::nearest_one::wasm_simd::nearest_one_wasm_arena_unchecked_f32::<
+                    Self::WasmSimdF32Ops,
+                    T,
+                    K,
+                >(tile_base, tile_len, query_wide, best_dist, best_item);
+                let tile_bytes =
+                    K * tile_len * std::mem::size_of::<f32>() + tile_len * std::mem::size_of::<T>();
+                tile_base = tile_base.add(tile_bytes);
+                remaining -= tile_len;
+            }
+
+            return true;
+        }
+
+        false
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    #[inline(always)]
+    /// Try a SIMD128-specialized `nearest_n_within` leaf kernel.
+    unsafe fn try_nearest_n_within_leaf_wasm_simd<
+        T,
+        E,
+        R,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    >(
+        leaf: &LeafView<'_, A, T, K, B>,
+        query_wide: &[Self::Output; K],
+        max_dist: Self::Output,
+        results: &mut R,
+    ) -> bool
+    where
+        A: Axis<Coord = A> + 'static,
+        T: crate::Content,
+        Self::Output: Axis<Coord = Self::Output> + 'static,
+        E: FromLeafCandidate<A, T, Self::Output, K>,
+        R: ResultCollection<Self::Output, E>,
+    {
+        if TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::WasmSimdF64Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF64LeafOps>()
+        {
+            let leaf =
+                &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f64, T, K, B>);
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f64);
+            with_nearest_result_emitter!(results, E, f64, T, emit, {
+                let mut emit_positioned =
+                    |position, distance, item| emit(leaf.point(position), distance, item);
+                crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_unchecked_f64::<
+                    Self::WasmSimdF64Ops,
+                    T,
+                    _,
+                    EXCLUSIVE,
+                    K,
+                    B,
+                >(leaf, query_wide, max_dist, &mut emit_positioned);
+            });
+
+            return true;
+        }
+
+        if TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::WasmSimdF32Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF32LeafOps>()
+        {
+            let leaf =
+                &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f32, T, K, B>);
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f32);
+            with_nearest_result_emitter!(results, E, f32, T, emit, {
+                let mut emit_positioned =
+                    |position, distance, item| emit(leaf.point(position), distance, item);
+                crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_unchecked_f32::<
+                    Self::WasmSimdF32Ops,
+                    T,
+                    _,
+                    EXCLUSIVE,
+                    K,
+                    B,
+                >(leaf, query_wide, max_dist, &mut emit_positioned);
+            });
+
+            return true;
+        }
+
+        false
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    #[inline(always)]
+    /// Try a SIMD128-specialized `nearest_n_within` arena kernel.
+    unsafe fn try_nearest_n_within_arena_wasm_simd<T, E, R, const EXCLUSIVE: bool, const K: usize>(
+        arena: &LeafArena<'_, A, T, K>,
+        query_wide: &[Self::Output; K],
+        max_dist: Self::Output,
+        results: &mut R,
+    ) -> bool
+    where
+        A: Axis<Coord = A> + 'static,
+        T: crate::Content,
+        Self::Output: Axis<Coord = Self::Output> + 'static,
+        E: FromLeafCandidate<A, T, Self::Output, K>,
+        R: ResultCollection<Self::Output, E>,
+    {
+        if TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::WasmSimdF64Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF64LeafOps>()
+        {
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f64);
+            with_nearest_result_emitter!(results, E, f64, T, emit, {
+                let mut tile_base = arena.as_ptr();
+                let mut remaining = arena.len();
+
+                while remaining != 0 {
+                    let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                    let mut emit_tile = |position, distance, item| {
+                        emit(
+                            point_from_leaf_arena_tile::<f64, K>(tile_base, tile_len, position),
+                            distance,
+                            item,
+                        )
+                    };
+                    crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_arena_unchecked_f64::<
+                        Self::WasmSimdF64Ops,
+                        T,
+                        _,
+                        EXCLUSIVE,
+                        K,
+                    >(tile_base, tile_len, query_wide, max_dist, &mut emit_tile);
+                    let tile_bytes = K * tile_len * std::mem::size_of::<f64>()
+                        + tile_len * std::mem::size_of::<T>();
+                    tile_base = tile_base.add(tile_bytes);
+                    remaining -= tile_len;
+                }
+            });
+
+            return true;
+        }
+
+        if TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::WasmSimdF32Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF32LeafOps>()
+        {
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f32);
+            with_nearest_result_emitter!(results, E, f32, T, emit, {
+                let mut tile_base = arena.as_ptr();
+                let mut remaining = arena.len();
+
+                while remaining != 0 {
+                    let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                    let mut emit_tile = |position, distance, item| {
+                        emit(
+                            point_from_leaf_arena_tile::<f32, K>(tile_base, tile_len, position),
+                            distance,
+                            item,
+                        )
+                    };
+                    crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_arena_unchecked_f32::<
+                        Self::WasmSimdF32Ops,
+                        T,
+                        _,
+                        EXCLUSIVE,
+                        K,
+                    >(tile_base, tile_len, query_wide, max_dist, &mut emit_tile);
+                    let tile_bytes = K * tile_len * std::mem::size_of::<f32>()
+                        + tile_len * std::mem::size_of::<T>();
+                    tile_base = tile_base.add(tile_bytes);
+                    remaining -= tile_len;
+                }
+            });
+
+            return true;
+        }
+
+        false
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    #[inline(always)]
+    /// Try a SIMD128-specialized `best_n_within` leaf kernel.
+    unsafe fn try_best_n_within_leaf_wasm_simd<
+        T,
+        R,
+        const EXCLUSIVE: bool,
+        const K: usize,
+        const B: usize,
+    >(
+        leaf: &LeafView<'_, A, T, K, B>,
+        query_wide: &[Self::Output; K],
+        max_dist: Self::Output,
+        threshold_item: Option<T>,
+        results: &mut R,
+    ) -> bool
+    where
+        A: Axis<Coord = A> + 'static,
+        T: crate::Content + PartialOrd,
+        Self::Output: Axis<Coord = Self::Output> + 'static,
+        R: BestNeighbourResultCollection<Self::Output, T>,
+    {
+        if TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::WasmSimdF64Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF64LeafOps>()
+        {
+            let leaf =
+                &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f64, T, K, B>);
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f64);
+            with_best_result_emitter!(results, threshold_item, f64, T, emit, {
+                crate::leaf_view_chunked::best_n_within::wasm_simd::best_n_within_wasm_unchecked_f64::<
+                    Self::WasmSimdF64Ops,
+                    T,
+                    _,
+                    EXCLUSIVE,
+                    K,
+                    B,
+                >(leaf, query_wide, max_dist, &mut emit);
+            });
+
+            return true;
+        }
+
+        if TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::WasmSimdF32Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF32LeafOps>()
+        {
+            let leaf =
+                &*(leaf as *const LeafView<'_, A, T, K, B> as *const LeafView<'_, f32, T, K, B>);
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f32);
+            with_best_result_emitter!(results, threshold_item, f32, T, emit, {
+                crate::leaf_view_chunked::best_n_within::wasm_simd::best_n_within_wasm_unchecked_f32::<
+                    Self::WasmSimdF32Ops,
+                    T,
+                    _,
+                    EXCLUSIVE,
+                    K,
+                    B,
+                >(leaf, query_wide, max_dist, &mut emit);
+            });
+
+            return true;
+        }
+
+        false
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    #[inline(always)]
+    /// Try a SIMD128-specialized `best_n_within` arena kernel.
+    unsafe fn try_best_n_within_arena_wasm_simd<T, R, const EXCLUSIVE: bool, const K: usize>(
+        arena: &LeafArena<'_, A, T, K>,
+        query_wide: &[Self::Output; K],
+        max_dist: Self::Output,
+        threshold_item: Option<T>,
+        results: &mut R,
+    ) -> bool
+    where
+        A: Axis<Coord = A> + 'static,
+        T: crate::Content + PartialOrd,
+        Self::Output: Axis<Coord = Self::Output> + 'static,
+        R: BestNeighbourResultCollection<Self::Output, T>,
+    {
+        if TypeId::of::<A>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f64>()
+            && TypeId::of::<Self::WasmSimdF64Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF64LeafOps>()
+        {
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f64; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f64);
+            with_best_result_emitter!(results, threshold_item, f64, T, emit, {
+                let mut tile_base = arena.as_ptr();
+                let mut remaining = arena.len();
+
+                while remaining != 0 {
+                    let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                    crate::leaf_view_chunked::best_n_within::wasm_simd::best_n_within_wasm_arena_unchecked_f64::<
+                        Self::WasmSimdF64Ops,
+                        T,
+                        _,
+                        EXCLUSIVE,
+                        K,
+                    >(tile_base, tile_len, query_wide, max_dist, &mut emit);
+                    let tile_bytes = K * tile_len * std::mem::size_of::<f64>()
+                        + tile_len * std::mem::size_of::<T>();
+                    tile_base = tile_base.add(tile_bytes);
+                    remaining -= tile_len;
+                }
+            });
+
+            return true;
+        }
+
+        if TypeId::of::<A>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::Output>() == TypeId::of::<f32>()
+            && TypeId::of::<Self::WasmSimdF32Ops>()
+                != TypeId::of::<distance_metric_wasm_simd::UnsupportedWasmSimdF32LeafOps>()
+        {
+            let query_wide = &*(query_wide as *const [Self::Output; K] as *const [f32; K]);
+            let max_dist = *(&max_dist as *const Self::Output as *const f32);
+            with_best_result_emitter!(results, threshold_item, f32, T, emit, {
+                let mut tile_base = arena.as_ptr();
+                let mut remaining = arena.len();
+
+                while remaining != 0 {
+                    let tile_len = crate::leaf_view::leaf_arena_tile_len(remaining);
+                    crate::leaf_view_chunked::best_n_within::wasm_simd::best_n_within_wasm_arena_unchecked_f32::<
+                        Self::WasmSimdF32Ops,
+                        T,
+                        _,
+                        EXCLUSIVE,
+                        K,
+                    >(tile_base, tile_len, query_wide, max_dist, &mut emit);
+                    let tile_bytes = K * tile_len * std::mem::size_of::<f32>()
+                        + tile_len * std::mem::size_of::<T>();
+                    tile_base = tile_base.add(tile_bytes);
+                    remaining -= tile_len;
+                }
+            });
+
+            return true;
+        }
+
+        false
+    }
+}
+
 /// Trait representing a distance metric that can be used in a `KdTree` query.
 #[doc(hidden)]
 pub trait DistanceMetric<A: Copy>:
-    DistanceMetricScalar<A> + DistanceMetricAvx512<A> + DistanceMetricAvx2<A> + DistanceMetricNeon<A>
+    DistanceMetricScalar<A>
+    + DistanceMetricAvx512<A>
+    + DistanceMetricAvx2<A>
+    + DistanceMetricNeon<A>
+    + DistanceMetricWasmSimd<A>
 {
     /// Autovec/scalar Block3 backtrack mask generation.
     #[inline(always)]
@@ -1505,6 +1979,7 @@ impl<T, A: Copy> DistanceMetric<A> for T where
         + DistanceMetricAvx512<A>
         + DistanceMetricAvx2<A>
         + DistanceMetricNeon<A>
+        + DistanceMetricWasmSimd<A>
 {
 }
 

--- a/src/dist/squared_euclidean/mod.rs
+++ b/src/dist/squared_euclidean/mod.rs
@@ -4,7 +4,7 @@ use crate::Axis;
 
 use crate::dist::{
     DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon, DistanceMetricScalar,
-    WideningCastFrom,
+    DistanceMetricWasmSimd, WideningCastFrom,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -15,6 +15,9 @@ mod avx512;
 
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 mod neon;
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+mod wasm_simd;
 
 /// Squared Euclidean distance metric, parameterized by output type `R`.
 pub struct SquaredEuclidean<R>(core::marker::PhantomData<R>);
@@ -72,6 +75,18 @@ where
 
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF32Ops = neon::SquaredEuclideanNeonF32LeafOps;
+}
+
+impl<A, R> DistanceMetricWasmSimd<A> for SquaredEuclidean<R>
+where
+    A: Copy,
+    R: Axis<Coord = R> + WideningCastFrom<A> + Mul<Output = R> + Add<Output = R>,
+{
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops = wasm_simd::SquaredEuclideanWasmSimdF64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops = wasm_simd::SquaredEuclideanWasmSimdF32LeafOps;
 }
 
 #[cfg(feature = "cargo_asm")]

--- a/src/dist/squared_euclidean/wasm_simd.rs
+++ b/src/dist/squared_euclidean/wasm_simd.rs
@@ -1,0 +1,51 @@
+use core::arch::wasm32::*;
+
+use crate::dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps};
+
+pub struct SquaredEuclideanWasmSimdF64LeafOps;
+
+impl WasmSimdF64LeafOps for SquaredEuclideanWasmSimdF64LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f64x2(delta: v128) -> v128 {
+        f64x2_mul(delta, delta)
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f64x2(acc: v128, delta: v128) -> v128 {
+        f64x2_add(acc, f64x2_mul(delta, delta))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f64x1(delta: f64) -> f64 {
+        delta * delta
+    }
+
+    #[inline(always)]
+    fn dist_kn_f64x1(acc: f64, delta: f64) -> f64 {
+        acc + delta * delta
+    }
+}
+
+pub struct SquaredEuclideanWasmSimdF32LeafOps;
+
+impl WasmSimdF32LeafOps for SquaredEuclideanWasmSimdF32LeafOps {
+    #[inline(always)]
+    unsafe fn dist_k0_f32x4(delta: v128) -> v128 {
+        f32x4_mul(delta, delta)
+    }
+
+    #[inline(always)]
+    unsafe fn dist_kn_f32x4(acc: v128, delta: v128) -> v128 {
+        f32x4_add(acc, f32x4_mul(delta, delta))
+    }
+
+    #[inline(always)]
+    fn dist_k0_f32x1(delta: f32) -> f32 {
+        delta * delta
+    }
+
+    #[inline(always)]
+    fn dist_kn_f32x1(acc: f32, delta: f32) -> f32 {
+        acc + delta * delta
+    }
+}

--- a/src/leaf_view/mod.rs
+++ b/src/leaf_view/mod.rs
@@ -396,7 +396,8 @@ where
     #[cfg(any(
         all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
         all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-        all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+        all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+        all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
     ))]
     #[inline(always)]
     pub(crate) fn len(&self) -> usize {
@@ -406,7 +407,8 @@ where
     #[cfg(any(
         all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
         all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-        all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+        all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+        all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
     ))]
     #[inline(always)]
     pub(crate) fn as_ptr(&self) -> *const u8 {
@@ -743,7 +745,8 @@ mod tests {
         #[cfg(any(
             all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"),
             all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"),
-            all(feature = "simd", target_arch = "aarch64", target_feature = "neon")
+            all(feature = "simd", target_arch = "aarch64", target_feature = "neon"),
+            all(feature = "simd", target_arch = "wasm32", target_feature = "simd128")
         ))]
         {
             assert_eq!(arena.len(), items.len());

--- a/src/leaf_view_chunked/best_n_within/mod.rs
+++ b/src/leaf_view_chunked/best_n_within/mod.rs
@@ -9,6 +9,9 @@ pub(crate) mod avx512;
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 pub(crate) mod neon;
 
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+pub(crate) mod wasm_simd;
+
 use crate::dist::DistanceMetric;
 use crate::leaf_view::{LeafArena, LeafView, TlsLeafScratch};
 use crate::results::result_collection::BestNeighbourResultCollection;
@@ -68,6 +71,19 @@ pub(crate) fn best_n_within_with_query_wide_arena<
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     if unsafe {
         try_best_n_within_arena_neon::<AX, T, D, R, EXCLUSIVE, K>(
+            arena,
+            query_wide,
+            dist,
+            threshold_item,
+            results,
+        )
+    } {
+        return;
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    if unsafe {
+        try_best_n_within_arena_wasm_simd::<AX, T, D, R, EXCLUSIVE, K>(
             arena,
             query_wide,
             dist,
@@ -138,6 +154,19 @@ pub(crate) fn best_n_within_with_query_wide<
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     if unsafe {
         try_best_n_within_neon::<AX, T, D, R, EXCLUSIVE, K, B>(
+            leaf,
+            query_wide,
+            dist,
+            threshold_item,
+            results,
+        )
+    } {
+        return;
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    if unsafe {
+        try_best_n_within_wasm_simd::<AX, T, D, R, EXCLUSIVE, K, B>(
             leaf,
             query_wide,
             dist,
@@ -323,6 +352,64 @@ where
     R: BestNeighbourResultCollection<D::Output, T>,
 {
     D::try_best_n_within_arena_neon::<T, R, EXCLUSIVE, K>(
+        arena,
+        query_wide,
+        dist,
+        threshold_item,
+        results,
+    )
+}
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+unsafe fn try_best_n_within_wasm_simd<
+    AX,
+    T,
+    D,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, AX, T, K, B>,
+    query_wide: &[D::Output; K],
+    dist: D::Output,
+    threshold_item: Option<T>,
+    results: &mut R,
+) -> bool
+where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content + PartialOrd,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+    R: BestNeighbourResultCollection<D::Output, T>,
+{
+    D::try_best_n_within_leaf_wasm_simd::<T, R, EXCLUSIVE, K, B>(
+        leaf,
+        query_wide,
+        dist,
+        threshold_item,
+        results,
+    )
+}
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+unsafe fn try_best_n_within_arena_wasm_simd<AX, T, D, R, const EXCLUSIVE: bool, const K: usize>(
+    arena: &LeafArena<'_, AX, T, K>,
+    query_wide: &[D::Output; K],
+    dist: D::Output,
+    threshold_item: Option<T>,
+    results: &mut R,
+) -> bool
+where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content + PartialOrd,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+    R: BestNeighbourResultCollection<D::Output, T>,
+{
+    D::try_best_n_within_arena_wasm_simd::<T, R, EXCLUSIVE, K>(
         arena,
         query_wide,
         dist,

--- a/src/leaf_view_chunked/best_n_within/wasm_simd.rs
+++ b/src/leaf_view_chunked/best_n_within/wasm_simd.rs
@@ -1,0 +1,115 @@
+use crate::{
+    dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps},
+    leaf_view::LeafView,
+    Content,
+};
+
+pub(crate) unsafe fn best_n_within_wasm_unchecked_f64<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f64, T, K, B>,
+    query: &[f64; K],
+    max_dist: f64,
+    emit: &mut F,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f64, T),
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_unchecked_f64::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+        B,
+    >(leaf, query, max_dist, &mut emit_positioned);
+}
+
+pub(crate) unsafe fn best_n_within_wasm_arena_unchecked_f64<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f64; K],
+    max_dist: f64,
+    emit: &mut F,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f64, T),
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_arena_unchecked_f64::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+    >(tile_base, len, query, max_dist, &mut emit_positioned);
+}
+
+pub(crate) unsafe fn best_n_within_wasm_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f32, T, K, B>,
+    query: &[f32; K],
+    max_dist: f32,
+    emit: &mut F,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f32, T),
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_unchecked_f32::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+        B,
+    >(leaf, query, max_dist, &mut emit_positioned);
+}
+
+pub(crate) unsafe fn best_n_within_wasm_arena_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f32; K],
+    max_dist: f32,
+    emit: &mut F,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content + PartialOrd,
+    F: FnMut(f32, T),
+{
+    let mut emit_positioned = |_, distance, item| emit(distance, item);
+    crate::leaf_view_chunked::nearest_n_within::wasm_simd::nearest_n_within_wasm_arena_unchecked_f32::<
+        L,
+        T,
+        _,
+        EXCLUSIVE,
+        K,
+    >(tile_base, len, query, max_dist, &mut emit_positioned);
+}

--- a/src/leaf_view_chunked/nearest_n_within/mod.rs
+++ b/src/leaf_view_chunked/nearest_n_within/mod.rs
@@ -9,6 +9,9 @@ pub(crate) mod avx512;
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 pub(crate) mod neon;
 
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+pub(crate) mod wasm_simd;
+
 use crate::dist::DistanceMetric;
 use crate::leaf_view::{LeafArena, LeafView, TlsLeafScratch};
 use crate::results::result_collection::{FromLeafCandidate, ResultCollection};
@@ -67,6 +70,15 @@ pub(crate) fn nearest_n_within_with_query_wide_arena<
         return;
     }
 
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    if unsafe {
+        try_nearest_n_within_arena_wasm_simd::<AX, T, D, E, R, EXCLUSIVE, K>(
+            arena, query_wide, dist, results,
+        )
+    } {
+        return;
+    }
+
     nearest_n_within_with_query_wide_arena_fallback::<AX, T, D, E, R, EXCLUSIVE, K>(
         arena, query_wide, dist, results,
     );
@@ -116,6 +128,15 @@ pub(crate) fn nearest_n_within_with_query_wide<
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     if unsafe {
         try_nearest_n_within_neon::<AX, T, D, E, R, EXCLUSIVE, K, B>(
+            leaf, query_wide, dist, results,
+        )
+    } {
+        return;
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    if unsafe {
+        try_nearest_n_within_wasm_simd::<AX, T, D, E, R, EXCLUSIVE, K, B>(
             leaf, query_wide, dist, results,
         )
     } {
@@ -266,4 +287,63 @@ where
     R: ResultCollection<D::Output, E>,
 {
     D::try_nearest_n_within_arena_neon::<T, E, R, EXCLUSIVE, K>(arena, query_wide, dist, results)
+}
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+unsafe fn try_nearest_n_within_wasm_simd<
+    AX,
+    T,
+    D,
+    E,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, AX, T, K, B>,
+    query_wide: &[D::Output; K],
+    dist: D::Output,
+    results: &mut R,
+) -> bool
+where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+    E: FromLeafCandidate<AX, T, D::Output, K>,
+    R: ResultCollection<D::Output, E>,
+{
+    D::try_nearest_n_within_leaf_wasm_simd::<T, E, R, EXCLUSIVE, K, B>(
+        leaf, query_wide, dist, results,
+    )
+}
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+unsafe fn try_nearest_n_within_arena_wasm_simd<
+    AX,
+    T,
+    D,
+    E,
+    R,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    arena: &LeafArena<'_, AX, T, K>,
+    query_wide: &[D::Output; K],
+    dist: D::Output,
+    results: &mut R,
+) -> bool
+where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+    E: FromLeafCandidate<AX, T, D::Output, K>,
+    R: ResultCollection<D::Output, E>,
+{
+    D::try_nearest_n_within_arena_wasm_simd::<T, E, R, EXCLUSIVE, K>(
+        arena, query_wide, dist, results,
+    )
 }

--- a/src/leaf_view_chunked/nearest_n_within/wasm_simd.rs
+++ b/src/leaf_view_chunked/nearest_n_within/wasm_simd.rs
@@ -1,0 +1,378 @@
+use core::arch::wasm32::*;
+
+use array_init::array_init;
+
+use crate::{
+    dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps},
+    leaf_view::LeafView,
+    Content,
+};
+
+/// Load 2 consecutive f64 lanes from an arbitrarily-aligned address.
+///
+/// Arena coordinate columns can land on an 8-byte boundary, so `v128_load` and
+/// its alignment of 16 would be unsound here.
+#[inline(always)]
+pub(crate) unsafe fn load_f64x2(ptr: *const f64) -> v128 {
+    std::ptr::read_unaligned(ptr as *const v128)
+}
+
+/// Load 4 consecutive f32 lanes from an arbitrarily-aligned address.
+///
+/// Unaligned for the same reason as [`load_f64x2`].
+#[inline(always)]
+unsafe fn load_f32x4(ptr: *const f32) -> v128 {
+    std::ptr::read_unaligned(ptr as *const v128)
+}
+
+#[inline(always)]
+unsafe fn emit_results_wasm_f64<T, F, const EXCLUSIVE: bool>(
+    dists: v128,
+    items: *const T,
+    base: usize,
+    max_dist: f64,
+    emit: &mut F,
+) where
+    T: Content,
+    F: FnMut(usize, f64, T),
+{
+    let mask = if EXCLUSIVE {
+        f64x2_lt(dists, f64x2_splat(max_dist))
+    } else {
+        f64x2_le(dists, f64x2_splat(max_dist))
+    };
+    let lanes = i64x2_bitmask(mask);
+    if lanes == 0 {
+        return;
+    }
+
+    if lanes & 0b01 != 0 {
+        emit(
+            base,
+            f64x2_extract_lane::<0>(dists),
+            std::ptr::read_unaligned(items.add(base)),
+        );
+    }
+    if lanes & 0b10 != 0 {
+        emit(
+            base + 1,
+            f64x2_extract_lane::<1>(dists),
+            std::ptr::read_unaligned(items.add(base + 1)),
+        );
+    }
+}
+
+#[inline(always)]
+pub(crate) unsafe fn line_dists_wasm_f64<L, const K: usize>(
+    points: &[*const f64; K],
+    query: &[v128; K],
+    base: usize,
+) -> v128
+where
+    L: WasmSimdF64LeafOps,
+{
+    let a0 = load_f64x2(points[0].add(base));
+    let d0 = f64x2_sub(a0, query[0]);
+    let mut acc = L::dist_k0_f64x2(d0);
+
+    for dim in 1..K {
+        let a = load_f64x2(points[dim].add(base));
+        let d = f64x2_sub(a, query[dim]);
+        acc = L::dist_kn_f64x2(acc, d);
+    }
+
+    acc
+}
+
+#[inline(always)]
+pub(crate) unsafe fn dist_scalar_f64<L, const K: usize>(
+    points: &[*const f64; K],
+    query: &[f64; K],
+    idx: usize,
+) -> f64
+where
+    L: WasmSimdF64LeafOps,
+{
+    let mut dist = L::dist_k0_f64x1(*points[0].add(idx) - query[0]);
+    for dim in 1..K {
+        dist = L::dist_kn_f64x1(dist, *points[dim].add(idx) - query[dim]);
+    }
+    dist
+}
+
+pub(crate) unsafe fn nearest_n_within_wasm_unchecked_f64<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f64, T, K, B>,
+    query: &[f64; K],
+    max_dist: f64,
+    emit: &mut F,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content,
+    F: FnMut(usize, f64, T),
+{
+    let points = leaf.points();
+    let point_ptrs = array_init(|dim| points[dim].as_ptr());
+    nearest_n_within_wasm_raw_f64::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs,
+        leaf.items().as_ptr(),
+        leaf.items().len(),
+        query,
+        max_dist,
+        emit,
+    );
+}
+
+pub(crate) unsafe fn nearest_n_within_wasm_arena_unchecked_f64<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f64; K],
+    max_dist: f64,
+    emit: &mut F,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content,
+    F: FnMut(usize, f64, T),
+{
+    let point_base = tile_base as *const f64;
+    let point_ptrs = array_init(|dim| point_base.add(dim * len));
+    let items = tile_base.add(K * len * std::mem::size_of::<f64>()) as *const T;
+
+    nearest_n_within_wasm_raw_f64::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs, items, len, query, max_dist, emit,
+    );
+}
+
+unsafe fn nearest_n_within_wasm_raw_f64<L, T, F, const EXCLUSIVE: bool, const K: usize>(
+    points: [*const f64; K],
+    items: *const T,
+    len: usize,
+    query: &[f64; K],
+    max_dist: f64,
+    emit: &mut F,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content,
+    F: FnMut(usize, f64, T),
+{
+    if len == 0 {
+        return;
+    }
+
+    let query_wide = array_init(|dim| f64x2_splat(query[dim]));
+    let mut base = 0usize;
+
+    while base + 2 <= len {
+        let d0 = line_dists_wasm_f64::<L, K>(&points, &query_wide, base);
+        emit_results_wasm_f64::<_, _, EXCLUSIVE>(d0, items, base, max_dist, emit);
+        base += 2;
+    }
+
+    for idx in base..len {
+        let dist = dist_scalar_f64::<L, K>(&points, query, idx);
+        let is_within_dist = if EXCLUSIVE {
+            dist < max_dist
+        } else {
+            dist <= max_dist
+        };
+
+        if is_within_dist {
+            emit(idx, dist, std::ptr::read_unaligned(items.add(idx)));
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn emit_results_wasm_f32<T, F, const EXCLUSIVE: bool>(
+    dists: v128,
+    items: *const T,
+    base: usize,
+    max_dist: f32,
+    emit: &mut F,
+) where
+    T: Content,
+    F: FnMut(usize, f32, T),
+{
+    let mask = if EXCLUSIVE {
+        f32x4_lt(dists, f32x4_splat(max_dist))
+    } else {
+        f32x4_le(dists, f32x4_splat(max_dist))
+    };
+    let lanes = i32x4_bitmask(mask);
+    if lanes == 0 {
+        return;
+    }
+
+    if lanes & 0b0001 != 0 {
+        emit(
+            base,
+            f32x4_extract_lane::<0>(dists),
+            std::ptr::read_unaligned(items.add(base)),
+        );
+    }
+    if lanes & 0b0010 != 0 {
+        emit(
+            base + 1,
+            f32x4_extract_lane::<1>(dists),
+            std::ptr::read_unaligned(items.add(base + 1)),
+        );
+    }
+    if lanes & 0b0100 != 0 {
+        emit(
+            base + 2,
+            f32x4_extract_lane::<2>(dists),
+            std::ptr::read_unaligned(items.add(base + 2)),
+        );
+    }
+    if lanes & 0b1000 != 0 {
+        emit(
+            base + 3,
+            f32x4_extract_lane::<3>(dists),
+            std::ptr::read_unaligned(items.add(base + 3)),
+        );
+    }
+}
+
+#[inline(always)]
+pub(crate) unsafe fn line_dists_wasm_f32<L, const K: usize>(
+    points: &[*const f32; K],
+    query: &[v128; K],
+    base: usize,
+) -> v128
+where
+    L: WasmSimdF32LeafOps,
+{
+    let a0 = load_f32x4(points[0].add(base));
+    let d0 = f32x4_sub(a0, query[0]);
+    let mut acc = L::dist_k0_f32x4(d0);
+
+    for dim in 1..K {
+        let a = load_f32x4(points[dim].add(base));
+        let d = f32x4_sub(a, query[dim]);
+        acc = L::dist_kn_f32x4(acc, d);
+    }
+
+    acc
+}
+
+#[inline(always)]
+pub(crate) unsafe fn dist_scalar_f32<L, const K: usize>(
+    points: &[*const f32; K],
+    query: &[f32; K],
+    idx: usize,
+) -> f32
+where
+    L: WasmSimdF32LeafOps,
+{
+    let mut dist = L::dist_k0_f32x1(*points[0].add(idx) - query[0]);
+    for dim in 1..K {
+        dist = L::dist_kn_f32x1(dist, *points[dim].add(idx) - query[dim]);
+    }
+    dist
+}
+
+pub(crate) unsafe fn nearest_n_within_wasm_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+    const B: usize,
+>(
+    leaf: &LeafView<'_, f32, T, K, B>,
+    query: &[f32; K],
+    max_dist: f32,
+    emit: &mut F,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content,
+    F: FnMut(usize, f32, T),
+{
+    let points = leaf.points();
+    let point_ptrs = array_init(|dim| points[dim].as_ptr());
+    nearest_n_within_wasm_raw_f32::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs,
+        leaf.items().as_ptr(),
+        leaf.items().len(),
+        query,
+        max_dist,
+        emit,
+    );
+}
+
+pub(crate) unsafe fn nearest_n_within_wasm_arena_unchecked_f32<
+    L,
+    T,
+    F,
+    const EXCLUSIVE: bool,
+    const K: usize,
+>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f32; K],
+    max_dist: f32,
+    emit: &mut F,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content,
+    F: FnMut(usize, f32, T),
+{
+    let point_base = tile_base as *const f32;
+    let point_ptrs = array_init(|dim| point_base.add(dim * len));
+    let items = tile_base.add(K * len * std::mem::size_of::<f32>()) as *const T;
+
+    nearest_n_within_wasm_raw_f32::<L, T, F, EXCLUSIVE, K>(
+        point_ptrs, items, len, query, max_dist, emit,
+    );
+}
+
+unsafe fn nearest_n_within_wasm_raw_f32<L, T, F, const EXCLUSIVE: bool, const K: usize>(
+    points: [*const f32; K],
+    items: *const T,
+    len: usize,
+    query: &[f32; K],
+    max_dist: f32,
+    emit: &mut F,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content,
+    F: FnMut(usize, f32, T),
+{
+    if len == 0 {
+        return;
+    }
+
+    let query_wide = array_init(|dim| f32x4_splat(query[dim]));
+    let mut base = 0usize;
+
+    while base + 4 <= len {
+        let d0 = line_dists_wasm_f32::<L, K>(&points, &query_wide, base);
+        emit_results_wasm_f32::<_, _, EXCLUSIVE>(d0, items, base, max_dist, emit);
+        base += 4;
+    }
+
+    for idx in base..len {
+        let dist = dist_scalar_f32::<L, K>(&points, query, idx);
+        let is_within_dist = if EXCLUSIVE {
+            dist < max_dist
+        } else {
+            dist <= max_dist
+        };
+
+        if is_within_dist {
+            emit(idx, dist, std::ptr::read_unaligned(items.add(idx)));
+        }
+    }
+}

--- a/src/leaf_view_chunked/nearest_one/mod.rs
+++ b/src/leaf_view_chunked/nearest_one/mod.rs
@@ -3,6 +3,9 @@ mod fallback;
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
 pub(crate) mod avx512;
 
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+pub(crate) mod wasm_simd;
+
 use crate::dist::DistanceMetric;
 use crate::leaf_view::{LeafArena, LeafView};
 use crate::{Axis, Content};
@@ -32,6 +35,13 @@ pub(crate) fn nearest_one_with_query_wide_arena<AX, T, D, const K: usize>(
         return;
     }
 
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    if unsafe {
+        try_nearest_one_arena_wasm_simd::<AX, T, D, K>(arena, query_wide, best_dist, best_item)
+    } {
+        return;
+    }
+
     nearest_one_with_query_wide_arena_fallback::<AX, T, D, K>(
         arena, query_wide, best_dist, best_item,
     );
@@ -51,6 +61,13 @@ pub(crate) fn nearest_one_with_query_wide<AX, T, D, const K: usize, const B: usi
 {
     #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
     if unsafe { try_nearest_one_avx512::<AX, T, D, K, B>(leaf, query_wide, best_dist, best_item) } {
+        return;
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    if unsafe {
+        try_nearest_one_wasm_simd::<AX, T, D, K, B>(leaf, query_wide, best_dist, best_item)
+    } {
         return;
     }
 
@@ -89,4 +106,38 @@ where
     D::Output: Axis<Coord = D::Output> + 'static,
 {
     D::try_nearest_one_arena_avx512(arena, query_wide, best_dist, best_item)
+}
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+unsafe fn try_nearest_one_wasm_simd<AX, T, D, const K: usize, const B: usize>(
+    leaf: &LeafView<'_, AX, T, K, B>,
+    query_wide: &[D::Output; K],
+    best_dist: &mut D::Output,
+    best_item: &mut T,
+) -> bool
+where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+{
+    D::try_nearest_one_leaf_wasm_simd(leaf, query_wide, best_dist, best_item)
+}
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+unsafe fn try_nearest_one_arena_wasm_simd<AX, T, D, const K: usize>(
+    arena: &LeafArena<'_, AX, T, K>,
+    query_wide: &[D::Output; K],
+    best_dist: &mut D::Output,
+    best_item: &mut T,
+) -> bool
+where
+    AX: Axis<Coord = AX> + 'static,
+    T: Content,
+    D: DistanceMetric<AX>,
+    D::Output: Axis<Coord = D::Output> + 'static,
+{
+    D::try_nearest_one_arena_wasm_simd(arena, query_wide, best_dist, best_item)
 }

--- a/src/leaf_view_chunked/nearest_one/wasm_simd.rs
+++ b/src/leaf_view_chunked/nearest_one/wasm_simd.rs
@@ -1,0 +1,222 @@
+use core::arch::wasm32::*;
+
+use array_init::array_init;
+
+use super::super::nearest_n_within::wasm_simd::{
+    dist_scalar_f32, dist_scalar_f64, line_dists_wasm_f32, line_dists_wasm_f64,
+};
+use crate::{
+    dist::distance_metric_wasm_simd::{WasmSimdF32LeafOps, WasmSimdF64LeafOps},
+    leaf_view::LeafView,
+    Content,
+};
+
+/// Sentinel for "no lane has produced a candidate yet".
+const NO_CANDIDATE: i64 = -1;
+
+pub(crate) unsafe fn nearest_one_wasm_unchecked_f64<L, T, const K: usize, const B: usize>(
+    leaf: &LeafView<'_, f64, T, K, B>,
+    query: &[f64; K],
+    best_dist: &mut f64,
+    best_item: &mut T,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content,
+{
+    let points = leaf.points();
+    let point_ptrs = array_init(|dim| points[dim].as_ptr());
+    nearest_one_wasm_raw_f64::<L, T, K>(
+        point_ptrs,
+        leaf.items().as_ptr(),
+        leaf.items().len(),
+        query,
+        best_dist,
+        best_item,
+    );
+}
+
+pub(crate) unsafe fn nearest_one_wasm_arena_unchecked_f64<L, T, const K: usize>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f64; K],
+    best_dist: &mut f64,
+    best_item: &mut T,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content,
+{
+    let point_base = tile_base as *const f64;
+    let point_ptrs = array_init(|dim| point_base.add(dim * len));
+    let items = tile_base.add(K * len * std::mem::size_of::<f64>()) as *const T;
+
+    nearest_one_wasm_raw_f64::<L, T, K>(point_ptrs, items, len, query, best_dist, best_item);
+}
+
+unsafe fn nearest_one_wasm_raw_f64<L, T, const K: usize>(
+    points: [*const f64; K],
+    items: *const T,
+    len: usize,
+    query: &[f64; K],
+    best_dist: &mut f64,
+    best_item: &mut T,
+) where
+    L: WasmSimdF64LeafOps,
+    T: Content,
+{
+    if len == 0 {
+        return;
+    }
+
+    let query_wide: [v128; K] = array_init(|dim| f64x2_splat(query[dim]));
+
+    let mut best_vec = f64x2_splat(*best_dist);
+    let mut best_idx = i64x2_splat(NO_CANDIDATE);
+    let mut idx_vec = i64x2(0, 1);
+    let step = i64x2_splat(2);
+
+    let mut base = 0usize;
+    while base + 2 <= len {
+        let dists = line_dists_wasm_f64::<L, K>(&points, &query_wide, base);
+        let improves = f64x2_lt(dists, best_vec);
+        best_vec = v128_bitselect(dists, best_vec, improves);
+        best_idx = v128_bitselect(idx_vec, best_idx, improves);
+        idx_vec = i64x2_add(idx_vec, step);
+        base += 2;
+    }
+
+    // Break a distance tie on the smaller index.  The scalar fallback updates on
+    // a strict `<`, keeping the first point that achieves the minimum; within a
+    // lane `f64x2_lt` does the same, but across lanes only this comparison does.
+    let (mut winning_dist, mut winning_idx) = (
+        f64x2_extract_lane::<0>(best_vec),
+        i64x2_extract_lane::<0>(best_idx),
+    );
+    let (lane1_dist, lane1_idx) = (
+        f64x2_extract_lane::<1>(best_vec),
+        i64x2_extract_lane::<1>(best_idx),
+    );
+    if lane1_dist < winning_dist || (lane1_dist == winning_dist && lane1_idx < winning_idx) {
+        winning_dist = lane1_dist;
+        winning_idx = lane1_idx;
+    }
+
+    for idx in base..len {
+        let dist = dist_scalar_f64::<L, K>(&points, query, idx);
+        if dist < winning_dist {
+            winning_dist = dist;
+            winning_idx = idx as i64;
+        }
+    }
+
+    if winning_idx != NO_CANDIDATE {
+        *best_dist = winning_dist;
+        *best_item = std::ptr::read_unaligned(items.add(winning_idx as usize));
+    }
+}
+
+pub(crate) unsafe fn nearest_one_wasm_unchecked_f32<L, T, const K: usize, const B: usize>(
+    leaf: &LeafView<'_, f32, T, K, B>,
+    query: &[f32; K],
+    best_dist: &mut f32,
+    best_item: &mut T,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content,
+{
+    let points = leaf.points();
+    let point_ptrs = array_init(|dim| points[dim].as_ptr());
+    nearest_one_wasm_raw_f32::<L, T, K>(
+        point_ptrs,
+        leaf.items().as_ptr(),
+        leaf.items().len(),
+        query,
+        best_dist,
+        best_item,
+    );
+}
+
+pub(crate) unsafe fn nearest_one_wasm_arena_unchecked_f32<L, T, const K: usize>(
+    tile_base: *const u8,
+    len: usize,
+    query: &[f32; K],
+    best_dist: &mut f32,
+    best_item: &mut T,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content,
+{
+    let point_base = tile_base as *const f32;
+    let point_ptrs = array_init(|dim| point_base.add(dim * len));
+    let items = tile_base.add(K * len * std::mem::size_of::<f32>()) as *const T;
+
+    nearest_one_wasm_raw_f32::<L, T, K>(point_ptrs, items, len, query, best_dist, best_item);
+}
+
+unsafe fn nearest_one_wasm_raw_f32<L, T, const K: usize>(
+    points: [*const f32; K],
+    items: *const T,
+    len: usize,
+    query: &[f32; K],
+    best_dist: &mut f32,
+    best_item: &mut T,
+) where
+    L: WasmSimdF32LeafOps,
+    T: Content,
+{
+    if len == 0 {
+        return;
+    }
+
+    let query_wide: [v128; K] = array_init(|dim| f32x4_splat(query[dim]));
+
+    let mut best_vec = f32x4_splat(*best_dist);
+    let mut best_idx = i32x4_splat(NO_CANDIDATE as i32);
+    let mut idx_vec = i32x4(0, 1, 2, 3);
+    let step = i32x4_splat(4);
+
+    let mut base = 0usize;
+    while base + 4 <= len {
+        let dists = line_dists_wasm_f32::<L, K>(&points, &query_wide, base);
+        let improves = f32x4_lt(dists, best_vec);
+        best_vec = v128_bitselect(dists, best_vec, improves);
+        best_idx = v128_bitselect(idx_vec, best_idx, improves);
+        idx_vec = i32x4_add(idx_vec, step);
+        base += 4;
+    }
+
+    let mut winning_dist = f32x4_extract_lane::<0>(best_vec);
+    let mut winning_idx = i32x4_extract_lane::<0>(best_idx);
+    let lanes = [
+        (
+            f32x4_extract_lane::<1>(best_vec),
+            i32x4_extract_lane::<1>(best_idx),
+        ),
+        (
+            f32x4_extract_lane::<2>(best_vec),
+            i32x4_extract_lane::<2>(best_idx),
+        ),
+        (
+            f32x4_extract_lane::<3>(best_vec),
+            i32x4_extract_lane::<3>(best_idx),
+        ),
+    ];
+    for (dist, idx) in lanes {
+        if dist < winning_dist || (dist == winning_dist && idx < winning_idx) {
+            winning_dist = dist;
+            winning_idx = idx;
+        }
+    }
+
+    for idx in base..len {
+        let dist = dist_scalar_f32::<L, K>(&points, query, idx);
+        if dist < winning_dist {
+            winning_dist = dist;
+            winning_idx = idx as i32;
+        }
+    }
+
+    if winning_idx != NO_CANDIDATE as i32 {
+        *best_dist = winning_dist;
+        *best_item = std::ptr::read_unaligned(items.add(winning_idx as usize));
+    }
+}

--- a/src/traits/dist.rs
+++ b/src/traits/dist.rs
@@ -3,7 +3,7 @@
 #[doc(inline)]
 pub use crate::dist::{
     DistanceMetric, DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon,
-    DistanceMetricScalar,
+    DistanceMetricScalar, DistanceMetricWasmSimd,
 };
 
 #[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx2"))]
@@ -19,3 +19,9 @@ pub use crate::dist::distance_metric_avx512::{
 #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
 #[doc(inline)]
 pub use crate::dist::distance_metric_neon::{UnsupportedNeonF32LeafOps, UnsupportedNeonF64LeafOps};
+
+#[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+#[doc(inline)]
+pub use crate::dist::distance_metric_wasm_simd::{
+    UnsupportedWasmSimdF32LeafOps, UnsupportedWasmSimdF64LeafOps,
+};

--- a/tests/custom_metric_block_fallback.rs
+++ b/tests/custom_metric_block_fallback.rs
@@ -1,6 +1,6 @@
 use kiddo::dist::{
     DistanceMetric, DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon,
-    DistanceMetricScalar,
+    DistanceMetricScalar, DistanceMetricWasmSimd,
 };
 use kiddo::leaf_strategies::VecOfArenas;
 use kiddo::stem_strategies::{DonnellySimdFull, Eytzinger};
@@ -42,6 +42,14 @@ impl DistanceMetricNeon<f64> for AbsDistance {
 
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF32Ops = kiddo::traits::dist::UnsupportedNeonF32LeafOps;
+}
+
+impl DistanceMetricWasmSimd<f64> for AbsDistance {
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops = kiddo::traits::dist::UnsupportedWasmSimdF64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops = kiddo::traits::dist::UnsupportedWasmSimdF32LeafOps;
 }
 
 type GeneralTree = KdTree<f64, u32, Eytzinger, VecOfArenas<f64, u32, 2, 32>, 2, 32>;

--- a/tests/custom_query_metric.rs
+++ b/tests/custom_query_metric.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 
 use kiddo::dist::{
     DistanceMetric, DistanceMetricAvx2, DistanceMetricAvx512, DistanceMetricNeon,
-    DistanceMetricScalar, QueryMetric,
+    DistanceMetricScalar, DistanceMetricWasmSimd, QueryMetric,
 };
 use kiddo::leaf_strategies::VecOfArrays;
 use kiddo::{Axis, Eytzinger, KdTree};
@@ -43,6 +43,14 @@ impl DistanceMetricNeon<f64> for AbsDistance {
 
     #[cfg(all(feature = "simd", target_arch = "aarch64", target_feature = "neon"))]
     type NeonF32Ops = kiddo::traits::dist::UnsupportedNeonF32LeafOps;
+}
+
+impl DistanceMetricWasmSimd<f64> for AbsDistance {
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF64Ops = kiddo::traits::dist::UnsupportedWasmSimdF64LeafOps;
+
+    #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
+    type WasmSimdF32Ops = kiddo::traits::dist::UnsupportedWasmSimdF32LeafOps;
 }
 
 type TestTree = KdTree<f64, u32, Eytzinger, VecOfArrays<f64, u32, 2, 32>, 2, 32>;

--- a/tests/wasm-smoke/Cargo.toml
+++ b/tests/wasm-smoke/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[features]
+simd = ["kiddo/simd"]
+
 [dependencies]
 kiddo = { path = "../.." }


### PR DESCRIPTION
# WebAssembly SIMD128 leaf kernels: benchmark

50k clustered points, 50k uniform probes, best of 12 x 6 rotating rounds; two independent
runs, reported as `A / B`. Three builds: `scalar`, `simd128/auto` (+simd128, autovectorizer
only) and `simd128/kiddo` (+simd128 plus the kernels).

| kernel | vs scalar | vs autovec |
| --- | --- | --- |
| build items *(control)* | 1.00x / 1.00x | 1.00x / 1.00x |
| build points *(control)* | 1.02x / 1.01x | 1.00x / 0.99x |
| knn k=6 | 1.04x / 1.05x | 1.07x / 1.07x |
| **nearest_one** | **1.19x / 1.20x** | **1.19x / 1.21x** |
| k=2 off-index | 1.01x / 1.00x | 0.99x / 1.00x |
| k=2 self-excluded | 1.00x / 0.99x | 1.00x / 1.00x |
| knn k=6, B=128 | 1.07x / 1.05x | 1.09x / 1.08x |
| **nearest_one, B=128** | **1.67x / 1.70x** | **1.68x / 1.69x** |

`nearest_one` is the only clear win; `B = 128` quadruples the leaf scan and nearly doubles
its lead, confirming that is what the kernel speeds up, while `knn k=6` barely moves because
its time goes into the per-candidate result insertion. Construction runs no leaf kernel, so
the controls qualify the run; all builds agree on every checksum, which is order-sensitive
over selected items and so covers `nearest_one`'s tie-breaking.