### PR TITLE
chore: release v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,9 @@
 
 - Add item-sorted leaves with embedded min-item summaries ([@sdd](https://github.com/sdd))
 
-
 ### 🐛 Bug Fixes
 
 - Gate ITEM_LEAF_MODE_UNSORTED import to AVX512 targets ([@sdd](https://github.com/sdd))
-
 
 ### 🧹 Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Kiddo Changelog
 
+## [6.3.0] - 2026-09-06
+
+### ✨ Features
+
+- Add immutable tree-to-tree queries ([@sdd](https://github.com/sdd))
+
+- Add item-sorted leaves with embedded min-item summaries ([@sdd](https://github.com/sdd))
+
+
+### 🐛 Bug Fixes
+
+- Gate ITEM_LEAF_MODE_UNSORTED import to AVX512 targets ([@sdd](https://github.com/sdd))
+
+
+### 🧹 Chore
+
+- Bump taiki-e/install-action from 2.87.1 to 2.87.3 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
+
 ## [6.2.0] - 2026-09-03
 
 ### ✨ Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiddo"
-version = "6.2.0"
+version = "6.3.0"
 edition = "2021"
 rust-version = "1.89.0"
 authors = ["Scott Donnelly <scott@donnel.ly>"]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add `kiddo` to `Cargo.toml`
 
 ```toml
 [dependencies]
-kiddo = "6.2.0"
+kiddo = "6.3.0"
 ```
 
 Add points to a k-d tree and query the nearest points with a distance metric:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_root_url = "https://docs.rs/kiddo/6.2.0")]
+#![doc(html_root_url = "https://docs.rs/kiddo/6.3.0")]
 #![doc(issue_tracker_base_url = "https://github.com/sdd/kiddo/issues/")]
 #![allow(clippy::pointers_in_nomem_asm_block)]
 #![allow(clippy::too_many_arguments)]
@@ -106,7 +106,7 @@
 //! Add `kiddo` to `Cargo.toml`
 //! ```toml
 //! [dependencies]
-//! kiddo = "6.2.0"
+//! kiddo = "6.3.0"
 //! ```
 //!
 //! ## Usage


### PR DESCRIPTION



## 🤖 New release

* `kiddo`: 6.2.0 -> 6.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [6.3.0] - 2026-09-06

### ✨ Features

- Add immutable tree-to-tree queries ([@sdd](https://github.com/sdd))

- Add item-sorted leaves with embedded min-item summaries ([@sdd](https://github.com/sdd))


### 🐛 Bug Fixes

- Gate ITEM_LEAF_MODE_UNSORTED import to AVX512 targets ([@sdd](https://github.com/sdd))


### 🧹 Chore

- Bump taiki-e/install-action from 2.87.1 to 2.87.3 ([@dependabot[bot]](https://github.com/dependabot[bot]), Signed-off-by:dependabot[bot] <support@github.com>)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).