### PR TITLE
feat: add immutable tree-to-tree queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,11 @@ harness = false
 required-features = ["test_utils"]
 
 [[bench]]
+name = "tree_radius_join"
+harness = false
+required-features = ["multi-threaded"]
+
+[[bench]]
 name = "v6_periodic_queries"
 harness = false
 required-features = ["test_utils"]
@@ -783,3 +788,7 @@ path = "tests/custom_query_metric.rs"
 [[test]]
 name = "custom_leaf_strategy"
 path = "tests/custom_leaf_strategy.rs"
+
+[[test]]
+name = "tree_radius_join"
+path = "tests/tree_radius_join.rs"

--- a/benches/tree_radius_join.rs
+++ b/benches/tree_radius_join.rs
@@ -1,0 +1,175 @@
+//! Standalone interleaved benchmark. Configuration is through JOIN_* variables.
+//! See docs/tree-radius-join.md for reproducible commands and workload selection.
+use kiddo::batch::{Executor, ThreadPoolBuilder};
+use kiddo::kd_tree::KdTreeAccessor;
+use kiddo::leaf_strategy::{FlatVec, VecOfArenas};
+use kiddo::stem_strategy::{Donnelly, Eytzinger};
+use kiddo::{KdTree, LeafStrategy, SquaredEuclidean, StemStrategy};
+use rayon::prelude::*;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Instant;
+
+fn env(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.into())
+}
+fn integer(name: &str, default: &str) -> usize {
+    env(name, default).parse().unwrap()
+}
+
+macro_rules! runner {
+    ($name:ident, $a:ty, $store:ident) => {
+        fn $name<SS: StemStrategy, const K: usize, const B: usize>() {
+            let n = integer("JOIN_N","65536");
+            let m = integer("JOIN_M", &n.to_string());
+            let threads = integer("JOIN_THREADS","1");
+            let rounds = integer("JOIN_ROUNDS","7");
+            let kind = env("JOIN_DISTRIBUTION","uniform");
+            let sink = env("JOIN_SINK","count");
+            let only = env("JOIN_ONLY","both");
+            let volume = if K == 2 { std::f64::consts::PI } else { 4.0 * std::f64::consts::PI / 3.0 };
+            let default_radius = (16.0 / (m.max(1) as f64 * volume)).powf(1.0 / K as f64);
+            let radius: $a = env("JOIN_RADIUS",&default_radius.to_string()).parse().unwrap();
+            let r2 = radius * radius;
+            let make = |len: usize, mut state: u64, right: bool| {
+                (0..len).map(|i| std::array::from_fn(|d| {
+                    state ^= state << 13; state ^= state >> 7; state ^= state << 17;
+                    let x = (state >> 11) as f64 / (1u64 << 53) as f64;
+                    (match kind.as_str() {
+                        "uniform" => x,
+                        "clustered" => ((i >> d) & 1) as f64 * 0.75 + x * 0.02,
+                        "separated" => x + if right { 2.0 } else { 0.0 },
+                        "anisotropic" => if d == 0 { x } else { x * 0.001 },
+                        "duplicates" => 0.5,
+                        _ => panic!("unknown distribution"),
+                    }) as $a
+                })).collect::<Vec<[$a;K]>>()
+            };
+            let started = Instant::now();
+            let left = KdTree::<$a,u32,SS,$store<$a,u32,K,B>,K,B>::new_from_slice(&make(n,17,false)).unwrap();
+            let right = KdTree::<$a,u32,SS,$store<$a,u32,K,B>,K,B>::new_from_slice(&make(m,78,true)).unwrap();
+            eprintln!("construction_seconds={:.6}",started.elapsed().as_secs_f64());
+            let pool = Arc::new(ThreadPoolBuilder::new().num_threads(threads).build().unwrap());
+            let mut executor = if threads == 1 { Executor::serial() } else { Executor::parallel_in_pool(pool.clone()) };
+            if let Ok(multiplier) = std::env::var("JOIN_TASK_MULTIPLIER") {
+                executor = executor.with_static_chunk_thread_multiplier(std::num::NonZeroUsize::new(multiplier.parse().unwrap()).unwrap());
+            }
+            let count = left.query_tree(&right).within::<SquaredEuclidean<$a>>(r2).with_executor(&executor).count();
+            if sink == "collect" || sink == "collect-distances" {
+                assert!(count <= integer("JOIN_MAX_RESULTS","16000000"), "collection exceeds JOIN_MAX_RESULTS; use count/streaming or raise the explicit limit");
+            }
+            let baseline = || {
+                let query_leaf = |leaf| {
+                    let leaves = KdTreeAccessor::leaves(&left);
+                    let len = <$store<$a,u32,K,B> as LeafStrategy<$a,u32,SS,K,B>>::leaf_len(leaves,leaf);
+                    let mut count = 0;
+                    let mut out = Vec::new();
+                    let mut items_out = Vec::new();
+                    let mut scratch = right.create_scratch::<SquaredEuclidean<$a>>();
+                    for i in 0..len {
+                        let (point,item) = <$store<$a,u32,K,B> as LeafStrategy<$a,u32,SS,K,B>>::leaf_point_item(leaves,leaf,i);
+                        match sink.as_str() {
+                            "count" => right.query(&point).within::<SquaredEuclidean<$a>>(r2).unsorted().without_items().without_distances()
+                                .with_scratch(&mut scratch).visit(|_| count += 1),
+                            "items" => right.query(&point).within::<SquaredEuclidean<$a>>(r2).unsorted().without_distances()
+                                .with_scratch(&mut scratch).visit(|p| { black_box((item,p.item)); count += 1; }),
+                            "distances" => right.query(&point).within::<SquaredEuclidean<$a>>(r2).unsorted()
+                                .with_scratch(&mut scratch).visit(|p| { black_box((item,p.item,p.distance)); count += 1; }),
+                            "collect" => right.query(&point).within::<SquaredEuclidean<$a>>(r2).unsorted().without_distances()
+                                .with_scratch(&mut scratch).visit(|p| { items_out.push((item,p.item)); count += 1; }),
+                            "collect-distances" => right.query(&point).within::<SquaredEuclidean<$a>>(r2).unsorted()
+                                .with_scratch(&mut scratch).visit(|p| { out.push((item,p.item,p.distance)); count += 1; }),
+                            _ => panic!("unknown sink"),
+                        }
+                    }
+                    (count,out,items_out)
+                };
+                if sink.starts_with("collect") {
+                    let chunks: Vec<_> = if threads == 1 { (0..left.leaf_count()).map(query_leaf).collect() }
+                        else { pool.install(|| (0..left.leaf_count()).into_par_iter().map(query_leaf).collect()) };
+                    let n: usize = chunks.iter().map(|(n,_,_)| n).sum();
+                    if sink == "collect" {
+                        let mut out = Vec::with_capacity(n);
+                        for (_,_,v) in chunks { out.extend(v); }
+                        black_box(out);
+                    } else {
+                        let mut out = Vec::with_capacity(n);
+                        for (_,v,_) in chunks { out.extend(v); }
+                        black_box(out);
+                    }
+                    n
+                } else if threads == 1 { (0..left.leaf_count()).map(|i| query_leaf(i).0).sum() }
+                else { pool.install(|| (0..left.leaf_count()).into_par_iter().map(|i| query_leaf(i).0).sum()) }
+            };
+            let join = || {
+                let q = left.query_tree(&right).within::<SquaredEuclidean<$a>>(r2).with_executor(&executor);
+                match sink.as_str() {
+                    "count" => assert_eq!(black_box(q.count()),count),
+                    "items" => q.without_distances().for_each(|p| { black_box(p); }),
+                    "distances" => q.for_each(|p| { black_box(p); }),
+                    "collect" => assert_eq!(black_box(q.without_distances().execute()).len(),count),
+                    "collect-distances" => assert_eq!(black_box(q.execute()).len(),count),
+                    _ => panic!("unknown sink"),
+                }
+            };
+            // Each variant warms once. Repeated runs alternate execution order.
+            join();
+            if only != "join" {
+                let old = baseline();
+                if old != count {
+                    assert_eq!(env("JOIN_ALLOW_BASELINE_BOUNDARY_DIFFERENCES","0"),"1",
+                        "baseline={old} scalar-exact join={count}; investigate with large_radius_boundary_diagnostic before accepting differences");
+                    eprintln!("boundary-difference allowed: baseline={old} scalar-exact-join={count}");
+                }
+            }
+            #[cfg(feature = "exact_query_stats")]
+            {
+                kiddo::tree_join_stats::reset();
+                join();
+                eprintln!("join_stats={:?}",kiddo::tree_join_stats::snapshot());
+            }
+            println!("variant,round,float,dimensions,bucket,storage,layout,n,m,threads,distribution,sink,matches,seconds");
+            for round in 0..rounds {
+                for baseline_first in [round % 2 == 0,round % 2 != 0] {
+                    if (only == "join" && baseline_first) || (only == "baseline" && !baseline_first) { continue; }
+                    let start = Instant::now();
+                    let actual_count = if baseline_first { black_box(baseline()) } else { join(); count };
+                    println!("{},{round},{},{K},{B},{},{},{n},{m},{threads},{kind},{sink},{actual_count},{:.9}",
+                        if baseline_first { "baseline" } else { "join" },stringify!($a),stringify!($store),std::any::type_name::<SS>(),start.elapsed().as_secs_f64());
+                    assert!(actual_count == count || env("JOIN_ALLOW_BASELINE_BOUNDARY_DIFFERENCES","0") == "1");
+                }
+            }
+        }
+    };
+}
+runner!(f32_flat, f32, FlatVec);
+runner!(f64_flat, f64, FlatVec);
+runner!(f32_arena, f32, VecOfArenas);
+runner!(f64_arena, f64, VecOfArenas);
+
+fn main() {
+    macro_rules! run {
+        ($runner:ident,$k:literal) => {
+            match env("JOIN_LAYOUT", "eytzinger").as_str() {
+                "eytzinger" => $runner::<Eytzinger, $k, 32>(),
+                "donnelly" => $runner::<Donnelly<3>, $k, 32>(),
+                _ => panic!("unknown layout"),
+            }
+        };
+    }
+    match (
+        env("JOIN_FLOAT", "f32").as_str(),
+        env("JOIN_STORAGE", "flat").as_str(),
+        integer("JOIN_DIMENSIONS", "3"),
+    ) {
+        ("f32", "flat", 2) => run!(f32_flat, 2),
+        ("f32", "flat", 3) => run!(f32_flat, 3),
+        ("f64", "flat", 2) => run!(f64_flat, 2),
+        ("f64", "flat", 3) => run!(f64_flat, 3),
+        ("f32", "arena", 2) => run!(f32_arena, 2),
+        ("f32", "arena", 3) => run!(f32_arena, 3),
+        ("f64", "arena", 2) => run!(f64_arena, 2),
+        ("f64", "arena", 3) => run!(f64_arena, 3),
+        _ => panic!("choose f32/f64, flat/arena and 2/3 dimensions"),
+    }
+}

--- a/src/kd_tree/query/batch.rs
+++ b/src/kd_tree/query/batch.rs
@@ -367,7 +367,7 @@ impl Executor {
     /// threshold.
     #[cfg(feature = "multi-threaded")]
     #[inline]
-    fn is_parallel(&self, query_count: usize) -> bool {
+    pub(crate) fn is_parallel(&self, query_count: usize) -> bool {
         if matches!(self.kind, ExecutorKind::Serial) {
             return false;
         }
@@ -378,7 +378,7 @@ impl Executor {
     /// The pool to run on, or `None` for Rayon's global pool.
     #[cfg(feature = "multi-threaded")]
     #[inline]
-    fn pool(&self) -> Option<&ThreadPool> {
+    pub(crate) fn pool(&self) -> Option<&ThreadPool> {
         match &self.kind {
             ExecutorKind::ParallelInPool(pool) => Some(pool),
             _ => None,
@@ -410,6 +410,20 @@ impl Executor {
         query_count
             .div_ceil(chunks)
             .clamp(1, MAX_STATIC_CHUNK_QUERIES)
+    }
+
+    /// Radius joins interpret the static chunk multiplier as a frontier budget.
+    #[cfg(feature = "multi-threaded")]
+    pub(crate) fn join_task_budget(&self) -> usize {
+        let threads = self
+            .pool()
+            .map_or_else(rayon::current_num_threads, ThreadPool::current_num_threads);
+        threads
+            .saturating_mul(
+                self.static_chunk_thread_multiplier
+                    .map_or(8, NonZeroUsize::get),
+            )
+            .max(1)
     }
 }
 

--- a/src/kd_tree/query/mod.rs
+++ b/src/kd_tree/query/mod.rs
@@ -7,5 +7,6 @@ pub use builder::{Exclude, Include, Projection, QueryBuilder};
 mod nearest_n;
 mod nearest_n_within;
 mod nearest_one;
+pub mod tree;
 mod within;
 mod within_unsorted;

--- a/src/kd_tree/query/tree/avx2.rs
+++ b/src/kd_tree/query/tree/avx2.rs
@@ -1,0 +1,94 @@
+//! Squared-Euclidean tile kernels, preserving scalar axis accumulation order.
+use std::arch::x86_64::*;
+
+#[inline(always)]
+pub(super) unsafe fn mask_f32<const K: usize, const EX: bool>(
+    query: &[f32; K],
+    columns: &[*const f32; K],
+    len: usize,
+    radius: f32,
+    distances: &mut [f32; 32],
+) -> u32 {
+    debug_assert!(len <= 32);
+    let threshold = _mm256_set1_ps(radius);
+    let mut mask = 0u32;
+    let mut j = 0;
+    while j + 8 <= len {
+        let mut acc = _mm256_setzero_ps();
+        for d in 0..K {
+            let delta = _mm256_sub_ps(_mm256_set1_ps(query[d]), _mm256_loadu_ps(columns[d].add(j)));
+            acc = _mm256_add_ps(acc, _mm256_mul_ps(delta, delta));
+        }
+        _mm256_storeu_ps(distances.as_mut_ptr().add(j), acc);
+        let bits = if EX {
+            _mm256_movemask_ps(_mm256_cmp_ps::<_CMP_LT_OQ>(acc, threshold))
+        } else {
+            _mm256_movemask_ps(_mm256_cmp_ps::<_CMP_LE_OQ>(acc, threshold))
+        } as u32;
+        mask |= bits << j;
+        j += 8;
+    }
+    while j < len {
+        let mut distance = 0.0;
+        for d in 0..K {
+            let delta = query[d] - columns[d].add(j).read_unaligned();
+            distance += delta * delta;
+        }
+        distances[j] = distance;
+        if if EX {
+            distance < radius
+        } else {
+            distance <= radius
+        } {
+            mask |= 1 << j;
+        }
+        j += 1;
+    }
+    mask
+}
+
+#[inline(always)]
+pub(super) unsafe fn mask_f64<const K: usize, const EX: bool>(
+    query: &[f64; K],
+    columns: &[*const f64; K],
+    len: usize,
+    radius: f64,
+    distances: &mut [f64; 32],
+) -> u32 {
+    debug_assert!(len <= 32);
+    let threshold = _mm256_set1_pd(radius);
+    let mut mask = 0u32;
+    let mut j = 0;
+    while j + 4 <= len {
+        let mut acc = _mm256_setzero_pd();
+        for d in 0..K {
+            let delta = _mm256_sub_pd(_mm256_set1_pd(query[d]), _mm256_loadu_pd(columns[d].add(j)));
+            acc = _mm256_add_pd(acc, _mm256_mul_pd(delta, delta));
+        }
+        _mm256_storeu_pd(distances.as_mut_ptr().add(j), acc);
+        let bits = if EX {
+            _mm256_movemask_pd(_mm256_cmp_pd::<_CMP_LT_OQ>(acc, threshold))
+        } else {
+            _mm256_movemask_pd(_mm256_cmp_pd::<_CMP_LE_OQ>(acc, threshold))
+        } as u32;
+        mask |= bits << j;
+        j += 4;
+    }
+    while j < len {
+        let mut distance = 0.0;
+        for d in 0..K {
+            let delta = query[d] - columns[d].add(j).read_unaligned();
+            distance += delta * delta;
+        }
+        distances[j] = distance;
+        if if EX {
+            distance < radius
+        } else {
+            distance <= radius
+        } {
+            mask |= 1 << j;
+        }
+        j += 1;
+    }
+    mask
+}

--- a/src/kd_tree/query/tree/avx512.rs
+++ b/src/kd_tree/query/tree/avx512.rs
@@ -1,0 +1,94 @@
+//! Squared-Euclidean tile kernels, preserving scalar axis accumulation order.
+use std::arch::x86_64::*;
+
+#[inline(always)]
+pub(super) unsafe fn mask_f32<const K: usize, const EX: bool>(
+    query: &[f32; K],
+    columns: &[*const f32; K],
+    len: usize,
+    radius: f32,
+    distances: &mut [f32; 32],
+) -> u32 {
+    debug_assert!(len <= 32);
+    let threshold = _mm512_set1_ps(radius);
+    let mut mask = 0u32;
+    let mut j = 0;
+    while j + 16 <= len {
+        let mut acc = _mm512_setzero_ps();
+        for d in 0..K {
+            let delta = _mm512_sub_ps(_mm512_set1_ps(query[d]), _mm512_loadu_ps(columns[d].add(j)));
+            acc = _mm512_add_ps(acc, _mm512_mul_ps(delta, delta));
+        }
+        _mm512_storeu_ps(distances.as_mut_ptr().add(j), acc);
+        let bits = if EX {
+            _mm512_cmp_ps_mask::<_CMP_LT_OQ>(acc, threshold)
+        } else {
+            _mm512_cmp_ps_mask::<_CMP_LE_OQ>(acc, threshold)
+        } as u32;
+        mask |= bits << j;
+        j += 16;
+    }
+    while j < len {
+        let mut distance = 0.0;
+        for d in 0..K {
+            let delta = query[d] - columns[d].add(j).read_unaligned();
+            distance += delta * delta;
+        }
+        distances[j] = distance;
+        if if EX {
+            distance < radius
+        } else {
+            distance <= radius
+        } {
+            mask |= 1 << j;
+        }
+        j += 1;
+    }
+    mask
+}
+
+#[inline(always)]
+pub(super) unsafe fn mask_f64<const K: usize, const EX: bool>(
+    query: &[f64; K],
+    columns: &[*const f64; K],
+    len: usize,
+    radius: f64,
+    distances: &mut [f64; 32],
+) -> u32 {
+    debug_assert!(len <= 32);
+    let threshold = _mm512_set1_pd(radius);
+    let mut mask = 0u32;
+    let mut j = 0;
+    while j + 8 <= len {
+        let mut acc = _mm512_setzero_pd();
+        for d in 0..K {
+            let delta = _mm512_sub_pd(_mm512_set1_pd(query[d]), _mm512_loadu_pd(columns[d].add(j)));
+            acc = _mm512_add_pd(acc, _mm512_mul_pd(delta, delta));
+        }
+        _mm512_storeu_pd(distances.as_mut_ptr().add(j), acc);
+        let bits = if EX {
+            _mm512_cmp_pd_mask::<_CMP_LT_OQ>(acc, threshold)
+        } else {
+            _mm512_cmp_pd_mask::<_CMP_LE_OQ>(acc, threshold)
+        } as u32;
+        mask |= bits << j;
+        j += 8;
+    }
+    while j < len {
+        let mut distance = 0.0;
+        for d in 0..K {
+            let delta = query[d] - columns[d].add(j).read_unaligned();
+            distance += delta * delta;
+        }
+        distances[j] = distance;
+        if if EX {
+            distance < radius
+        } else {
+            distance <= radius
+        } {
+            mask |= 1 << j;
+        }
+        j += 1;
+    }
+    mask
+}

--- a/src/kd_tree/query/tree/cursor.rs
+++ b/src/kd_tree/query/tree/cursor.rs
@@ -1,0 +1,196 @@
+use std::marker::PhantomData;
+use std::ops::Range;
+
+use super::metric::JoinFloat;
+use crate::kd_tree::{KdTreeAccessor, OwnedStemLeafResolution};
+use crate::leaf_strategy::{FlatVec, VecOfArenas};
+use crate::traits::leaf_strategy::{Immutable, LeafProjection};
+use crate::{Content, KdTree, LeafStrategy, StemStrategy};
+
+mod sealed {
+    pub trait Storage {}
+    impl<A, T, const K: usize, const B: usize> Storage for crate::leaf_strategy::FlatVec<A, T, K, B> {}
+    impl<A, T, const K: usize, const B: usize> Storage
+        for crate::leaf_strategy::VecOfArenas<A, T, K, B>
+    {
+    }
+    pub trait Tree {}
+    impl<A, T, SS, LS, const K: usize, const B: usize> Tree for crate::KdTree<A, T, SS, LS, K, B> {}
+}
+
+#[doc(hidden)]
+pub trait JoinStorage: sealed::Storage {}
+impl<A, T, const K: usize, const B: usize> JoinStorage for FlatVec<A, T, K, B> {}
+impl<A, T, const K: usize, const B: usize> JoinStorage for VecOfArenas<A, T, K, B> {}
+
+/// Borrowed columns of at most 32 points. Pointers may be unaligned.
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct Tile<'a, A, T, const K: usize> {
+    pub(super) columns: [*const A; K],
+    items: *const T,
+    pub(super) len: usize,
+    _borrow: PhantomData<&'a (A, T)>,
+}
+impl<A: Copy, T: Copy, const K: usize> Tile<'_, A, T, K> {
+    #[inline(always)]
+    pub(super) fn coord(&self, dim: usize, i: usize) -> A {
+        debug_assert!(dim < K && i < self.len);
+        unsafe { self.columns[dim].add(i).read_unaligned() }
+    }
+    #[inline(always)]
+    pub(super) fn item(&self, i: usize) -> T {
+        debug_assert!(i < self.len);
+        unsafe { self.items.add(i).read_unaligned() }
+    }
+}
+
+/// Internal sealed access to implemented immutable storage.
+#[doc(hidden)]
+pub trait JoinTree<const K: usize>: sealed::Tree + Sync {
+    type A: JoinFloat;
+    type Item: Content;
+    type Strategy: StemStrategy;
+    fn stems(&self) -> &[Self::A];
+    fn depth(&self) -> usize;
+    fn max_stem_level(&self) -> i32;
+    fn size(&self) -> usize;
+    fn leaf_count(&self) -> usize;
+    fn max_leaf_len(&self) -> usize;
+    fn leaf_len(&self, leaf: usize) -> usize;
+    fn tiles(
+        &self,
+        leaf: usize,
+        rows: Range<usize>,
+        f: impl FnMut(Tile<'_, Self::A, Self::Item, K>),
+    );
+}
+
+impl<A, T, SS, LS, const K: usize, const B: usize> JoinTree<K> for KdTree<A, T, SS, LS, K, B>
+where
+    A: JoinFloat,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B, Mutability = Immutable> + JoinStorage + Sync,
+{
+    type A = A;
+    type Item = T;
+    type Strategy = SS;
+    fn stems(&self) -> &[A] {
+        KdTreeAccessor::stems(self)
+    }
+    fn depth(&self) -> usize {
+        match self.stem_leaf_resolution {
+            OwnedStemLeafResolution::Arithmetic { stems_depth, .. } => stems_depth,
+            _ => unreachable!("immutable join requires arithmetic leaf resolution"),
+        }
+    }
+    fn size(&self) -> usize {
+        self.size()
+    }
+    fn max_stem_level(&self) -> i32 {
+        KdTreeAccessor::max_stem_level(self)
+    }
+    fn leaf_count(&self) -> usize {
+        self.leaf_count()
+    }
+    fn max_leaf_len(&self) -> usize {
+        self.max_leaf_len()
+    }
+    fn leaf_len(&self, leaf: usize) -> usize {
+        self.leaves().leaf_len(leaf)
+    }
+    fn tiles(&self, leaf: usize, rows: Range<usize>, mut f: impl FnMut(Tile<'_, A, T, K>)) {
+        match LS::LEAF_PROJECTION {
+            LeafProjection::LeafView => {
+                let view = self.leaves().leaf_view(leaf);
+                let end = rows.end.min(view.len());
+                for start in (rows.start.min(end)..end).step_by(32) {
+                    f(Tile {
+                        columns: std::array::from_fn(|d| unsafe {
+                            view.points()[d].as_ptr().add(start)
+                        }),
+                        items: unsafe { view.items().as_ptr().add(start) },
+                        len: (end - start).min(32),
+                        _borrow: PhantomData,
+                    });
+                }
+            }
+            LeafProjection::LeafArena => {
+                let arena = self.leaves().leaf_arena(leaf);
+                let mut base = 0;
+                arena.for_each_tiled_chunk(|tile| {
+                    let start = rows.start.saturating_sub(base).min(tile.len());
+                    let end = rows.end.saturating_sub(base).min(tile.len());
+                    if start < end {
+                        let (columns, items) = tile.join_columns();
+                        f(Tile {
+                            columns: columns.map(|p| unsafe { p.add(start) }),
+                            items: unsafe { items.add(start) },
+                            len: end - start,
+                            _borrow: PhantomData,
+                        });
+                    }
+                    base += tile.len();
+                });
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Cursor<S> {
+    pub strategy: S,
+    pub range: Range<usize>,
+    pub remaining: usize,
+    /// Synthetic root levels added solely to align a block strategy.
+    pub padding_remaining: usize,
+}
+impl<S: StemStrategy> Cursor<S> {
+    pub fn root<const K: usize, Tree: JoinTree<K, Strategy = S>>(tree: &Tree) -> Self {
+        Self {
+            strategy: S::new_no_ptr(),
+            range: 0..tree.leaf_count(),
+            remaining: tree.depth(),
+            padding_remaining: tree
+                .depth()
+                .saturating_sub((tree.max_stem_level() + 1).max(0) as usize),
+        }
+    }
+    pub fn leaf(&self) -> bool {
+        self.remaining == 0
+    }
+    pub fn span(&self) -> usize {
+        self.range.end - self.range.start
+    }
+    pub fn split<A: JoinFloat, const K: usize>(&self) -> (Self, Self) {
+        assert!(self.remaining > 0);
+        let half = 1usize
+            .checked_shl((self.remaining - 1) as u32)
+            .expect("join tree depth exceeds address width");
+        let mid = self.range.start.saturating_add(half).min(self.range.end);
+        let mut left = self.clone();
+        let right_strategy = left.strategy.branch::<A, K>();
+        left.remaining -= 1;
+        left.range.end = mid;
+        let right = Self {
+            strategy: right_strategy,
+            range: mid..self.range.end,
+            remaining: left.remaining,
+            padding_remaining: left.padding_remaining,
+        };
+        (left, right)
+    }
+
+    /// Descends through a structural `+inf` padding pivot. It advances the
+    /// physical layout only: that pivot partitions no real leaves.
+    pub fn descend_padding<A: JoinFloat, const K: usize>(&self) -> Self {
+        assert!(self.remaining > 0);
+        assert!(self.padding_remaining > 0);
+        let mut next = self.clone();
+        next.strategy.traverse::<A, K>(false);
+        next.remaining -= 1;
+        next.padding_remaining -= 1;
+        next
+    }
+}

--- a/src/kd_tree/query/tree/leaf.rs
+++ b/src/kd_tree/query/tree/leaf.rs
@@ -1,0 +1,103 @@
+use super::cursor::JoinTree;
+use super::cursor::Tile;
+use super::metric::{accepts, JoinFloat, JoinMetric};
+use super::traversal::Sink;
+use crate::Content;
+use std::ops::Range;
+
+#[inline(always)]
+fn tile_mask<A: JoinFloat, T: Content, D: JoinMetric<A>, const K: usize, const EX: bool>(
+    query: &[D::Output; K],
+    tile: &Tile<'_, A, T, K>,
+    radius: D::Output,
+    distances: &mut [D::Output; 32],
+) -> u32 {
+    // TypeId checks are constant after monomorphization. Both coordinate and
+    // output identity must hold before reinterpreting typed pointers.
+    #[cfg(all(
+        feature = "simd",
+        target_arch = "x86_64",
+        any(target_feature = "avx2", target_feature = "avx512f")
+    ))]
+    if D::SQUARED_EUCLIDEAN {
+        #[cfg(not(target_feature = "avx512f"))]
+        use super::avx2 as kernel;
+        #[cfg(target_feature = "avx512f")]
+        use super::avx512 as kernel;
+        use std::any::TypeId;
+        macro_rules! dispatch {
+            ($t:ty, $f:ident) => {
+                if TypeId::of::<A>() == TypeId::of::<$t>()
+                    && TypeId::of::<D::Output>() == TypeId::of::<$t>()
+                {
+                    // SAFETY: type identity above establishes every cast; each
+                    // column has tile.len initialized coordinates. Kernels use
+                    // unaligned loads and never read past that length.
+                    return unsafe {
+                        kernel::$f::<K, EX>(
+                            &*(query as *const _ as *const [$t; K]),
+                            &tile.columns.map(|p| p.cast::<$t>()),
+                            tile.len,
+                            *(&radius as *const _ as *const $t),
+                            &mut *(distances as *mut _ as *mut [$t; 32]),
+                        )
+                    };
+                }
+            };
+        }
+        dispatch!(f32, mask_f32);
+        dispatch!(f64, mask_f64);
+    }
+    for (d, q) in query.iter().enumerate() {
+        for (j, distance) in distances.iter_mut().enumerate().take(tile.len) {
+            D::combine_component(distance, D::dist1(*q, D::widen_coord(tile.coord(d, j))));
+        }
+    }
+    let mut mask = 0;
+    for (j, &distance) in distances.iter().enumerate().take(tile.len) {
+        if accepts::<_, EX>(distance, radius) {
+            mask |= 1 << j;
+        }
+    }
+    mask
+}
+
+pub(super) fn leaf_pair<L, R, D, S, const K: usize, const EX: bool>(
+    left: &L,
+    right: &R,
+    li: usize,
+    ri: usize,
+    rows: &[Range<usize>; 2],
+    radius: D::Output,
+    sink: &mut S,
+) where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+    S: Sink<L::Item, R::Item, D::Output>,
+{
+    #[cfg(feature = "exact_query_stats")]
+    super::stats::record(super::stats::Event::Leaf, 1);
+    left.tiles(li, rows[0].clone(), |lt| {
+        right.tiles(ri, rows[1].clone(), |rt| {
+            #[cfg(feature = "exact_query_stats")]
+            super::stats::record(super::stats::Event::Distances, lt.len * rt.len);
+            for i in 0..lt.len {
+                let query: [D::Output; K] = std::array::from_fn(|d| D::widen_coord(lt.coord(d, i)));
+                let mut distances = [D::Output::ZERO; 32];
+                let mut mask = tile_mask::<_, _, D, K, EX>(&query, &rt, radius, &mut distances);
+                #[cfg(feature = "exact_query_stats")]
+                super::stats::record(super::stats::Event::Matches, mask.count_ones() as usize);
+                if S::COUNT {
+                    sink.add_count(mask.count_ones() as usize);
+                } else {
+                    while mask != 0 {
+                        let j = mask.trailing_zeros() as usize;
+                        sink.emit(lt.item(i), rt.item(j), distances[j]);
+                        mask &= mask - 1;
+                    }
+                }
+            }
+        });
+    });
+}

--- a/src/kd_tree/query/tree/metric.rs
+++ b/src/kd_tree/query/tree/metric.rs
@@ -1,0 +1,125 @@
+use crate::dist::{Chebyshev, DistanceMetricScalar, Manhattan, Minkowski, SquaredEuclidean};
+use crate::Axis;
+
+mod sealed {
+    pub trait Float {}
+    impl Float for f32 {}
+    impl Float for f64 {}
+    pub trait Metric<A> {}
+}
+
+/// Floating-point types supported by tree joins.
+#[doc(hidden)]
+pub trait JoinFloat: sealed::Float + Axis<Coord = Self> + Send + Sync {
+    const ZERO: Self;
+    const INFINITY: Self;
+    const NEG_INFINITY: Self;
+    fn is_nan(self) -> bool;
+    fn is_finite(self) -> bool;
+}
+macro_rules! float {
+    ($t:ty) => {
+        impl JoinFloat for $t {
+            const ZERO: Self = 0.0;
+            const INFINITY: Self = Self::INFINITY;
+            const NEG_INFINITY: Self = Self::NEG_INFINITY;
+            fn is_nan(self) -> bool {
+                self.is_nan()
+            }
+            fn is_finite(self) -> bool {
+                self.is_finite()
+            }
+        }
+    };
+}
+float!(f32);
+float!(f64);
+
+/// Sealed metric capability for exact immutable tree joins.
+/// Supports the built-in float metrics, with identity or f32-to-f64 accumulation.
+#[doc(hidden)]
+pub trait JoinMetric<A: JoinFloat>:
+    sealed::Metric<A> + DistanceMetricScalar<A, Output: JoinFloat>
+{
+    const VALID: () = ();
+    const SQUARED_EUCLIDEAN: bool = false;
+}
+
+macro_rules! metrics {
+    ($a:ty, $o:ty) => {
+        impl sealed::Metric<$a> for SquaredEuclidean<$o> {}
+        impl JoinMetric<$a> for SquaredEuclidean<$o> {
+            const SQUARED_EUCLIDEAN: bool = true;
+        }
+        impl sealed::Metric<$a> for Manhattan<$o> {}
+        impl JoinMetric<$a> for Manhattan<$o> {}
+        impl sealed::Metric<$a> for Chebyshev<$o> {}
+        impl JoinMetric<$a> for Chebyshev<$o> {}
+        impl<const P: u32> sealed::Metric<$a> for Minkowski<P, $o> {}
+        impl<const P: u32> JoinMetric<$a> for Minkowski<P, $o> {
+            const VALID: () = assert!(
+                P >= 3 && P <= i32::MAX as u32,
+                "tree joins require Minkowski power in 3..=i32::MAX"
+            );
+        }
+    };
+}
+metrics!(f32, f32);
+metrics!(f32, f64);
+metrics!(f64, f64);
+
+#[derive(Clone, Copy)]
+pub(super) struct Bounds<O, const K: usize> {
+    pub min: [[O; K]; 2],
+    pub max: [[O; K]; 2],
+}
+
+impl<O: JoinFloat, const K: usize> Bounds<O, K> {
+    pub fn new() -> Self {
+        Self {
+            min: [[O::NEG_INFINITY; K]; 2],
+            max: [[O::INFINITY; K]; 2],
+        }
+    }
+
+    pub fn lower<A: JoinFloat, D: JoinMetric<A, Output = O>>(&self) -> O {
+        let mut acc = O::ZERO;
+        for d in 0..K {
+            let c = if self.max[0][d] < self.min[1][d] {
+                D::dist1(self.max[0][d], self.min[1][d])
+            } else if self.max[1][d] < self.min[0][d] {
+                D::dist1(self.max[1][d], self.min[0][d])
+            } else {
+                O::ZERO
+            };
+            D::combine_component(&mut acc, c);
+        }
+        acc
+    }
+
+    pub fn upper<A: JoinFloat, D: JoinMetric<A, Output = O>>(&self) -> O {
+        let mut acc = O::ZERO;
+        for d in 0..K {
+            if !(self.min[0][d].is_finite()
+                && self.min[1][d].is_finite()
+                && self.max[0][d].is_finite()
+                && self.max[1][d].is_finite())
+            {
+                return O::INFINITY;
+            }
+            let a = D::dist1(self.min[0][d], self.max[1][d]);
+            let b = D::dist1(self.max[0][d], self.min[1][d]);
+            D::combine_component(&mut acc, if a > b { a } else { b });
+        }
+        acc
+    }
+}
+
+#[inline(always)]
+pub(super) fn accepts<O: JoinFloat, const EX: bool>(distance: O, radius: O) -> bool {
+    if EX {
+        distance < radius
+    } else {
+        distance <= radius
+    }
+}

--- a/src/kd_tree/query/tree/mod.rs
+++ b/src/kd_tree/query/tree/mod.rs
@@ -1,0 +1,512 @@
+//! Exact radius joins between two owned immutable trees.
+#![allow(private_bounds)]
+
+#[cfg(all(
+    feature = "simd",
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
+mod avx2;
+#[cfg(all(feature = "simd", target_arch = "x86_64", target_feature = "avx512f"))]
+mod avx512;
+mod cursor;
+mod leaf;
+mod metric;
+mod nearest;
+#[cfg(feature = "multi-threaded")]
+mod parallel;
+#[cfg(feature = "exact_query_stats")]
+pub mod stats;
+mod traversal;
+
+use crate::batch::Executor;
+use crate::traits::leaf_strategy::Immutable;
+use crate::{Content, KdTree, LeafStrategy, StemStrategy};
+use cursor::{JoinStorage, JoinTree};
+use metric::{JoinFloat, JoinMetric};
+#[cfg(feature = "multi-threaded")]
+use rayon::prelude::*;
+use std::marker::PhantomData;
+use traversal::{Counter, Sink};
+
+/// The exact nearest entry in the right tree for one entry in the left tree.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct TreeNearestQueryResult<L, R, D> {
+    /// Item from the tree on which `query_tree` was called.
+    pub left_item: L,
+    /// Nearest item from the argument to `query_tree`.
+    pub right_item: R,
+    /// Distance in the selected metric's output units.
+    pub distance: D,
+}
+
+/// One matching entry pair. Equality compares both items and the distance.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct PairQueryResult<L, R, D> {
+    /// Item from the tree on which `query_tree` was called.
+    pub left_item: L,
+    /// Item from the argument to `query_tree`.
+    pub right_item: R,
+    /// Metric distance, or `()` when distances are omitted.
+    pub distance: D,
+}
+
+#[doc(hidden)]
+pub struct NoMetric;
+#[doc(hidden)]
+pub struct WithDistances;
+#[doc(hidden)]
+pub struct WithoutDistances;
+
+#[doc(hidden)]
+pub trait DistanceProjection<O> {
+    type Output: Send;
+    const ENABLED: bool;
+    fn project(distance: O) -> Self::Output;
+}
+impl<O: Send> DistanceProjection<O> for WithDistances {
+    type Output = O;
+    const ENABLED: bool = true;
+    fn project(distance: O) -> O {
+        distance
+    }
+}
+impl<O> DistanceProjection<O> for WithoutDistances {
+    type Output = ();
+    const ENABLED: bool = false;
+    fn project(_: O) {}
+}
+
+/// Builder for an exact, unsorted radius join between distinct immutable trees.
+///
+/// Stored coordinates must be finite. Item values and coordinates may repeat;
+/// every matching entry pair is preserved. Ordering is unspecified. Distances
+/// use the metric's output units, just like single-point queries.
+///
+/// ```
+/// use kiddo::{ImmutableKdTree, SquaredEuclidean};
+/// let left = ImmutableKdTree::new_from_slice(&[[0.0f64, 0.0], [1.0, 0.0]]).unwrap();
+/// let right = ImmutableKdTree::new_from_slice(&[[0.5f64, 0.0]]).unwrap();
+/// let query = left.query_tree(&right).within::<SquaredEuclidean<f64>>(0.25);
+/// assert_eq!(query.count(), 2usize);
+/// let pairs = left.query_tree(&right).within::<SquaredEuclidean<f64>>(0.25)
+///     .without_distances().execute();
+/// assert_eq!(pairs.len(), 2);
+/// ```
+///
+/// Execution requires selecting a metric:
+/// ```compile_fail
+/// use kiddo::ImmutableKdTree;
+/// let a = ImmutableKdTree::new_from_slice(&[[0.0f64, 0.0]]).unwrap();
+/// let b = ImmutableKdTree::new_from_slice(&[[0.0f64, 0.0]]).unwrap();
+/// a.query_tree(&b).execute();
+/// ```
+///
+/// Mutable trees are not join operands:
+/// ```compile_fail
+/// use kiddo::{ImmutableKdTree, MutableKdTree};
+/// let a = ImmutableKdTree::new_from_slice(&[[0.0f64, 0.0]]).unwrap();
+/// let b = MutableKdTree::new_from_slice(&[[0.0f64, 0.0]]).unwrap();
+/// a.query_tree(&b);
+/// ```
+///
+/// Output precision cannot narrow the stored coordinates:
+/// ```compile_fail
+/// use kiddo::{ImmutableKdTree, SquaredEuclidean};
+/// let a = ImmutableKdTree::new_from_slice(&[[0.0f64, 0.0]]).unwrap();
+/// let b = ImmutableKdTree::new_from_slice(&[[1.0f64, 0.0]]).unwrap();
+/// a.query_tree(&b).within::<SquaredEuclidean<f32>>(1.0);
+/// ```
+///
+/// Integer coordinate trees are not supported:
+/// ```compile_fail
+/// use kiddo::ImmutableKdTree;
+/// let a = ImmutableKdTree::new_from_slice(&[[0u16, 0]]).unwrap();
+/// let b = ImmutableKdTree::new_from_slice(&[[1u16, 0]]).unwrap();
+/// a.query_tree(&b);
+/// ```
+///
+/// A custom scalar metric cannot opt into box pruning implicitly:
+/// ```compile_fail
+/// use kiddo::{ImmutableKdTree, dist::DistanceMetricScalar};
+/// struct Custom;
+/// impl DistanceMetricScalar<f64> for Custom {
+///     type Output = f64;
+///     fn widen_coord(x: f64) -> f64 { x }
+///     fn dist1(a: f64, b: f64) -> f64 { (a-b).abs() }
+/// }
+/// let a = ImmutableKdTree::new_from_slice(&[[0.0f64, 0.0]]).unwrap();
+/// let b = ImmutableKdTree::new_from_slice(&[[1.0f64, 0.0]]).unwrap();
+/// a.query_tree(&b).within::<Custom>(1.0);
+/// ```
+pub struct TreeQueryBuilder<
+    'a,
+    L,
+    R,
+    const K: usize,
+    D = NoMetric,
+    P = WithDistances,
+    const EX: bool = false,
+    O = (),
+> {
+    left: &'a L,
+    right: &'a R,
+    radius: O,
+    executor: Executor,
+    _state: PhantomData<(D, P)>,
+}
+
+/// Builder for an exact dual-tree nearest-one query.
+///
+/// This evaluates every entry in the left tree against the right tree, but
+/// shares node-pair bounds between neighbouring left entries. Results are in
+/// unspecified left-tree storage order.
+pub struct TreeNearestQueryBuilder<'a, L, R, const K: usize, D = NoMetric> {
+    left: &'a L,
+    right: &'a R,
+    _state: PhantomData<D>,
+}
+
+impl<A, T, SS, LS, const K: usize, const B: usize> KdTree<A, T, SS, LS, K, B>
+where
+    A: JoinFloat,
+    T: Content,
+    SS: StemStrategy,
+    LS: LeafStrategy<A, T, SS, K, B, Mutability = Immutable> + JoinStorage + Sync,
+{
+    /// Starts a radius join with another owned immutable tree.
+    ///
+    /// Both trees must have finite coordinates and the same coordinate type and
+    /// dimensionality. Item types, leaf stores, layouts and bucket sizes may differ.
+    ///
+    /// # Panics
+    /// Panics if both references identify the same tree object. Independently
+    /// allocated trees with identical contents are allowed.
+    pub fn query_tree<'a, R: JoinTree<K, A = A>>(
+        &'a self,
+        other: &'a R,
+    ) -> TreeQueryBuilder<'a, Self, R, K> {
+        assert!(
+            !std::ptr::eq(
+                (self as *const Self).cast::<()>(),
+                (other as *const R).cast::<()>()
+            ),
+            "tree joins require two distinct tree objects"
+        );
+        assert!(K > 0, "tree joins require at least one dimension");
+        TreeQueryBuilder {
+            left: self,
+            right: other,
+            radius: (),
+            executor: Executor::new(),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<'a, L: JoinTree<K>, R: JoinTree<K, A = L::A>, const K: usize, P, const EX: bool>
+    TreeQueryBuilder<'a, L, R, K, NoMetric, P, EX>
+{
+    /// Selects a metric and threshold in metric-output units.
+    ///
+    /// # Panics
+    /// Negative and NaN thresholds are rejected. Zero and positive infinity are valid.
+    pub fn within<D: JoinMetric<L::A>>(
+        self,
+        radius: D::Output,
+    ) -> TreeQueryBuilder<'a, L, R, K, D, P, EX, D::Output> {
+        let () = D::VALID;
+        assert!(
+            !radius.is_nan() && radius >= D::Output::ZERO,
+            "tree join threshold must be nonnegative and not NaN"
+        );
+        TreeQueryBuilder {
+            left: self.left,
+            right: self.right,
+            radius,
+            executor: self.executor,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<'a, L: JoinTree<K>, R: JoinTree<K, A = L::A>, const K: usize, P, const EX: bool>
+    TreeQueryBuilder<'a, L, R, K, NoMetric, P, EX>
+{
+    /// Selects an exact nearest target entry for each left-tree entry.
+    pub fn nearest_one<D: JoinMetric<L::A>>(self) -> TreeNearestQueryBuilder<'a, L, R, K, D> {
+        let () = D::VALID;
+        TreeNearestQueryBuilder {
+            left: self.left,
+            right: self.right,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<L, R, const K: usize, D> TreeNearestQueryBuilder<'_, L, R, K, D>
+where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+{
+    /// Executes the exact dual-tree nearest-one query.
+    ///
+    /// An empty right tree has no nearest entries, so it returns an empty
+    /// vector. Ties are resolved in unspecified tree-traversal order.
+    pub fn execute(self) -> Vec<TreeNearestQueryResult<L::Item, R::Item, D::Output>> {
+        nearest::execute::<L, R, D, K>(self.left, self.right)
+    }
+}
+
+impl<'a, L, R, const K: usize, D, P, const EX: bool, O> TreeQueryBuilder<'a, L, R, K, D, P, EX, O> {
+    /// Omits returned distances, enabling bulk acceptance of whole subtree pairs.
+    pub fn without_distances(self) -> TreeQueryBuilder<'a, L, R, K, D, WithoutDistances, EX, O> {
+        TreeQueryBuilder {
+            left: self.left,
+            right: self.right,
+            radius: self.radius,
+            executor: self.executor,
+            _state: PhantomData,
+        }
+    }
+    /// Includes metric distances (the default).
+    pub fn with_distances(self) -> TreeQueryBuilder<'a, L, R, K, D, WithDistances, EX, O> {
+        TreeQueryBuilder {
+            left: self.left,
+            right: self.right,
+            radius: self.radius,
+            executor: self.executor,
+            _state: PhantomData,
+        }
+    }
+    /// Selects strict `distance < threshold` membership.
+    pub fn exclusive_boundaries(self) -> TreeQueryBuilder<'a, L, R, K, D, P, true, O> {
+        TreeQueryBuilder {
+            left: self.left,
+            right: self.right,
+            radius: self.radius,
+            executor: self.executor,
+            _state: PhantomData,
+        }
+    }
+    /// Selects serial, global-pool, or caller-owned-pool execution.
+    /// The default follows [`Executor::new`].
+    ///
+    /// Serial fallback uses the left tree's entry count. A static chunk
+    /// multiplier is interpreted as the desired number of frontier tasks per
+    /// pool thread (eight by default); it does not fix task or thread order.
+    pub fn with_executor(mut self, executor: &Executor) -> Self {
+        self.executor = executor.clone();
+        self
+    }
+}
+
+struct Visitor<'a, F, P>(&'a F, PhantomData<P>);
+impl<
+        L: Content,
+        R: Content,
+        O: JoinFloat,
+        P: DistanceProjection<O>,
+        F: Fn(PairQueryResult<L, R, P::Output>),
+    > Sink<L, R, O> for Visitor<'_, F, P>
+{
+    const DISTANCES: bool = P::ENABLED;
+    fn emit(&mut self, left: L, right: R, distance: O) {
+        (self.0)(PairQueryResult {
+            left_item: left,
+            right_item: right,
+            distance: P::project(distance),
+        });
+    }
+}
+struct Collector<L, R, O, P: DistanceProjection<O>>(Vec<PairQueryResult<L, R, P::Output>>);
+impl<L: Content, R: Content, O: JoinFloat, P: DistanceProjection<O>> Sink<L, R, O>
+    for Collector<L, R, O, P>
+{
+    const DISTANCES: bool = P::ENABLED;
+    fn emit(&mut self, left: L, right: R, distance: O) {
+        self.0.push(PairQueryResult {
+            left_item: left,
+            right_item: right,
+            distance: P::project(distance),
+        });
+    }
+}
+
+impl<L, R, const K: usize, D, P, const EX: bool> TreeQueryBuilder<'_, L, R, K, D, P, EX, D::Output>
+where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+    P: DistanceProjection<D::Output>,
+{
+    /// Collects every matching entry pair in unspecified order.
+    pub fn execute(self) -> Vec<PairQueryResult<L::Item, R::Item, P::Output>> {
+        if self.left.size() == 0 || self.right.size() == 0 {
+            return Vec::new();
+        }
+        #[cfg(feature = "multi-threaded")]
+        if self.executor.is_parallel(self.left.size()) {
+            let tasks = parallel::frontier::<_, _, D, K, EX>(
+                self.left,
+                self.right,
+                self.radius,
+                self.executor.join_task_budget(),
+            );
+            let run = || {
+                let chunks: Vec<_> = tasks
+                    .into_par_iter()
+                    .map(|task| {
+                        let mut sink = Collector::<_, _, _, P>(Vec::new());
+                        traversal::walk::<_, _, D, _, K, EX>(
+                            self.left,
+                            self.right,
+                            task,
+                            self.radius,
+                            &mut sink,
+                        );
+                        sink.0
+                    })
+                    .collect();
+                let len = chunks
+                    .iter()
+                    .map(Vec::len)
+                    .try_fold(0usize, usize::checked_add)
+                    .expect(traversal::COUNT_OVERFLOW);
+                let mut result = Vec::with_capacity(len);
+                for chunk in chunks {
+                    result.extend(chunk);
+                }
+                result
+            };
+            return match self.executor.pool() {
+                Some(pool) => pool.install(run),
+                None => run(),
+            };
+        }
+        let mut sink = Collector::<_, _, _, P>(Vec::new());
+        if self.left.size() != 0 && self.right.size() != 0 {
+            traversal::walk::<_, _, D, _, K, EX>(
+                self.left,
+                self.right,
+                traversal::root(self.left, self.right),
+                self.radius,
+                &mut sink,
+            );
+        }
+        sink.0
+    }
+    /// Visits each matching pair without collecting results.
+    ///
+    /// The visitor may be called concurrently and in any order. Panics propagate.
+    pub fn for_each<F: Fn(PairQueryResult<L::Item, R::Item, P::Output>) + Send + Sync>(
+        self,
+        visitor: F,
+    ) {
+        if self.left.size() == 0 || self.right.size() == 0 {
+            return;
+        }
+        #[cfg(feature = "multi-threaded")]
+        if self.executor.is_parallel(self.left.size()) {
+            let tasks = parallel::frontier::<_, _, D, K, EX>(
+                self.left,
+                self.right,
+                self.radius,
+                self.executor.join_task_budget(),
+            );
+            let run = || {
+                tasks.into_par_iter().for_each(|task| {
+                    traversal::walk::<_, _, D, _, K, EX>(
+                        self.left,
+                        self.right,
+                        task,
+                        self.radius,
+                        &mut Visitor::<_, P>(&visitor, PhantomData),
+                    );
+                })
+            };
+            match self.executor.pool() {
+                Some(pool) => pool.install(run),
+                None => run(),
+            };
+            return;
+        }
+        if self.left.size() != 0 && self.right.size() != 0 {
+            traversal::walk::<_, _, D, _, K, EX>(
+                self.left,
+                self.right,
+                traversal::root(self.left, self.right),
+                self.radius,
+                &mut Visitor::<_, P>(&visitor, PhantomData),
+            );
+        }
+    }
+    /// Counts matching entry pairs without allocating results or loading items.
+    ///
+    /// # Panics
+    /// Panics if the result exceeds `usize::MAX`, in debug and release builds.
+    pub fn count(self) -> usize {
+        if self.left.size() == 0 || self.right.size() == 0 {
+            return 0;
+        }
+        if !EX && self.radius == D::Output::INFINITY {
+            let count = self
+                .left
+                .size()
+                .checked_mul(self.right.size())
+                .expect(traversal::COUNT_OVERFLOW);
+            #[cfg(feature = "exact_query_stats")]
+            {
+                stats::record(stats::Event::Node, 1);
+                stats::record(stats::Event::Accepted, 1);
+                stats::record(stats::Event::Matches, count);
+            }
+            return count;
+        }
+        #[cfg(feature = "multi-threaded")]
+        if self.executor.is_parallel(self.left.size()) {
+            let tasks = parallel::frontier::<_, _, D, K, EX>(
+                self.left,
+                self.right,
+                self.radius,
+                self.executor.join_task_budget(),
+            );
+            let run = || {
+                tasks
+                    .into_par_iter()
+                    .map(|task| {
+                        let mut sink = Counter::default();
+                        traversal::walk::<_, _, D, _, K, EX>(
+                            self.left,
+                            self.right,
+                            task,
+                            self.radius,
+                            &mut sink,
+                        );
+                        sink.0
+                    })
+                    .reduce(
+                        || 0usize,
+                        |a, b| a.checked_add(b).expect(traversal::COUNT_OVERFLOW),
+                    )
+            };
+            return match self.executor.pool() {
+                Some(pool) => pool.install(run),
+                None => run(),
+            };
+        }
+        let mut sink = Counter::default();
+        if self.left.size() != 0 && self.right.size() != 0 {
+            traversal::walk::<_, _, D, _, K, EX>(
+                self.left,
+                self.right,
+                traversal::root(self.left, self.right),
+                self.radius,
+                &mut sink,
+            );
+        }
+        sink.0
+    }
+}

--- a/src/kd_tree/query/tree/nearest.rs
+++ b/src/kd_tree/query/tree/nearest.rs
@@ -1,0 +1,210 @@
+//! Exact batched nearest-one traversal shared by tree-to-tree consumers.
+
+use super::cursor::{Cursor, JoinTree};
+use super::metric::{JoinFloat, JoinMetric};
+use super::traversal::Work;
+use super::TreeNearestQueryResult;
+use crate::{Content, StemStrategy};
+
+#[derive(Clone, Copy)]
+struct Candidate<L, R, O> {
+    left: L,
+    right: R,
+    distance: O,
+}
+
+fn candidate_upper<L: Content, R: Content, O: JoinFloat, SL>(
+    starts: &[usize],
+    cursor: &Cursor<SL>,
+    candidates: &[Candidate<L, R, O>],
+) -> O {
+    let start = starts[cursor.range.start];
+    let end = starts[cursor.range.end];
+    candidates[start..end]
+        .iter()
+        .fold(O::ZERO, |max, candidate| {
+            if candidate.distance > max {
+                candidate.distance
+            } else {
+                max
+            }
+        })
+}
+
+fn update_leaf<L, R, D, const K: usize>(
+    left: &L,
+    right: &R,
+    left_leaf: usize,
+    right_leaf: usize,
+    starts: &[usize],
+    candidates: &mut [Candidate<L::Item, R::Item, D::Output>],
+) where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+{
+    let mut left_offset = 0;
+    left.tiles(left_leaf, 0..usize::MAX, |left_tile| {
+        right.tiles(right_leaf, 0..usize::MAX, |right_tile| {
+            for i in 0..left_tile.len {
+                let candidate = &mut candidates[starts[left_leaf] + left_offset + i];
+                for j in 0..right_tile.len {
+                    let mut distance = D::Output::ZERO;
+                    for dim in 0..K {
+                        D::combine_component(
+                            &mut distance,
+                            D::dist1(
+                                D::widen_coord(left_tile.coord(dim, i)),
+                                D::widen_coord(right_tile.coord(dim, j)),
+                            ),
+                        );
+                    }
+                    if distance < candidate.distance {
+                        candidate.distance = distance;
+                        candidate.right = right_tile.item(j);
+                    }
+                }
+            }
+        });
+        left_offset += left_tile.len;
+    });
+}
+
+/// Exact dual-tree all-nearest-neighbours traversal.
+pub(super) fn execute<L, R, D, const K: usize>(
+    left: &L,
+    right: &R,
+) -> Vec<TreeNearestQueryResult<L::Item, R::Item, D::Output>>
+where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+{
+    if left.size() == 0 || right.size() == 0 {
+        return Vec::new();
+    }
+
+    let mut starts = Vec::with_capacity(left.leaf_count() + 1);
+    starts.push(0);
+    for leaf in 0..left.leaf_count() {
+        starts.push(starts[leaf] + left.leaf_len(leaf));
+    }
+    let mut candidates = Vec::with_capacity(left.size());
+    for leaf in 0..left.leaf_count() {
+        left.tiles(leaf, 0..usize::MAX, |tile| {
+            for i in 0..tile.len {
+                candidates.push(Candidate {
+                    left: tile.item(i),
+                    right: R::Item::default(),
+                    distance: D::Output::INFINITY,
+                });
+            }
+        });
+    }
+
+    let mut work = vec![super::traversal::root::<L, R, D::Output, K>(left, right)];
+    while let Some(Work {
+        left: lc,
+        right: rc,
+        bounds,
+        rows: _,
+    }) = work.pop()
+    {
+        if lc.span() == 0 || rc.span() == 0 {
+            continue;
+        }
+        // The box lower bound applies to every left entry in this node pair.
+        // If it cannot improve even the worst current left candidate, it cannot
+        // improve any candidate in the subtree.
+        if bounds.lower::<L::A, D>() >= candidate_upper(&starts, &lc, &candidates) {
+            continue;
+        }
+        if lc.leaf() && rc.leaf() {
+            for left_leaf in lc.range.clone() {
+                for right_leaf in rc.range.clone() {
+                    update_leaf::<L, R, D, K>(
+                        left,
+                        right,
+                        left_leaf,
+                        right_leaf,
+                        &starts,
+                        &mut candidates,
+                    );
+                }
+            }
+            continue;
+        }
+
+        let side = usize::from(lc.leaf() || (!rc.leaf() && rc.span() > lc.span()));
+        let (dim, pivot) = if side == 0 {
+            (
+                lc.strategy.construction_dim::<K>(),
+                D::widen_coord(left.stems()[lc.strategy.stem_idx()]),
+            )
+        } else {
+            (
+                rc.strategy.construction_dim::<K>(),
+                D::widen_coord(right.stems()[rc.strategy.stem_idx()]),
+            )
+        };
+        let padding =
+            (side == 0 && lc.padding_remaining > 0) || (side == 1 && rc.padding_remaining > 0);
+        if !pivot.is_finite() && padding {
+            work.push(Work {
+                left: if side == 0 {
+                    lc.descend_padding::<L::A, K>()
+                } else {
+                    lc
+                },
+                right: if side == 1 {
+                    rc.descend_padding::<L::A, K>()
+                } else {
+                    rc
+                },
+                bounds,
+                rows: [0..usize::MAX, 0..usize::MAX],
+            });
+            continue;
+        }
+
+        let (near_left, near_right, far_left, far_right) = if side == 0 {
+            let (near, far) = lc.split::<L::A, K>();
+            (near, rc.clone(), far, rc)
+        } else {
+            let (near, far) = rc.split::<L::A, K>();
+            (lc.clone(), near, lc, far)
+        };
+        let mut near_bounds = bounds;
+        if pivot.is_finite() && pivot < near_bounds.max[side][dim] {
+            near_bounds.max[side][dim] = pivot;
+        }
+        work.push(Work {
+            left: near_left,
+            right: near_right,
+            bounds: near_bounds,
+            rows: [0..usize::MAX, 0..usize::MAX],
+        });
+        // A real infinite pivot routes all entries to the left child.
+        if pivot.is_finite() {
+            let mut far_bounds = bounds;
+            if pivot > far_bounds.min[side][dim] {
+                far_bounds.min[side][dim] = pivot;
+            }
+            work.push(Work {
+                left: far_left,
+                right: far_right,
+                bounds: far_bounds,
+                rows: [0..usize::MAX, 0..usize::MAX],
+            });
+        }
+    }
+
+    candidates
+        .into_iter()
+        .map(|candidate| TreeNearestQueryResult {
+            left_item: candidate.left,
+            right_item: candidate.right,
+            distance: candidate.distance,
+        })
+        .collect()
+}

--- a/src/kd_tree/query/tree/parallel.rs
+++ b/src/kd_tree/query/tree/parallel.rs
@@ -1,0 +1,134 @@
+//! Bounded geometric frontier; all task payloads own their traversal state.
+use super::cursor::JoinTree;
+use super::metric::{JoinFloat, JoinMetric};
+use super::traversal::{rejected, root, Work};
+use crate::StemStrategy;
+
+type Task<L, R, D, const K: usize> = Work<
+    <L as JoinTree<K>>::Strategy,
+    <R as JoinTree<K>>::Strategy,
+    <D as crate::dist::DistanceMetricScalar<<L as JoinTree<K>>::A>>::Output,
+    K,
+>;
+
+pub(super) fn frontier<L, R, D, const K: usize, const EX: bool>(
+    left: &L,
+    right: &R,
+    radius: D::Output,
+    budget: usize,
+) -> Vec<Task<L, R, D, K>>
+where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+{
+    let mut tasks = vec![root(left, right)];
+    while tasks.len() < budget {
+        let best = tasks
+            .iter()
+            .enumerate()
+            .filter_map(|(i, w)| {
+                let l = if w.left.leaf() {
+                    left.leaf_len(w.left.range.start)
+                        .min(w.rows[0].end)
+                        .saturating_sub(w.rows[0].start)
+                } else {
+                    w.left
+                        .span()
+                        .saturating_mul(left.max_leaf_len())
+                        .min(left.size())
+                };
+                let r = if w.right.leaf() {
+                    right
+                        .leaf_len(w.right.range.start)
+                        .min(w.rows[1].end)
+                        .saturating_sub(w.rows[1].start)
+                } else {
+                    w.right
+                        .span()
+                        .saturating_mul(right.max_leaf_len())
+                        .min(right.size())
+                };
+                let score = l.saturating_mul(r);
+                (score > 4096).then_some((i, score))
+            })
+            .max_by_key(|&(_, score)| score);
+        let Some((index, _)) = best else {
+            break;
+        };
+        let mut a = tasks.swap_remove(index);
+        if rejected::<L::A, D, K, EX>(&a.bounds, radius) {
+            continue;
+        }
+        let mut b = a.clone();
+        if a.left.leaf() && a.right.leaf() {
+            a.rows[0].end = a.rows[0].end.min(left.leaf_len(a.left.range.start));
+            a.rows[1].end = a.rows[1].end.min(right.leaf_len(a.right.range.start));
+            b.rows = a.rows.clone();
+            let side = usize::from(a.rows[1].len() > a.rows[0].len());
+            let len = a.rows[side].len();
+            let mid = a.rows[side].start + ((len / 2).div_ceil(32) * 32).min(len - 1);
+            a.rows[side].end = mid;
+            b.rows[side].start = mid;
+        } else {
+            let side =
+                usize::from(a.left.leaf() || (!a.right.leaf() && a.right.span() > a.left.span()));
+            let (dim, pivot) = if side == 0 {
+                let dim = a.left.strategy.construction_dim::<K>();
+                let pivot = D::widen_coord(left.stems()[a.left.strategy.stem_idx()]);
+                (dim, pivot)
+            } else {
+                let dim = a.right.strategy.construction_dim::<K>();
+                let pivot = D::widen_coord(right.stems()[a.right.strategy.stem_idx()]);
+                (dim, pivot)
+            };
+            let padding = (side == 0 && a.left.padding_remaining > 0)
+                || (side == 1 && a.right.padding_remaining > 0);
+            if !pivot.is_finite() && padding {
+                if side == 0 {
+                    a.left = a.left.descend_padding::<L::A, K>();
+                } else {
+                    a.right = a.right.descend_padding::<L::A, K>();
+                }
+                if a.left.span() > 0 && a.right.span() > 0 {
+                    tasks.push(a);
+                }
+                continue;
+            }
+            if side == 0 {
+                (a.left, b.left) = a.left.split::<L::A, K>();
+            } else {
+                (a.right, b.right) = a.right.split::<L::A, K>();
+            }
+            // A real infinite pivot denotes a degenerate split.  Unlike the
+            // synthetic root padding handled above, every point belongs to
+            // the left child, so the right child must not be scheduled.
+            if !pivot.is_finite() {
+                if a.left.span() > 0
+                    && a.right.span() > 0
+                    && !rejected::<L::A, D, K, EX>(&a.bounds, radius)
+                {
+                    tasks.push(a);
+                }
+                continue;
+            }
+            if pivot.is_finite() && pivot < a.bounds.max[side][dim] {
+                a.bounds.max[side][dim] = pivot;
+            }
+            if pivot.is_finite() && pivot > b.bounds.min[side][dim] {
+                b.bounds.min[side][dim] = pivot;
+            }
+        }
+        for task in [a, b] {
+            if task.left.span() > 0
+                && task.right.span() > 0
+                && !rejected::<L::A, D, K, EX>(&task.bounds, radius)
+            {
+                tasks.push(task);
+            }
+        }
+    }
+    #[cfg(feature = "exact_query_stats")]
+    super::stats::record(super::stats::Event::Tasks, tasks.len());
+    tasks
+}

--- a/src/kd_tree/query/tree/stats.rs
+++ b/src/kd_tree/query/tree/stats.rs
@@ -1,0 +1,64 @@
+//! Invasive, process-wide tree-join counters, enabled by `exact_query_stats`.
+//! Reset only when no joins are running. Do not enable these counters in timing
+//! builds: recording synchronizes across workers and changes performance.
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug, Default, Clone, Copy)]
+/// Structural counters for exact dual-tree radius-join development.
+pub struct TreeJoinStats {
+    /// Node pairs considered by serial task traversals.
+    pub node_pairs: usize,
+    /// Empty or geometrically excluded node pairs.
+    pub rejected_pairs: usize,
+    /// Subtree pairs emitted without calculating point distances.
+    pub accepted_pairs: usize,
+    /// Leaf pairs evaluated by the distance kernel.
+    pub leaf_pairs: usize,
+    /// Point distances evaluated by leaf kernels.
+    pub point_distances: usize,
+    /// Matching entry pairs counted or emitted.
+    pub matches: usize,
+    /// Work units surviving parallel frontier construction.
+    pub tasks: usize,
+    /// Continuation frames placed in heap spill storage.
+    pub stack_spills: usize,
+}
+
+static COUNTERS: [AtomicUsize; 8] = [const { AtomicUsize::new(0) }; 8];
+
+pub(super) enum Event {
+    Node,
+    Rejected,
+    Accepted,
+    Leaf,
+    Distances,
+    Matches,
+    Tasks,
+    Spill,
+}
+#[inline]
+pub(super) fn record(event: Event, count: usize) {
+    COUNTERS[event as usize].fetch_add(count, Ordering::Relaxed);
+}
+
+/// Clears the process-wide counters. Do not race this with query execution.
+pub fn reset() {
+    for counter in &COUNTERS {
+        counter.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Reads the counters; concurrent queries may still change them.
+pub fn snapshot() -> TreeJoinStats {
+    let c = std::array::from_fn::<_, 8, _>(|i| COUNTERS[i].load(Ordering::Relaxed));
+    TreeJoinStats {
+        node_pairs: c[0],
+        rejected_pairs: c[1],
+        accepted_pairs: c[2],
+        leaf_pairs: c[3],
+        point_distances: c[4],
+        matches: c[5],
+        tasks: c[6],
+        stack_spills: c[7],
+    }
+}

--- a/src/kd_tree/query/tree/traversal.rs
+++ b/src/kd_tree/query/tree/traversal.rs
@@ -1,0 +1,318 @@
+use super::cursor::{Cursor, JoinTree};
+use super::leaf::leaf_pair;
+use super::metric::{accepts, Bounds, JoinFloat, JoinMetric};
+use crate::{Content, StemStrategy};
+use std::ops::Range;
+
+pub(super) const COUNT_OVERFLOW: &str = "tree join pair count exceeds usize::MAX";
+
+pub(super) trait Sink<L: Content, R: Content, O: JoinFloat> {
+    const COUNT: bool = false;
+    const DISTANCES: bool;
+    fn emit(&mut self, left: L, right: R, distance: O);
+    fn add_count(&mut self, _count: usize) {
+        unreachable!()
+    }
+}
+
+#[derive(Default)]
+pub(super) struct Counter(pub usize);
+impl<L: Content, R: Content, O: JoinFloat> Sink<L, R, O> for Counter {
+    const COUNT: bool = true;
+    const DISTANCES: bool = false;
+    fn emit(&mut self, _: L, _: R, _: O) {
+        unreachable!()
+    }
+    fn add_count(&mut self, count: usize) {
+        self.0 = self.0.checked_add(count).expect(COUNT_OVERFLOW);
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Work<SL, SR, O, const K: usize> {
+    pub left: Cursor<SL>,
+    pub right: Cursor<SR>,
+    pub bounds: Bounds<O, K>,
+    pub rows: [Range<usize>; 2],
+}
+
+pub(super) fn root<L: JoinTree<K>, R: JoinTree<K, A = L::A>, O: JoinFloat, const K: usize>(
+    left: &L,
+    right: &R,
+) -> Work<L::Strategy, R::Strategy, O, K> {
+    Work {
+        left: Cursor::root(left),
+        right: Cursor::root(right),
+        bounds: Bounds::new(),
+        rows: [0..usize::MAX, 0..usize::MAX],
+    }
+}
+
+pub(super) fn rejected<A: JoinFloat, D: JoinMetric<A>, const K: usize, const EX: bool>(
+    bounds: &Bounds<D::Output, K>,
+    radius: D::Output,
+) -> bool {
+    let lower = bounds.lower::<A, D>();
+    // NaN is uncertainty, never permission to prune.
+    if EX {
+        lower >= radius
+    } else {
+        lower > radius
+    }
+}
+
+enum Frame<SL, SR, O> {
+    Right {
+        left: Cursor<SL>,
+        right: Cursor<SR>,
+        side: usize,
+        dim: usize,
+        min: O,
+        max: O,
+        pivot: O,
+    },
+    Restore {
+        side: usize,
+        dim: usize,
+        min: O,
+        max: O,
+    },
+}
+
+struct Stack<T, const N: usize> {
+    inline: [Option<T>; N],
+    len: usize,
+    spill: Vec<T>,
+}
+impl<T, const N: usize> Stack<T, N> {
+    fn new() -> Self {
+        Self {
+            inline: std::array::from_fn(|_| None),
+            len: 0,
+            spill: Vec::new(),
+        }
+    }
+    fn push(&mut self, value: T) {
+        if self.len < N && self.spill.is_empty() {
+            self.inline[self.len] = Some(value);
+            self.len += 1;
+        } else {
+            #[cfg(feature = "exact_query_stats")]
+            super::stats::record(super::stats::Event::Spill, 1);
+            self.spill.push(value);
+        }
+    }
+    fn pop(&mut self) -> Option<T> {
+        if let Some(x) = self.spill.pop() {
+            return Some(x);
+        }
+        if self.len == 0 {
+            return None;
+        }
+        self.len -= 1;
+        self.inline[self.len].take()
+    }
+}
+
+pub(super) fn walk<L, R, D, S, const K: usize, const EX: bool>(
+    left: &L,
+    right: &R,
+    work: Work<L::Strategy, R::Strategy, D::Output, K>,
+    radius: D::Output,
+    sink: &mut S,
+) where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+    S: Sink<L::Item, R::Item, D::Output>,
+{
+    let Work {
+        left: mut lc,
+        right: mut rc,
+        mut bounds,
+        rows,
+    } = work;
+    let mut stack = Stack::<Frame<L::Strategy, R::Strategy, D::Output>, 64>::new();
+    loop {
+        #[cfg(feature = "exact_query_stats")]
+        super::stats::record(super::stats::Event::Node, 1);
+        if lc.span() > 0 && rc.span() > 0 && !rejected::<L::A, D, K, EX>(&bounds, radius) {
+            if !S::DISTANCES && accepts::<_, EX>(bounds.upper::<L::A, D>(), radius) {
+                bulk::<L, R, D, S, K>(left, right, &lc, &rc, &rows, sink);
+            } else if lc.leaf() && rc.leaf() {
+                leaf_pair::<L, R, D, S, K, EX>(
+                    left,
+                    right,
+                    lc.range.start,
+                    rc.range.start,
+                    &rows,
+                    radius,
+                    sink,
+                );
+            } else {
+                let side = usize::from(lc.leaf() || (!rc.leaf() && rc.span() > lc.span()));
+                let (dim, pivot) = if side == 0 {
+                    let dim = lc.strategy.construction_dim::<K>();
+                    let pivot = D::widen_coord(left.stems()[lc.strategy.stem_idx()]);
+                    (dim, pivot)
+                } else {
+                    let dim = rc.strategy.construction_dim::<K>();
+                    let pivot = D::widen_coord(right.stems()[rc.strategy.stem_idx()]);
+                    (dim, pivot)
+                };
+                if !pivot.is_finite()
+                    && ((side == 0 && lc.padding_remaining > 0)
+                        || (side == 1 && rc.padding_remaining > 0))
+                {
+                    // Construction puts block-alignment padding above the
+                    // true root. It must not halve the logical leaf range.
+                    if side == 0 {
+                        lc = lc.descend_padding::<L::A, K>();
+                    } else {
+                        rc = rc.descend_padding::<L::A, K>();
+                    }
+                    continue;
+                }
+                let (next_l, next_r, far_l, far_r) = if side == 0 {
+                    let (near, far) = lc.split::<L::A, K>();
+                    (near, rc.clone(), far, rc)
+                } else {
+                    let (near, far) = rc.split::<L::A, K>();
+                    (lc.clone(), near, lc, far)
+                };
+                let min = bounds.min[side][dim];
+                let max = bounds.max[side][dim];
+                if pivot.is_finite() {
+                    stack.push(Frame::Right {
+                        left: far_l,
+                        right: far_r,
+                        side,
+                        dim,
+                        min,
+                        max,
+                        pivot,
+                    });
+                    bounds.max[side][dim] = if pivot < max { pivot } else { max };
+                }
+                lc = next_l;
+                rc = next_r;
+                continue;
+            }
+        } else {
+            #[cfg(feature = "exact_query_stats")]
+            super::stats::record(super::stats::Event::Rejected, 1);
+        }
+        loop {
+            match stack.pop() {
+                None => return,
+                Some(Frame::Restore {
+                    side,
+                    dim,
+                    min,
+                    max,
+                }) => {
+                    bounds.min[side][dim] = min;
+                    bounds.max[side][dim] = max;
+                }
+                Some(Frame::Right {
+                    left,
+                    right,
+                    side,
+                    dim,
+                    min,
+                    max,
+                    pivot,
+                }) => {
+                    bounds.min[side][dim] = if pivot > min { pivot } else { min };
+                    bounds.max[side][dim] = max;
+                    stack.push(Frame::Restore {
+                        side,
+                        dim,
+                        min,
+                        max,
+                    });
+                    lc = left;
+                    rc = right;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn cardinality<Tree: JoinTree<K>, const K: usize>(
+    tree: &Tree,
+    leaves: Range<usize>,
+    rows: &Range<usize>,
+) -> usize {
+    leaves
+        .map(|i| tree.leaf_len(i).min(rows.end).saturating_sub(rows.start))
+        .try_fold(0usize, usize::checked_add)
+        .expect(COUNT_OVERFLOW)
+}
+
+fn bulk<L, R, D, S, const K: usize>(
+    left: &L,
+    right: &R,
+    lc: &Cursor<L::Strategy>,
+    rc: &Cursor<R::Strategy>,
+    rows: &[Range<usize>; 2],
+    sink: &mut S,
+) where
+    L: JoinTree<K>,
+    R: JoinTree<K, A = L::A>,
+    D: JoinMetric<L::A>,
+    S: Sink<L::Item, R::Item, D::Output>,
+{
+    #[cfg(feature = "exact_query_stats")]
+    {
+        super::stats::record(super::stats::Event::Accepted, 1);
+        let count = cardinality(left, lc.range.clone(), &rows[0])
+            .checked_mul(cardinality(right, rc.range.clone(), &rows[1]))
+            .expect(COUNT_OVERFLOW);
+        super::stats::record(super::stats::Event::Matches, count);
+    }
+    if S::COUNT {
+        let l = cardinality(left, lc.range.clone(), &rows[0]);
+        let r = cardinality(right, rc.range.clone(), &rows[1]);
+        sink.add_count(l.checked_mul(r).expect(COUNT_OVERFLOW));
+        return;
+    }
+    for li in lc.range.clone() {
+        left.tiles(li, rows[0].clone(), |lt| {
+            for ri in rc.range.clone() {
+                right.tiles(ri, rows[1].clone(), |rt| {
+                    for i in 0..lt.len {
+                        for j in 0..rt.len {
+                            sink.emit(lt.item(i), rt.item(j), D::Output::ZERO);
+                        }
+                    }
+                });
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn stack_spills_and_reuses() {
+        let mut stack = Stack::<_, 2>::new();
+        for i in 0..8 {
+            stack.push(i);
+        }
+        for i in (0..8).rev() {
+            assert_eq!(stack.pop(), Some(i));
+        }
+        assert_eq!(stack.pop(), None);
+        stack.push(42);
+        assert_eq!(stack.pop(), Some(42));
+    }
+    #[test]
+    #[should_panic(expected = "tree join pair count exceeds usize::MAX")]
+    fn count_overflow() {
+        let mut count = Counter(usize::MAX);
+        <Counter as Sink<u32, u32, f64>>::add_count(&mut count, 1);
+    }
+}

--- a/src/leaf_view/mod.rs
+++ b/src/leaf_view/mod.rs
@@ -483,6 +483,20 @@ where
     AX: Copy,
     T: Copy,
 {
+    /// Raw tile columns can be unaligned; callers must use unaligned loads.
+    pub(crate) fn join_columns(&self) -> ([*const AX; K], *const T) {
+        let columns = std::array::from_fn(|dim| unsafe {
+            self.bytes
+                .add(dim * self.len * std::mem::size_of::<AX>())
+                .cast()
+        });
+        let items = unsafe {
+            self.bytes
+                .add(K * self.len * std::mem::size_of::<AX>())
+                .cast()
+        };
+        (columns, items)
+    }
     #[inline(always)]
     pub(crate) fn len(&self) -> usize {
         self.len

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,11 @@ mod custom_serde;
 pub mod kd_tree;
 #[doc(hidden)]
 pub type KdTree<A, T, SS, LS, const K: usize, const B: usize> = kd_tree::KdTree<A, T, SS, LS, K, B>;
+#[cfg(feature = "exact_query_stats")]
+pub use kd_tree::query::tree::stats as tree_join_stats;
+pub use kd_tree::query::tree::{
+    PairQueryResult, TreeNearestQueryBuilder, TreeNearestQueryResult, TreeQueryBuilder,
+};
 #[cfg(feature = "multi-threaded")]
 pub use kd_tree::DEFAULT_PARALLEL_CONSTRUCTION_THRESHOLD;
 pub use kd_tree::{KdTreeBuilder, QueryScratch};

--- a/tests/tree_radius_join.rs
+++ b/tests/tree_radius_join.rs
@@ -1,0 +1,531 @@
+use kiddo::batch::Executor;
+use kiddo::dist::{Chebyshev, Manhattan, Minkowski, SquaredEuclidean};
+use kiddo::leaf_strategy::{FlatVec, VecOfArenas};
+use kiddo::stem_strategy::{
+    Donnelly, DonnellyCyclicSimdFull, DonnellySimdFull, DonnellyUnrolled, Eytzinger,
+};
+use kiddo::{KdTree, StemStrategy};
+
+fn entries<const K: usize>(n: usize, seed: u64) -> Vec<(u32, [f64; K])> {
+    let mut state = seed;
+    (0..n)
+        .map(|i| {
+            (
+                i as u32,
+                std::array::from_fn(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    (state >> 11) as f64 / (1u64 << 53) as f64
+                }),
+            )
+        })
+        .collect()
+}
+
+fn check<SL: StemStrategy, SR: StemStrategy, const K: usize, const B: usize>(n: usize, m: usize) {
+    let a = entries::<K>(n, 17);
+    let b = entries::<K>(m, 123);
+    let left = KdTree::<f64, u32, SL, FlatVec<f64, u32, K, B>, K, B>::new_from_entries(&a).unwrap();
+    let right = KdTree::<f64, u64, SR, VecOfArenas<f64, u64, K, 7>, K, 7>::new_from_entries(
+        &b.iter()
+            .map(|&(i, p)| (u64::from(i), p))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    for radius in [0.0, 0.005, 0.1, 0.6, 10.0, f64::INFINITY] {
+        let mut expected = Vec::new();
+        for &(i, p) in &a {
+            for &(j, q) in &b {
+                let distance: f64 = p.iter().zip(q).map(|(x, y)| (x - y) * (x - y)).sum();
+                if distance <= radius {
+                    expected.push((i, u64::from(j), distance));
+                }
+            }
+        }
+        let serial = Executor::serial();
+        let mut actual: Vec<_> = left
+            .query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .with_executor(&serial)
+            .execute()
+            .into_iter()
+            .map(|p| (p.left_item, p.right_item, p.distance))
+            .collect();
+        actual.sort_by_key(|p| (p.0, p.1));
+        assert_eq!(actual, expected, "n={n} m={m} K={K} B={B} radius={radius}");
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .with_executor(&serial)
+                .count(),
+            expected.len()
+        );
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(radius)
+                .without_distances()
+                .execute()
+                .len(),
+            expected.len()
+        );
+        let parallel = left
+            .query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(radius)
+            .execute();
+        let mut parallel: Vec<_> = parallel
+            .into_iter()
+            .map(|p| (p.left_item, p.right_item, p.distance))
+            .collect();
+        parallel.sort_by_key(|p| (p.0, p.1));
+        assert_eq!(parallel, expected);
+    }
+}
+
+#[test]
+fn dual_tree_nearest_one_matches_brute_force() {
+    let a = entries::<3>(137, 17);
+    let b = entries::<3>(113, 123);
+    let left =
+        KdTree::<f64, u32, Donnelly<3>, FlatVec<f64, u32, 3, 32>, 3, 32>::new_from_entries(&a)
+            .unwrap();
+    let right = KdTree::<f64, u64, Eytzinger, VecOfArenas<f64, u64, 3, 7>, 3, 7>::new_from_entries(
+        &b.iter()
+            .map(|&(item, point)| (u64::from(item), point))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    let mut actual: Vec<_> = left
+        .query_tree(&right)
+        .nearest_one::<SquaredEuclidean<f64>>()
+        .execute()
+        .into_iter()
+        .map(|p| (p.left_item, p.right_item, p.distance))
+        .collect();
+    actual.sort_by_key(|entry| entry.0);
+    let expected: Vec<_> = a
+        .iter()
+        .map(|&(left_item, point)| {
+            let (right_item, distance) = b
+                .iter()
+                .map(|&(right_item, target)| {
+                    (
+                        u64::from(right_item),
+                        point
+                            .iter()
+                            .zip(target)
+                            .map(|(a, b)| (a - b) * (a - b))
+                            .sum::<f64>(),
+                    )
+                })
+                .min_by(|a, b| a.1.total_cmp(&b.1))
+                .unwrap();
+            (left_item, right_item, distance)
+        })
+        .collect();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn mixed_layouts_and_shapes() {
+    for (n, m) in [
+        (0, 0),
+        (0, 3),
+        (1, 1),
+        (3, 2),
+        (9, 17),
+        (31, 47),
+        (65, 37),
+        (137, 93),
+    ] {
+        check::<Eytzinger, Eytzinger, 1, 4>(n, m);
+        check::<Eytzinger, Donnelly<3>, 2, 8>(n, m);
+        check::<Donnelly<3>, Eytzinger, 3, 16>(n, m);
+        check::<DonnellyUnrolled<4>, Donnelly<3>, 7, 4>(n, m);
+        check::<DonnellySimdFull<3>, DonnellyCyclicSimdFull<4>, 3, 4>(n, m);
+    }
+}
+
+#[test]
+fn remaining_layout_variants() {
+    use kiddo::stem_strategy::{
+        DonnellyCyclicSimdDescent, DonnellyNoPf, DonnellySimdDescent, DonnellyUnrolledBlockDim,
+        EytzingerNoPf,
+    };
+    check::<EytzingerNoPf, DonnellyNoPf<4>, 3, 4>(63, 93);
+    check::<DonnellyUnrolledBlockDim<3>, DonnellySimdDescent<4>, 2, 8>(129, 37);
+    check::<DonnellyCyclicSimdDescent<4>, DonnellySimdFull<3>, 7, 4>(91, 65);
+}
+
+#[test]
+fn duplicates_and_built_in_metrics() {
+    type Tree = KdTree<f32, u32, Eytzinger, VecOfArenas<f32, u32, 2, 4>, 2, 4>;
+    let left = Tree::new_from_entries(&vec![(7, [0.0, 0.0]); 97]).unwrap();
+    let right = Tree::new_from_entries(&vec![(7, [0.0, -0.0]); 133]).unwrap();
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f32>>(0.0)
+            .count(),
+        97 * 133
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(0.0)
+            .execute()
+            .len(),
+        97 * 133
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<Manhattan<f32>>(0.0)
+            .count(),
+        97 * 133
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<Chebyshev<f32>>(0.0)
+            .count(),
+        97 * 133
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<Minkowski<3, f64>>(0.0)
+            .count(),
+        97 * 133
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f32>>(0.0)
+            .exclusive_boundaries()
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn boundaries_and_overflow() {
+    type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+    let left = Tree::new_from_slice(&[[0.0, 0.0], [f64::MAX, 0.0]]).unwrap();
+    let right = Tree::new_from_slice(&[[1.0, 0.0], [-f64::MAX, 0.0]]).unwrap();
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(1.0)
+            .count(),
+        1
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(1.0)
+            .exclusive_boundaries()
+            .count(),
+        0
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(1.0f64.next_down())
+            .count(),
+        0
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(1.0f64.next_up())
+            .count(),
+        1
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(f64::INFINITY)
+            .count(),
+        4
+    );
+    assert_eq!(
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(f64::INFINITY)
+            .exclusive_boundaries()
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn rejects_same_object_and_invalid_thresholds() {
+    type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 2, 4>, 2, 4>;
+    for data in [vec![], vec![[0.0, 0.0]]] {
+        let left = Tree::new_from_slice(&data).unwrap();
+        let right = Tree::new_from_slice(&data).unwrap();
+        assert!(std::panic::catch_unwind(|| left.query_tree(&left)).is_err());
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(0.0)
+                .count(),
+            data.len()
+        );
+        for radius in [-1.0, f64::NAN, f64::NEG_INFINITY] {
+            assert!(std::panic::catch_unwind(|| left
+                .query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(radius))
+            .is_err());
+        }
+    }
+}
+
+#[test]
+fn nonzero_metric_and_float32_boundaries() {
+    use kiddo::dist::DistanceMetricScalar;
+    type Tree = KdTree<f32, u32, Donnelly<3>, VecOfArenas<f32, u32, 3, 7>, 3, 7>;
+    let a: Vec<_> = entries::<3>(93, 77)
+        .into_iter()
+        .map(|(i, p)| (i, p.map(|x| x as f32)))
+        .collect();
+    let b: Vec<_> = entries::<3>(71, 19)
+        .into_iter()
+        .map(|(i, p)| (i, p.map(|x| x as f32)))
+        .collect();
+    let left = Tree::new_from_entries(&a).unwrap();
+    let right = Tree::new_from_entries(&b).unwrap();
+    macro_rules! check_metric {
+        ($metric:ty) => {{
+            for index in 0..8 {
+                let edge =
+                    <$metric as DistanceMetricScalar<f32>>::dist_raw(&a[index].1, &b[index].1);
+                for radius in [edge.next_down(), edge, edge.next_up()] {
+                    let mut inclusive = Vec::new();
+                    let mut exclusive = Vec::new();
+                    for &(i, p) in &a {
+                        for &(j, q) in &b {
+                            let d = <$metric as DistanceMetricScalar<f32>>::dist_raw(&p, &q);
+                            if d <= radius {
+                                inclusive.push((i, j, d));
+                            }
+                            if d < radius {
+                                exclusive.push((i, j, d));
+                            }
+                        }
+                    }
+                    let mut actual: Vec<_> = left
+                        .query_tree(&right)
+                        .within::<$metric>(radius)
+                        .execute()
+                        .into_iter()
+                        .map(|x| (x.left_item, x.right_item, x.distance))
+                        .collect();
+                    actual.sort_by_key(|p| (p.0, p.1));
+                    assert_eq!(actual, inclusive);
+                    let mut strict: Vec<_> = left
+                        .query_tree(&right)
+                        .within::<$metric>(radius)
+                        .exclusive_boundaries()
+                        .execute()
+                        .into_iter()
+                        .map(|x| (x.left_item, x.right_item, x.distance))
+                        .collect();
+                    strict.sort_by_key(|p| (p.0, p.1));
+                    assert_eq!(strict, exclusive);
+                    assert_eq!(
+                        left.query_tree(&right).within::<$metric>(radius).count(),
+                        inclusive.len()
+                    );
+                    assert_eq!(
+                        left.query_tree(&right)
+                            .within::<$metric>(radius)
+                            .exclusive_boundaries()
+                            .count(),
+                        exclusive.len()
+                    );
+                }
+            }
+        }};
+    }
+    check_metric!(SquaredEuclidean<f32>);
+    check_metric!(SquaredEuclidean<f64>);
+    check_metric!(Manhattan<f32>);
+    check_metric!(Chebyshev<f32>);
+    check_metric!(Minkowski<3,f32>);
+    check_metric!(Minkowski<4,f64>);
+}
+
+#[test]
+fn large_workload_rounding_regressions() {
+    // Reduced from the 2^24-point differential diagnostic. Historical SIMD
+    // radius queries round these distances down onto the boundary; scalar
+    // metric arithmetic puts them one ULP above it. The join follows scalar.
+    type Tree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, 3, 32>, 3, 32>;
+    for (p, q) in [
+        (
+            [0.08790941, 0.8717605, 0.5734007],
+            [0.09077622, 0.8729093, 0.5681331],
+        ),
+        (
+            [0.5666268, 0.083839536, 0.5078225],
+            [0.56211233, 0.087421425, 0.50580376],
+        ),
+        (
+            [0.8286047, 0.6387919, 0.60467845],
+            [0.828009, 0.64475083, 0.60587096],
+        ),
+        (
+            [0.31691444, 0.8285374, 0.07836475],
+            [0.31279126, 0.8324673, 0.08056492],
+        ),
+    ] {
+        let left = Tree::new_from_slice(&[p; 17]).unwrap();
+        let right = Tree::new_from_slice(&[q; 32]).unwrap();
+        let radius = f32::from_bits(941384473);
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f32>>(radius)
+                .count(),
+            0
+        );
+        assert!(left
+            .query_tree(&right)
+            .within::<SquaredEuclidean<f32>>(radius)
+            .execute()
+            .is_empty());
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f32>>(radius.next_up())
+                .count(),
+            17 * 32
+        );
+    }
+}
+
+#[cfg(feature = "multi-threaded")]
+#[test]
+fn owned_pools_visitors_and_panic_recovery() {
+    use kiddo::batch::ThreadPoolBuilder;
+    use std::sync::{Arc, Mutex};
+    type Tree = KdTree<f64, u32, Eytzinger, FlatVec<f64, u32, 3, 32>, 3, 32>;
+    let left = Tree::new_from_entries(&entries::<3>(531, 17)).unwrap();
+    let right = Tree::new_from_entries(&entries::<3>(731, 78)).unwrap();
+    let serial = Executor::serial();
+    let mut expected: Vec<_> = left
+        .query_tree(&right)
+        .within::<SquaredEuclidean<f64>>(0.08)
+        .with_executor(&serial)
+        .execute()
+        .into_iter()
+        .map(|x| (x.left_item, x.right_item))
+        .collect();
+    expected.sort_unstable();
+    for threads in [1, 2, 4, 8] {
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .thread_name(|i| format!("join-owned-{i}"))
+                .build()
+                .unwrap(),
+        );
+        let executor = Executor::parallel_in_pool(pool).with_default_static_chunking();
+        let output = Mutex::new(Vec::new());
+        left.query_tree(&right)
+            .within::<SquaredEuclidean<f64>>(0.08)
+            .without_distances()
+            .with_executor(&executor)
+            .for_each(|pair| {
+                assert!(std::thread::current()
+                    .name()
+                    .unwrap()
+                    .starts_with("join-owned-"));
+                output
+                    .lock()
+                    .unwrap()
+                    .push((pair.left_item, pair.right_item));
+            });
+        let mut output = output.into_inner().unwrap();
+        output.sort_unstable();
+        assert_eq!(output, expected);
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(0.08)
+                .with_executor(&executor)
+                .count(),
+            expected.len()
+        );
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(0.08)
+                .with_executor(&executor)
+                .for_each(|_| panic!("visitor failure"));
+        }))
+        .is_err());
+        assert_eq!(
+            left.query_tree(&right)
+                .within::<SquaredEuclidean<f64>>(0.08)
+                .with_executor(&executor)
+                .count(),
+            expected.len()
+        );
+    }
+}
+
+/// Expensive differential diagnostic; emits minimal coordinate/threshold
+/// fixtures when the historical radius kernel and scalar metric disagree.
+#[test]
+#[ignore]
+fn large_radius_boundary_diagnostic() {
+    use kiddo::dist::DistanceMetricScalar;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    type Tree = KdTree<f32, u32, Eytzinger, FlatVec<f32, u32, 3, 32>, 3, 32>;
+    let n = 1 << 24;
+    let make = |mut state: u64| {
+        (0..n)
+            .map(|_| {
+                std::array::from_fn(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    ((state >> 11) as f64 / (1u64 << 53) as f64) as f32
+                })
+            })
+            .collect::<Vec<[f32; 3]>>()
+    };
+    let a = make(17);
+    let b = make(78);
+    let left = Tree::new_from_slice(&a).unwrap();
+    let right = Tree::new_from_slice(&b).unwrap();
+    let radius = (16.0 / (n as f64 * (4.0 * std::f64::consts::PI / 3.0))).powf(1.0 / 3.0) as f32;
+    let r2 = radius * radius;
+    let counts: Vec<_> = (0..n).map(|_| AtomicU32::new(0)).collect();
+    left.query_tree(&right)
+        .within::<SquaredEuclidean<f32>>(r2)
+        .for_each(|p| {
+            counts[p.left_item as usize].fetch_add(1, Ordering::Relaxed);
+        });
+    for (i, p) in a.iter().enumerate() {
+        let mut old = Vec::new();
+        right
+            .query(p)
+            .within::<SquaredEuclidean<f32>>(r2)
+            .unsorted()
+            .visit(|q| old.push(q));
+        let new = counts[i].load(Ordering::Relaxed) as usize;
+        if old.len() != new {
+            let mut exact = Vec::new();
+            for (j, q) in b.iter().enumerate() {
+                let d = <SquaredEuclidean<f32> as DistanceMetricScalar<f32>>::dist_raw(p, q);
+                if d <= r2 {
+                    exact.push(j as u32);
+                }
+            }
+            eprintln!(
+                "row={i} old={} new={new} oracle={} r2={r2:?} r2_bits={} p={p:?}",
+                old.len(),
+                exact.len(),
+                r2.to_bits()
+            );
+            for result in old {
+                if !exact.contains(&result.item) {
+                    let q = b[result.item as usize];
+                    let d = <SquaredEuclidean<f32> as DistanceMetricScalar<f32>>::dist_raw(p, &q);
+                    eprintln!(
+                        "old-only: q={q:?} old_dist={:?} scalar={d:?}",
+                        result.distance
+                    );
+                }
+            }
+            assert_eq!(new, exact.len());
+        }
+    }
+}

--- a/tests/wasm-smoke/src/main.rs
+++ b/tests/wasm-smoke/src/main.rs
@@ -11,4 +11,7 @@ fn main() {
 
     assert_eq!(nearest.item, 0);
     assert_eq!(nearest.distance, 0.0);
+
+    let other = ImmutableKdTree::new_from_slice(&[[0.0_f64, 0.0]]).unwrap();
+    assert_eq!(tree.query_tree(&other).within::<SquaredEuclidean<f64>>(0.0).count(), 1);
 }


### PR DESCRIPTION
## Summary

- add an exact, immutable tree-to-tree radius join addressing #85
- provide collecting, streaming, counting, built-in metric, SIMD leaf, and executor-backed parallel paths
- add an experimental exact dual-tree `nearest_one` mode for NBLAST-style tree-to-tree workloads
- add differential coverage across layouts, dimensions, metrics, boundaries, pools, wasm smoke coverage, and a configurable benchmark harness

## Validation

- `cargo test --test tree_radius_join`
- `cargo test --test tree_radius_join --features simd`
- `cargo clippy --lib --no-deps`
- wasm smoke build

## Nearest-neighbour experiment

The new `query_tree(...).nearest_one()` is exact and differential-tested. On the initial NBLAST-rs experiment it is slower than the existing per-point nearest-one path, so it is included as an experimental traversal rather than a claimed performance improvement. A true dual-tree `nearest_n` remains follow-up work: reusing radius pairs would enumerate candidates rather than maintain k-best state efficiently.